### PR TITLE
feat(ui): add detachable log viewer window

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,32 @@ pub mod pipeline;
 pub mod session;
 pub mod settings;
 
+mod commands {
+    #[tauri::command]
+    pub async fn open_log_window(app: tauri::AppHandle) -> Result<(), String> {
+        use tauri::{Manager, WebviewWindowBuilder};
+
+        // If window already exists, just focus it
+        if let Some(win) = app.get_webview_window("log-viewer") {
+            let _ = win.set_focus();
+            return Ok(());
+        }
+
+        WebviewWindowBuilder::new(
+            &app,
+            "log-viewer",
+            tauri::WebviewUrl::App("index.html?view=logs".into()),
+        )
+        .title("AgenticExplorer \u{2014} Logs")
+        .inner_size(900.0, 600.0)
+        .resizable(true)
+        .build()
+        .map_err(|e| format!("Failed to create log window: {}", e))?;
+
+        Ok(())
+    }
+}
+
 fn init_logging() {
     use env_logger::Builder;
     use log::LevelFilter;
@@ -148,6 +174,8 @@ pub fn run() {
             library::commands::commands::get_library_item_path,
             // Log reader
             log_reader::commands::read_backend_log,
+            // Log window
+            commands::open_log_window,
             // User settings (Documents/AgenticExplorer/)
             settings::commands::load_user_settings,
             settings::commands::save_user_settings,

--- a/src/LogWindowApp.tsx
+++ b/src/LogWindowApp.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { useThemeEffect } from "./hooks/useThemeEffect";
+import { useLogViewerStore } from "./store/logViewerStore";
+import { logError } from "./utils/errorLogger";
+import { LogViewer } from "./components/logs/LogViewer";
+
+/**
+ * Standalone app shell for the detached log viewer window.
+ * Renders LogViewer fullscreen and listens for pipeline-log events.
+ */
+export default function LogWindowApp() {
+  useThemeEffect();
+
+  const listenerActive = useRef(false);
+
+  useEffect(() => {
+    if (listenerActive.current) return;
+    listenerActive.current = true;
+
+    let unlisten: (() => void) | undefined;
+
+    listen<{ line: string; stream: string }>("pipeline-log", (event) => {
+      try {
+        const line = event?.payload?.line;
+        if (typeof line !== "string") return;
+
+        useLogViewerStore.getState().addEntries([
+          {
+            timestamp: new Date().toISOString(),
+            severity: "info",
+            source: "pipeline",
+            message: line,
+          },
+        ]);
+      } catch (err) {
+        logError("LogWindowApp", err);
+      }
+    })
+      .then((fn) => {
+        unlisten = fn;
+      })
+      .catch((err) => {
+        logError("LogWindowApp", err);
+      });
+
+    return () => {
+      unlisten?.();
+      listenerActive.current = false;
+    };
+  }, []);
+
+  return (
+    <div className="h-screen w-screen overflow-hidden bg-surface-base text-neutral-200">
+      <LogViewer />
+    </div>
+  );
+}

--- a/src/components/logs/LogViewer.tsx
+++ b/src/components/logs/LogViewer.tsx
@@ -5,6 +5,7 @@ import {
   Trash2,
   ArrowDownToLine,
   Search,
+  ExternalLink,
 } from "lucide-react";
 import {
   useLogViewerStore,
@@ -182,6 +183,14 @@ export function LogViewer() {
 
         {/* Action buttons */}
         <div className="flex gap-1">
+          <button
+            onClick={() => invoke("open_log_window").catch(console.error)}
+            className="flex items-center gap-1 px-2 py-1 text-[11px] text-neutral-400 hover:text-neutral-200 rounded transition-all"
+            title="In eigenem Fenster öffnen"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+          </button>
+
           <button
             onClick={toggleLiveTail}
             className={`flex items-center gap-1 px-2 py-1 text-[11px] rounded transition-all ${

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,29 @@
-import React from "react";
+import React, { Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { ErrorBoundary } from "./components/shared/ErrorBoundary";
 import { initTauriStorage } from "./store/tauriStorage";
 import "./index.css";
 
+const params = new URLSearchParams(window.location.search);
+const viewMode = params.get("view");
+
+const LogWindowApp = viewMode === "logs"
+  ? React.lazy(() => import("./LogWindowApp"))
+  : null;
+
 // Load persisted settings from Documents/AgenticExplorer/ before mounting
 initTauriStorage().then(() => {
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
       <ErrorBoundary>
-        <App />
+        {LogWindowApp ? (
+          <Suspense fallback={null}>
+            <LogWindowApp />
+          </Suspense>
+        ) : (
+          <App />
+        )}
       </ErrorBoundary>
     </React.StrictMode>
   );


### PR DESCRIPTION
## Summary
- Add `open_log_window` Tauri command that creates/focuses a dedicated log viewer WebviewWindow
- Route `?view=logs` in `main.tsx` to a lazy-loaded `LogWindowApp` shell wrapping `LogViewer` fullscreen
- Add detach button (ExternalLink icon) to LogViewer toolbar for opening the separate window

Closes #26

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes (LogWindowApp code-split as separate chunk)
- [ ] `cargo check` passes in src-tauri
- [ ] Click detach button in log viewer — new window opens with live log updates
- [ ] Click detach button again — existing window is focused (no duplicate)
- [ ] Close log window independently — main app unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)