### PR TITLE
perf(ui): shared timer hook + SessionCard memoization

### DIFF
--- a/src/components/sessions/GridCell.tsx
+++ b/src/components/sessions/GridCell.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from "react";
 import { Maximize2, X } from "lucide-react";
 import { useSessionStore } from "../../store/sessionStore";
 import { SessionTerminal } from "./SessionTerminal";
 import { getActivityLevel } from "./activityLevel";
+import { useNowTick } from "../../hooks/useNowTick";
 
 interface GridCellProps {
   sessionId: string;
@@ -45,14 +45,8 @@ export function GridCell({
   const status = session?.status ?? "starting";
   const lastOutputAt = session?.lastOutputAt ?? Date.now();
 
-  const [now, setNow] = useState(Date.now());
+  const now = useNowTick();
   const isRunning = status === "running" || status === "starting";
-
-  useEffect(() => {
-    if (!isRunning) return;
-    const interval = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(interval);
-  }, [isRunning]);
 
   const activityLevel = isRunning ? getActivityLevel(lastOutputAt, now) : null;
   const isThinking = activityLevel === "thinking";

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -1,15 +1,16 @@
-import { useEffect, useState } from "react";
+import React from "react";
 import { X, Check, AlertTriangle, LayoutGrid, FolderOpen, Terminal } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import type { ClaudeSession } from "../../store/sessionStore";
 import { getActivityLevel, type ActivityLevel } from "./activityLevel";
+import { useNowTick } from "../../hooks/useNowTick";
 
 interface SessionCardProps {
   session: ClaudeSession;
   isActive: boolean;
   isInGrid?: boolean;
-  onClick: () => void;
-  onClose: () => void;
+  onClick: (sessionId: string) => void;
+  onClose: (sessionId: string) => void;
 }
 
 function formatDuration(ms: number): string {
@@ -104,22 +105,15 @@ function shortenPath(path: string): string {
   return "~/" + parts.slice(-2).join("/");
 }
 
-export function SessionCard({ session, isActive, isInGrid, onClick, onClose }: SessionCardProps) {
-  const [now, setNow] = useState(Date.now());
-
-  useEffect(() => {
-    if (session.status === "running" || session.status === "starting") {
-      const interval = setInterval(() => setNow(Date.now()), 1000);
-      return () => clearInterval(interval);
-    }
-  }, [session.status]);
+const SessionCardInner = ({ session, isActive, isInGrid, onClick, onClose }: SessionCardProps) => {
+  const now = useNowTick();
 
   const isRunning = session.status === "running" || session.status === "starting";
   const activityLevel = isRunning ? getActivityLevel(session.lastOutputAt, now) : null;
 
   return (
     <div
-      onClick={onClick}
+      onClick={() => onClick(session.id)}
       className={`
         relative group px-3 py-2.5 cursor-pointer transition-all duration-150
         border-l-2
@@ -156,7 +150,7 @@ export function SessionCard({ session, isActive, isInGrid, onClick, onClose }: S
         <button
           onClick={(e) => {
             e.stopPropagation();
-            onClose();
+            onClose(session.id);
           }}
           className="p-0.5 text-neutral-600 hover:text-neutral-300"
           aria-label="Session schliessen"
@@ -187,4 +181,6 @@ export function SessionCard({ session, isActive, isInGrid, onClick, onClose }: S
       </div>
     </div>
   );
-}
+};
+
+export const SessionCard = React.memo(SessionCardInner);

--- a/src/components/sessions/SessionList.tsx
+++ b/src/components/sessions/SessionList.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { Plus } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useSessionStore } from "../../store/sessionStore";
@@ -26,17 +27,34 @@ function sortSessions(sessions: ClaudeSession[]): ClaudeSession[] {
 export function SessionList({ onNewSession, onQuickStart }: SessionListProps) {
   const sessions = useSessionStore((s) => s.sessions);
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
-  const setActiveSession = useSessionStore((s) => s.setActiveSession);
-  const removeSession = useSessionStore((s) => s.removeSession);
   const layoutMode = useSessionStore((s) => s.layoutMode);
   const gridSessionIds = useSessionStore((s) => s.gridSessionIds);
-  const addToGrid = useSessionStore((s) => s.addToGrid);
   const focusedGridSessionId = useSessionStore((s) => s.focusedGridSessionId);
-  const setFocusedGridSession = useSessionStore((s) => s.setFocusedGridSession);
-  const maximizeGridSession = useSessionStore((s) => s.maximizeGridSession);
   const favorites = useSettingsStore((s) => s.favorites);
 
   const sorted = sortSessions(sessions);
+
+  const handleClick = useCallback((sessionId: string) => {
+    const store = useSessionStore.getState();
+    if (store.layoutMode === "grid") {
+      if (store.gridSessionIds.includes(sessionId)) {
+        store.setFocusedGridSession(sessionId);
+      } else if (store.gridSessionIds.length < 4) {
+        store.addToGrid(sessionId);
+      } else {
+        store.maximizeGridSession(sessionId);
+      }
+    } else {
+      store.setActiveSession(sessionId);
+    }
+  }, []);
+
+  const handleClose = useCallback((sessionId: string) => {
+    invoke("close_session", { id: sessionId }).catch((err) =>
+      console.error("[SessionList] close_session failed:", err)
+    );
+    useSessionStore.getState().removeSession(sessionId);
+  }, []);
 
   return (
     <div className="flex flex-col h-full bg-surface-base">
@@ -76,25 +94,8 @@ export function SessionList({ onNewSession, onQuickStart }: SessionListProps) {
                   : session.id === activeSessionId
               }
               isInGrid={isInGrid}
-              onClick={() => {
-                if (layoutMode === "grid") {
-                  if (isInGrid) {
-                    setFocusedGridSession(session.id);
-                  } else if (gridSessionIds.length < 4) {
-                    addToGrid(session.id);
-                  } else {
-                    maximizeGridSession(session.id);
-                  }
-                } else {
-                  setActiveSession(session.id);
-                }
-              }}
-              onClose={() => {
-                invoke("close_session", { id: session.id }).catch((err) =>
-                  console.error("[SessionList] close_session failed:", err)
-                );
-                removeSession(session.id);
-              }}
+              onClick={handleClick}
+              onClose={handleClose}
             />
           );
         })}

--- a/src/hooks/useNowTick.ts
+++ b/src/hooks/useNowTick.ts
@@ -1,0 +1,42 @@
+import { useSyncExternalStore } from "react";
+
+/** Shared module-level timer — one setInterval for all subscribers. */
+let now = Date.now();
+let listeners = new Set<() => void>();
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function startTimer() {
+  if (intervalId !== null) return;
+  intervalId = setInterval(() => {
+    now = Date.now();
+    listeners.forEach((cb) => cb());
+  }, 1000);
+}
+
+function stopTimer() {
+  if (intervalId === null) return;
+  clearInterval(intervalId);
+  intervalId = null;
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  if (listeners.size === 1) startTimer();
+  return () => {
+    listeners.delete(callback);
+    if (listeners.size === 0) stopTimer();
+  };
+}
+
+function getSnapshot(): number {
+  return now;
+}
+
+/**
+ * Shared per-second timer hook.
+ * All components using this hook share a single setInterval(1000).
+ * Returns Date.now() updated once per second.
+ */
+export function useNowTick(): number {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}


### PR DESCRIPTION
## Summary
- **Shared timer hook** (`useNowTick`): Replaces per-component `setInterval(1000)` timers with a single module-level interval using `useSyncExternalStore`. With 8 sessions open, this reduces from 8 intervals firing 8 re-renders/sec to 1 shared tick.
- **SessionCard memoization**: Wrapped in `React.memo` so cards only re-render when their own props change, not when any sibling session updates.
- **Stable callbacks**: `onClick`/`onClose` in `SessionList` use `useCallback` with `getState()` to avoid inline lambda identity changes that defeat memo.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] `npx vitest run` — all 251 tests pass
- [ ] Visual test: open multiple sessions in dev mode, verify timers update correctly and card selection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)