### PR TITLE
chore(config): rebrand agentic-dashboard to AgenticExplorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
-  "name": "agentic-dashboard",
-  "version": "0.1.0",
+  "name": "agentic-explorer",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agentic-dashboard",
-      "version": "0.1.0",
+      "name": "agentic-explorer",
+      "version": "1.2.2",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",
-        "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-shell": "^2.0.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -1818,15 +1817,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz",
       "integrity": "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.8.0"
-      }
-    },
-    "node_modules/@tauri-apps/plugin-notification": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
-      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentic-dashboard",
+  "name": "agentic-explorer",
   "private": true,
   "version": "1.2.2",
   "type": "module",

--- a/scripts/copy-to-desktop.mjs
+++ b/scripts/copy-to-desktop.mjs
@@ -38,9 +38,8 @@ try {
 }
 
 // --- 3. Copy new version ---
-// Cargo binary name is "agentic-dashboard" (from Cargo.toml [package].name),
-// not the Tauri productName "AgenticExplorer"
-const src = join("src-tauri", "target", "release", "agentic-dashboard.exe");
+// Cargo binary name is "agentic-explorer" (from Cargo.toml [package].name)
+const src = join("src-tauri", "target", "release", "agentic-explorer.exe");
 const dest = join(desktop, `${appName}-${version}.exe`);
 
 try {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "agentic-dashboard"
+name = "agentic-explorer"
 version = "1.2.2"
 dependencies = [
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agentic-dashboard"
+name = "agentic-explorer"
 version = "1.2.2"
 description = "AgenticExplorer - Manage and monitor Claude CLI sessions"
 authors = []
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-name = "agentic_dashboard_lib"
+name = "agentic_explorer_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -48,7 +48,7 @@ impl fmt::Display for ADPErrorCode {
     }
 }
 
-/// Structured error type for the Agentic Dashboard Protocol.
+/// Structured error type for the AgenticExplorer Protocol.
 /// Mirrors the `ADPError` interface from `schema.ts`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ADPError {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,7 +101,7 @@ impl Default for PipelineState {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     init_logging();
-    log::info!("Agentic Dashboard starting up");
+    log::info!("AgenticExplorer starting up");
 
     let pipeline_state = Arc::new(Mutex::new(PipelineState::default()));
     let session_manager = Arc::new(session::manager::SessionManager::new());
@@ -171,7 +171,7 @@ pub fn run() {
         .run(tauri::generate_context!());
 
     match result {
-        Ok(()) => log::info!("Agentic Dashboard exited cleanly"),
+        Ok(()) => log::info!("AgenticExplorer exited cleanly"),
         Err(e) => {
             log::error!("Tauri application failed to run: {}", e);
             eprintln!("Fatal: Tauri application failed to run: {}", e);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    agentic_dashboard_lib::run()
+    agentic_explorer_lib::run()
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,7 @@ export function Header() {
       <div className="flex items-center gap-3">
         <Cpu className="w-6 h-6 text-accent" />
         <span className="text-accent font-bold text-lg tracking-wider font-display">
-          AGENTIC DASHBOARD
+          AGENTIC EXPLORER
         </span>
         <button
           onClick={() => setShowChangelog(true)}

--- a/src/protocols/schema.ts
+++ b/src/protocols/schema.ts
@@ -1,8 +1,8 @@
 /**
- * Agentic Dashboard Protocol (ADP) v1
+ * AgenticExplorer Protocol (ADP) v1
  *
  * Einheitliches JSON-Kommunikationsprotokoll fuer den Austausch zwischen
- * allen Services im Agentic Dashboard. Jede Nachricht folgt dem gleichen
+ * allen Services im AgenticExplorer. Jede Nachricht folgt dem gleichen
  * Envelope-Format, unabhaengig von Quelle oder Ziel.
  *
  * Design-Prinzipien:

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -281,7 +281,7 @@ export const useSettingsStore = create<SettingsState>()(
         })),
     }),
     {
-      name: "agentic-dashboard-settings",
+      name: "agentic-explorer-settings",
       storage: createJSONStorage(() => tauriStorage),
     }
   )

--- a/src/store/tauriStorage.ts
+++ b/src/store/tauriStorage.ts
@@ -23,7 +23,15 @@ export function initTauriStorage(): Promise<void> {
   initPromise = invoke<string>("load_user_settings")
     .then((data) => {
       if (data) {
-        cache.set("agentic-dashboard-settings", data);
+        cache.set("agentic-explorer-settings", data);
+      }
+
+      // One-time migration from old key
+      const oldKey = "agentic-dashboard-settings";
+      const newKey = "agentic-explorer-settings";
+      if (cache.has(oldKey) && !cache.has(newKey)) {
+        cache.set(newKey, cache.get(oldKey)!);
+        cache.delete(oldKey);
       }
     })
     .catch((err) => {


### PR DESCRIPTION
## Summary
- Renamed npm package from `agentic-dashboard` to `agentic-explorer`
- Renamed Rust crate and lib from `agentic-dashboard`/`agentic_dashboard_lib` to `agentic-explorer`/`agentic_explorer_lib`
- Updated UI header text from "AGENTIC DASHBOARD" to "AGENTIC EXPLORER"
- Updated log messages, doc comments, cache keys, and binary path in deploy script
- Added one-time settings migration from old cache key in `tauriStorage.ts`

Closes #27

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `cargo check` passes
- [ ] Visual check: header shows "AGENTIC EXPLORER"
- [ ] Settings persist correctly after upgrade (migration from old key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)