### PR TITLE
feat(store,tauri): settings schema versioning, migration & backup (#23)

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -34,25 +34,76 @@ fn sanitize_note_filename(folder_key: &str) -> String {
         .to_string()
 }
 
+/// Rotate up to 3 backup copies before overwriting settings.json.
+/// Best-effort: failures are logged but do not block the save.
+fn create_settings_backup(path: &std::path::Path) {
+    if !path.exists() {
+        return;
+    }
+    if let Some(dir) = path.parent() {
+        // Rotate: .backup.3 → delete, .backup.2 → .backup.3, .backup.1 → .backup.2
+        for i in (1..3).rev() {
+            let from = dir.join(format!("settings.backup.{}.json", i));
+            let to = dir.join(format!("settings.backup.{}.json", i + 1));
+            if from.exists() {
+                let _ = std::fs::rename(&from, &to);
+            }
+        }
+        // Current → .backup.1
+        let backup = dir.join("settings.backup.1.json");
+        if let Err(e) = std::fs::copy(path, &backup) {
+            log::warn!("Settings backup failed: {}", e);
+        }
+    }
+}
+
+/// Try loading from the most recent valid backup file.
+fn load_from_backup() -> Result<String, String> {
+    let dir = settings_dir()?;
+    for i in 1..=3 {
+        let backup = dir.join(format!("settings.backup.{}.json", i));
+        if let Ok(data) = std::fs::read_to_string(&backup) {
+            if serde_json::from_str::<serde_json::Value>(&data).is_ok() {
+                log::info!("Restored settings from backup {}", i);
+                return Ok(data);
+            }
+        }
+    }
+    // All backups failed or missing → fresh start
+    Ok(String::new())
+}
+
 pub mod commands {
     use super::*;
 
     /// Load settings JSON from Documents/AgenticExplorer/settings.json
     /// Returns empty string if file doesn't exist yet (first run).
+    /// Falls back to backup files if the main file is corrupted.
     #[tauri::command]
     pub async fn load_user_settings() -> Result<String, String> {
         let path = settings_path()?;
         if !path.exists() {
             return Ok(String::new());
         }
-        std::fs::read_to_string(&path)
-            .map_err(|e| format!("Failed to read settings: {}", e))
+        let data = std::fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read settings: {}", e))?;
+
+        // Validate JSON; fall back to backup if corrupted
+        match serde_json::from_str::<serde_json::Value>(&data) {
+            Ok(_) => Ok(data),
+            Err(_) => {
+                log::warn!("Settings file corrupted, trying backup");
+                load_from_backup()
+            }
+        }
     }
 
     /// Save settings JSON to Documents/AgenticExplorer/settings.json
+    /// Creates a rotating backup before each write.
     #[tauri::command]
     pub async fn save_user_settings(data: String) -> Result<(), String> {
         let path = settings_path()?;
+        create_settings_backup(&path);
         std::fs::write(&path, data)
             .map_err(|e| format!("Failed to write settings: {}", e))
     }

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -145,6 +145,32 @@ function saveFavoritesFile(favorites: FavoriteFolder[]): void {
 }
 
 // ============================================================================
+// Schema versioning & migration
+// ============================================================================
+
+const SETTINGS_VERSION = 1;
+
+type MigrationFn = (state: Record<string, unknown>) => Record<string, unknown>;
+const migrations: Record<number, MigrationFn> = {
+  // Future migrations go here, e.g.:
+  // 2: (state) => ({ ...state, newField: "defaultValue" }),
+};
+
+function runMigrations(
+  persisted: Record<string, unknown>,
+  fromVersion: number
+): Record<string, unknown> {
+  let state = { ...persisted };
+  for (let v = fromVersion + 1; v <= SETTINGS_VERSION; v++) {
+    const migrateFn = migrations[v];
+    if (migrateFn) {
+      state = migrateFn(state);
+    }
+  }
+  return state;
+}
+
+// ============================================================================
 // Store (with persist middleware)
 // ============================================================================
 
@@ -283,6 +309,28 @@ export const useSettingsStore = create<SettingsState>()(
     {
       name: "agentic-dashboard-settings",
       storage: createJSONStorage(() => tauriStorage),
+      version: SETTINGS_VERSION,
+      migrate: (persisted: unknown, version: number) => {
+        if (version < SETTINGS_VERSION) {
+          return runMigrations(
+            persisted as Record<string, unknown>,
+            version
+          );
+        }
+        return persisted;
+      },
+      merge: (persisted: unknown, current: SettingsState): SettingsState => {
+        const p = persisted as Partial<SettingsState> | undefined;
+        if (!p) return current;
+        return {
+          ...current,
+          ...p,
+          theme: { ...current.theme, ...(p.theme ?? {}) },
+          notifications: { ...current.notifications, ...(p.notifications ?? {}) },
+          sound: { ...current.sound, ...(p.sound ?? {}) },
+          pipeline: { ...current.pipeline, ...(p.pipeline ?? {}) },
+        };
+      },
     }
   )
 );


### PR DESCRIPTION
## Summary
- **Schema versioning & migration** (frontend): Added `version` and `migrate` to the Zustand persist config with a forward-compatible migration runner. New schema versions just need a migration function entry.
- **Deep merge on hydration** (frontend): The `merge` option deep-merges persisted state with defaults, so new fields added in updates get their default values while existing user settings are preserved.
- **Backup rotation** (Rust): Before each settings write, rotates up to 3 backup copies (`settings.backup.{1,2,3}.json`). Best-effort -- failures don't block saves.
- **Corrupted file fallback** (Rust): On load, validates JSON. If corrupted, falls back to the most recent valid backup. If all backups fail, starts fresh.

Closes #23

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `cargo check` passes
- [ ] Manual: verify settings persist across app restart
- [ ] Manual: corrupt settings.json, verify backup fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)