### PR TITLE
fix(ui): add min-h-0 to session list flex chain for reliable scrolling

### DIFF
--- a/src/components/sessions/SessionList.tsx
+++ b/src/components/sessions/SessionList.tsx
@@ -70,7 +70,7 @@ export function SessionList({ onNewSession, onQuickStart }: SessionListProps) {
       </div>
 
       {/* Scrollable content: Favorites + Sessions */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto min-h-0">
         {/* Favorites section */}
         <FavoritesList onQuickStart={onQuickStart} />
 

--- a/src/components/sessions/SessionManagerView.tsx
+++ b/src/components/sessions/SessionManagerView.tsx
@@ -220,7 +220,7 @@ export function SessionManagerView() {
     <div className="flex flex-col h-full">
       <div className="flex flex-1 min-h-0">
         {/* Left column: Session list */}
-        <div className="w-[280px] min-w-[280px] border-r border-neutral-700 flex flex-col">
+        <div className="w-[280px] min-w-[280px] border-r border-neutral-700 flex flex-col min-h-0">
           <SessionList onNewSession={() => setShowNewDialog(true)} onQuickStart={handleQuickStart} />
         </div>
 


### PR DESCRIPTION
## Summary
- Fixes #25: Session list sporadically not scrollable, requiring grid toggle workaround
- Added `min-h-0` to the sidebar column in `SessionManagerView.tsx` and the scroll container in `SessionList.tsx`
- Root cause: flex children default to `min-height: auto`, preventing `overflow-y-auto` from activating when content exceeds the viewport

## Why this works
In CSS flexbox, a flex child won't shrink below its content size unless `min-height: 0` is set. Without it, the container grows to fit all content instead of enabling scrolling. The grid toggle "fixed" it as a side effect by forcing React to remount, triggering a fresh layout calculation.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] Visual: open app with 10+ sessions, verify session list scrolls without grid toggle workaround
- [ ] Visual: verify grid layout mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)