### PR TITLE
perf(config): Vite manual chunks for vendor bundle splitting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,17 @@ export default defineConfig(async () => ({
     __BUILD_DATE__: JSON.stringify(new Date().toISOString().slice(0, 16)),
     __GIT_HASH__: JSON.stringify(getGitHash()),
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-xterm': ['@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-web-links'],
+          'vendor-motion': ['framer-motion'],
+          'vendor-react': ['react', 'react-dom'],
+        },
+      },
+    },
+  },
   clearScreen: false,
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
- Add `build.rollupOptions.output.manualChunks` to `vite.config.ts`
- Splits the single ~719 KB JS bundle into 4 cacheable chunks: xterm (337 KB), react (134 KB), framer-motion (122 KB), and app code (105 KB)
- Vendor chunks change rarely, enabling better browser/CDN caching

## Test plan
- [x] `npx vitest run` -- 251 tests pass
- [x] `npx tsc --noEmit` -- zero errors
- [x] `npm run build` -- produces 4 separate JS chunks as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)