### PR TITLE
fix(tauri): standardize error handling in session manager

### DIFF
--- a/src-tauri/src/session/commands.rs
+++ b/src-tauri/src/session/commands.rs
@@ -22,12 +22,12 @@ pub mod commands {
         // Validate that folder exists and is a directory
         let folder_path = std::path::Path::new(&folder);
         if !folder_path.exists() {
-            let msg = format!("Folder does not exist: {}", folder);
+            let msg = format!("Failed to create session: folder does not exist: {}", folder);
             log::error!("{}", msg);
             return Err(msg);
         }
         if !folder_path.is_dir() {
-            let msg = format!("Path is not a directory: {}", folder);
+            let msg = format!("Failed to create session: path is not a directory: {}", folder);
             log::error!("{}", msg);
             return Err(msg);
         }

--- a/src-tauri/src/session/file_reader.rs
+++ b/src-tauri/src/session/file_reader.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 fn safe_resolve(folder: &str, relative_path: &str) -> Result<PathBuf, String> {
     let base = PathBuf::from(folder);
     if !base.is_dir() {
-        return Err(format!("Folder does not exist: {}", folder));
+        return Err(format!("Failed to resolve path: folder does not exist: {}", folder));
     }
 
     let target = base.join(relative_path);
@@ -14,13 +14,13 @@ fn safe_resolve(folder: &str, relative_path: &str) -> Result<PathBuf, String> {
     // Canonicalize base; target may not exist yet so we canonicalize its parent
     let canon_base = base
         .canonicalize()
-        .map_err(|e| format!("Cannot resolve base folder: {}", e))?;
+        .map_err(|e| format!("Failed to resolve base folder '{}': {}", folder, e))?;
 
     // For the target, check if it exists first
     if target.exists() {
         let canon_target = target
             .canonicalize()
-            .map_err(|e| format!("Cannot resolve target path: {}", e))?;
+            .map_err(|e| format!("Failed to resolve target path '{}': {}", relative_path, e))?;
 
         if !canon_target.starts_with(&canon_base) {
             return Err("Path traversal detected: target is outside project folder".to_string());
@@ -45,7 +45,7 @@ pub mod commands {
         }
 
         std::fs::read_to_string(&path)
-            .map_err(|e| format!("Failed to read file: {}", e))
+            .map_err(|e| format!("Failed to read file '{}': {}", relative_path, e))
     }
 
     #[tauri::command]
@@ -58,7 +58,7 @@ pub mod commands {
 
         let mut entries = Vec::new();
         let read_dir = std::fs::read_dir(&path)
-            .map_err(|e| format!("Failed to read directory: {}", e))?;
+            .map_err(|e| format!("Failed to read directory '{}': {}", relative_path, e))?;
 
         for entry in read_dir {
             if let Ok(entry) = entry {

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -139,7 +139,9 @@ impl SessionManager {
         };
 
         {
-            let mut sessions = self.sessions.lock().map_err(|e| e.to_string())?;
+            let mut sessions = self.sessions.lock().map_err(|e| {
+                format!("Failed to lock session manager for create_session: {e}")
+            })?;
             sessions.insert(
                 id.clone(),
                 SessionHandle {
@@ -248,24 +250,29 @@ impl SessionManager {
 
     /// Sendet Daten (User-Input) an eine laufende Session.
     pub fn write_to_session(&self, id: &str, data: &str) -> Result<(), String> {
-        let mut sessions = self.sessions.lock().map_err(|e| e.to_string())?;
+        let mut sessions = self.sessions.lock().map_err(|e| {
+            format!("Failed to lock session manager for write_to_session: {e}")
+        })?;
         let session = sessions
             .get_mut(id)
             .ok_or_else(|| format!("Session {id} nicht gefunden"))?;
         session
             .writer
             .write_all(data.as_bytes())
-            .map_err(|e| format!("Write failed: {e}"))?;
+            .map_err(|e| format!("Failed to write to session {id}: {e}"))?;
         session
             .writer
             .flush()
-            .map_err(|e| format!("Flush failed: {e}"))?;
+            .map_err(|e| format!("Failed to flush session {id}: {e}"))?;
         Ok(())
     }
 
     /// Aendert die Terminal-Groesse einer Session.
     pub fn resize_session(&self, id: &str, cols: u16, rows: u16) -> Result<(), String> {
-        let sessions = self.sessions.lock().map_err(|e| e.to_string())?;
+        let sessions = self.sessions.lock().unwrap_or_else(|e| {
+            log::warn!("SessionManager mutex was poisoned during resize_session, recovering");
+            e.into_inner()
+        });
         let session = sessions
             .get(id)
             .ok_or_else(|| format!("Session {id} nicht gefunden"))?;
@@ -277,12 +284,14 @@ impl SessionManager {
                 pixel_width: 0,
                 pixel_height: 0,
             })
-            .map_err(|e| format!("Resize failed: {e}"))
+            .map_err(|e| format!("Failed to resize session {id}: {e}"))
     }
 
     /// Schliesst eine Session (killt den Prozess).
     pub fn close_session(&self, id: &str) -> Result<(), String> {
-        let mut sessions = self.sessions.lock().map_err(|e| e.to_string())?;
+        let mut sessions = self.sessions.lock().map_err(|e| {
+            format!("Failed to lock session manager for close_session: {e}")
+        })?;
         // Drop entfernt den MasterPty, was den Child-Prozess signalisiert
         sessions
             .remove(id)
@@ -408,6 +417,6 @@ fn which_executable(name: &str) -> Option<std::path::PathBuf> {
         .and_then(|o| {
             String::from_utf8(o.stdout)
                 .ok()
-                .map(|s| std::path::PathBuf::from(s.lines().next().unwrap_or("").trim()))
+                .map(|s| std::path::PathBuf::from(s.lines().next().unwrap_or_default().trim()))
         })
 }


### PR DESCRIPTION
## Summary
- Standardize mutex poisoning strategy: READ operations (`list_sessions`, `resize_session`) recover from poisoned mutex via `into_inner()`; WRITE operations (`create_session`, `close_session`, `write_to_session`) propagate the error with descriptive context
- Add operation context to all error messages using consistent `"Failed to {action}: {err}"` pattern across `manager.rs`, `commands.rs`, and `file_reader.rs`
- Replace `unwrap_or("")` with idiomatic `unwrap_or_default()` in `which_executable`

## Test plan
- [x] `cargo check` passes with zero errors and zero warnings
- [ ] Manual smoke test: create, resize, write to, and close sessions in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)