### PR TITLE
perf(store): stabilize agent/worktree selectors with useShallow

### DIFF
--- a/src/components/sessions/AgentBottomPanel.tsx
+++ b/src/components/sessions/AgentBottomPanel.tsx
@@ -8,6 +8,7 @@ import {
   AlertTriangle,
   Loader2,
 } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
 import {
   useAgentStore,
   selectAgentsForSession,
@@ -21,8 +22,8 @@ interface AgentBottomPanelProps {
 }
 
 export function AgentBottomPanel({ sessionId }: AgentBottomPanelProps) {
-  const agents = useAgentStore(selectAgentsForSession(sessionId));
-  const worktrees = useAgentStore(selectWorktreesForSession(sessionId));
+  const agents = useAgentStore(useShallow(selectAgentsForSession(sessionId)));
+  const worktrees = useAgentStore(useShallow(selectWorktreesForSession(sessionId)));
   const collapsed = useAgentStore((s) => s.bottomPanelCollapsed);
   const setCollapsed = useAgentStore((s) => s.setBottomPanelCollapsed);
   const selectedAgentId = useAgentStore((s) => s.selectedAgentId);


### PR DESCRIPTION
## Summary
- Wrap `selectAgentsForSession` and `selectWorktreesForSession` calls in `AgentBottomPanel.tsx` with `useShallow` from `zustand/react/shallow`
- Prevents unnecessary re-renders caused by `Object.values().filter()` always returning a new array reference, even when the filtered data hasn't changed
- Zustand's default `Object.is` equality check sees the new array as different every time; `useShallow` does a shallow comparison of array elements instead

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npm run build` succeeds
- [x] `npx vitest run` — all 251 tests pass
- [ ] Visual verification: AgentBottomPanel renders correctly in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)