### PR TITLE
feat(ui): add GitHub Projects Kanban board

### DIFF
--- a/src-tauri/src/github/commands.rs
+++ b/src-tauri/src/github/commands.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
-use std::process::Command;
+
+use super::{is_command_available, run_command};
 
 #[derive(Serialize, Clone)]
 pub struct GitCommitInfo {
@@ -31,42 +32,6 @@ pub struct GithubIssue {
     pub labels: Vec<String>,
     pub assignee: String,
     pub url: String,
-}
-
-/// Creates a Command with hidden console window on Windows.
-fn silent_command(program: &str) -> Command {
-    let mut cmd = Command::new(program);
-    #[cfg(target_os = "windows")]
-    {
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
-        cmd.creation_flags(CREATE_NO_WINDOW);
-    }
-    cmd
-}
-
-fn run_command(folder: &str, program: &str, args: &[&str]) -> Result<String, String> {
-    let output = silent_command(program)
-        .args(args)
-        .current_dir(folder)
-        .output()
-        .map_err(|e| format!("Failed to run {}: {}", program, e))?;
-
-    if output.status.success() {
-        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        Err(format!("{} failed: {}", program, stderr))
-    }
-}
-
-fn is_command_available(cmd: &str) -> bool {
-    #[cfg(target_os = "windows")]
-    let check = silent_command("where").arg(cmd).output();
-    #[cfg(not(target_os = "windows"))]
-    let check = silent_command("which").arg(cmd).output();
-
-    check.map(|o| o.status.success()).unwrap_or(false)
 }
 
 // Commands im mod-Block wegen rustc 1.94 E0255 Workaround (siehe CLAUDE.md)

--- a/src-tauri/src/github/kanban.rs
+++ b/src-tauri/src/github/kanban.rs
@@ -1,0 +1,266 @@
+use serde::{Deserialize, Serialize};
+
+use super::{is_command_available, run_global_command};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ProjectInfo {
+    pub number: u64,
+    pub title: String,
+    pub id: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ProjectColumn {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ProjectColumnsResult {
+    pub field_id: String,
+    pub columns: Vec<ProjectColumn>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct KanbanItem {
+    pub id: String,
+    pub title: String,
+    pub number: Option<u64>,
+    pub status: String,
+    pub labels: Vec<String>,
+    pub assignees: Vec<String>,
+    pub url: String,
+    pub item_type: String,
+}
+
+// Commands im mod-Block wegen rustc 1.94 E0255 Workaround (siehe CLAUDE.md)
+pub mod commands {
+    use super::*;
+
+    #[tauri::command]
+    pub async fn get_github_projects(owner: String) -> Result<Vec<ProjectInfo>, String> {
+        if !is_command_available("gh") {
+            return Err("gh CLI not found. Install from https://cli.github.com".to_string());
+        }
+
+        let output = run_global_command(
+            "gh",
+            &[
+                "project", "list",
+                "--owner", &owner,
+                "--format", "json",
+                "--limit", "20",
+            ],
+        )?;
+
+        if output.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let parsed: serde_json::Value = serde_json::from_str(&output)
+            .map_err(|e| format!("Failed to parse gh project list output: {}", e))?;
+
+        // gh project list --format json returns { "projects": [...] }
+        let projects_array = parsed.get("projects")
+            .and_then(|p| p.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let projects = projects_array
+            .iter()
+            .filter_map(|p| {
+                let number = p["number"].as_u64()?;
+                let title = p["title"].as_str().unwrap_or("").to_string();
+                let id = p["id"].as_str().unwrap_or("").to_string();
+                Some(ProjectInfo { number, title, id })
+            })
+            .collect();
+
+        Ok(projects)
+    }
+
+    #[tauri::command]
+    pub async fn get_project_columns(
+        owner: String,
+        project_number: u64,
+    ) -> Result<ProjectColumnsResult, String> {
+        if !is_command_available("gh") {
+            return Err("gh CLI not found. Install from https://cli.github.com".to_string());
+        }
+
+        let number_str = project_number.to_string();
+        let output = run_global_command(
+            "gh",
+            &[
+                "project", "field-list",
+                &number_str,
+                "--owner", &owner,
+                "--format", "json",
+            ],
+        )?;
+
+        if output.is_empty() {
+            return Ok(ProjectColumnsResult { field_id: String::new(), columns: Vec::new() });
+        }
+
+        let parsed: serde_json::Value = serde_json::from_str(&output)
+            .map_err(|e| format!("Failed to parse gh project field-list output: {}", e))?;
+
+        // gh project field-list --format json returns { "fields": [...] }
+        let fields = parsed.get("fields")
+            .and_then(|f| f.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        // Find the "Status" single-select field and extract options + field ID
+        for field in &fields {
+            let name = field.get("name").and_then(|n| n.as_str()).unwrap_or("");
+            if name == "Status" {
+                let field_id = field.get("id")
+                    .and_then(|i| i.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                let options = field.get("options")
+                    .and_then(|o| o.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+
+                let columns = options
+                    .iter()
+                    .filter_map(|opt| {
+                        let id = opt["id"].as_str()?.to_string();
+                        let opt_name = opt["name"].as_str().unwrap_or("").to_string();
+                        Some(ProjectColumn { id, name: opt_name })
+                    })
+                    .collect();
+
+                return Ok(ProjectColumnsResult { field_id, columns });
+            }
+        }
+
+        // No Status field found — return empty
+        Ok(ProjectColumnsResult { field_id: String::new(), columns: Vec::new() })
+    }
+
+    #[tauri::command]
+    pub async fn get_project_items(
+        owner: String,
+        project_number: u64,
+    ) -> Result<Vec<KanbanItem>, String> {
+        if !is_command_available("gh") {
+            return Err("gh CLI not found. Install from https://cli.github.com".to_string());
+        }
+
+        let number_str = project_number.to_string();
+        let output = run_global_command(
+            "gh",
+            &[
+                "project", "item-list",
+                &number_str,
+                "--owner", &owner,
+                "--format", "json",
+                "--limit", "100",
+            ],
+        )?;
+
+        if output.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let parsed: serde_json::Value = serde_json::from_str(&output)
+            .map_err(|e| format!("Failed to parse gh project item-list output: {}", e))?;
+
+        // gh project item-list --format json returns { "items": [...] }
+        let items_array = parsed.get("items")
+            .and_then(|i| i.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let items = items_array
+            .iter()
+            .map(|item| {
+                let id = item["id"].as_str().unwrap_or("").to_string();
+                let title = item["title"].as_str().unwrap_or("").to_string();
+
+                let content = item.get("content");
+                let number = content
+                    .and_then(|c| c.get("number"))
+                    .and_then(|n| n.as_u64());
+                let url = content
+                    .and_then(|c| c.get("url"))
+                    .and_then(|u| u.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let item_type = content
+                    .and_then(|c| c.get("type"))
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("DraftIssue")
+                    .to_string();
+
+                let labels = content
+                    .and_then(|c| c.get("labels"))
+                    .and_then(|l| l.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|l| l.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let assignees = content
+                    .and_then(|c| c.get("assignees"))
+                    .and_then(|a| a.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|a| a.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let status = item.get("status")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                KanbanItem {
+                    id,
+                    title,
+                    number,
+                    status,
+                    labels,
+                    assignees,
+                    url,
+                    item_type,
+                }
+            })
+            .collect();
+
+        Ok(items)
+    }
+
+    #[tauri::command]
+    pub async fn update_item_status(
+        project_id: String,
+        item_id: String,
+        field_id: String,
+        option_id: String,
+    ) -> Result<(), String> {
+        if !is_command_available("gh") {
+            return Err("gh CLI not found. Install from https://cli.github.com".to_string());
+        }
+
+        run_global_command(
+            "gh",
+            &[
+                "project", "item-edit",
+                "--project-id", &project_id,
+                "--id", &item_id,
+                "--field-id", &field_id,
+                "--single-select-option-id", &option_id,
+            ],
+        )?;
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -1,1 +1,55 @@
 pub mod commands;
+pub mod kanban;
+
+use std::process::Command;
+
+/// Creates a Command with hidden console window on Windows.
+pub(crate) fn silent_command(program: &str) -> Command {
+    let mut cmd = Command::new(program);
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}
+
+/// Run a command, optionally in a specific working directory.
+pub(crate) fn exec_command(folder: Option<&str>, program: &str, args: &[&str]) -> Result<String, String> {
+    let mut cmd = silent_command(program);
+    cmd.args(args);
+    if let Some(dir) = folder {
+        cmd.current_dir(dir);
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run {}: {}", program, e))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(format!("{} failed: {}", program, stderr))
+    }
+}
+
+/// Run a command in a specific working directory.
+pub(crate) fn run_command(folder: &str, program: &str, args: &[&str]) -> Result<String, String> {
+    exec_command(Some(folder), program, args)
+}
+
+/// Run a command without a working directory (uses system PATH only).
+pub(crate) fn run_global_command(program: &str, args: &[&str]) -> Result<String, String> {
+    exec_command(None, program, args)
+}
+
+pub(crate) fn is_command_available(cmd: &str) -> bool {
+    #[cfg(target_os = "windows")]
+    let check = silent_command("where").arg(cmd).output();
+    #[cfg(not(target_os = "windows"))]
+    let check = silent_command("which").arg(cmd).output();
+
+    check.map(|o| o.status.success()).unwrap_or(false)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,11 @@ pub fn run() {
             github::commands::commands::get_git_info,
             github::commands::commands::get_github_prs,
             github::commands::commands::get_github_issues,
+            // GitHub Projects / Kanban
+            github::kanban::commands::get_github_projects,
+            github::kanban::commands::get_project_columns,
+            github::kanban::commands::get_project_items,
+            github::kanban::commands::update_item_status,
             // Library
             library::commands::commands::list_library_items,
             library::commands::commands::read_library_item,

--- a/src/components/sessions/ContentTabs.tsx
+++ b/src/components/sessions/ContentTabs.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
-import { Terminal, FileText, Puzzle, Webhook, Github, ChevronDown, Settings2, BookOpen } from "lucide-react";
+import { Terminal, FileText, Puzzle, Webhook, Github, ChevronDown, Settings2, BookOpen, Layout } from "lucide-react";
 
-export type PrimaryTab = "terminal" | "config";
+export type PrimaryTab = "terminal" | "config" | "kanban";
 export type ConfigSubTab = "claude-md" | "skills" | "hooks" | "github" | "library";
 
 // Combined type for backwards compatibility with SessionManagerView
@@ -117,6 +117,19 @@ export function ContentTabs({ activeTab, configSubTab, onTabChange }: ContentTab
           </div>
         )}
       </div>
+
+      {/* Kanban tab */}
+      <button
+        onClick={() => onTabChange("kanban")}
+        className={`flex items-center gap-1.5 px-3 h-full text-xs font-medium transition-colors duration-150 border-b-2 ${
+          activeTab === "kanban"
+            ? "text-accent border-accent bg-accent-a05"
+            : "text-neutral-400 border-transparent hover:text-neutral-200 hover:bg-hover-overlay"
+        }`}
+      >
+        <Layout className="w-3.5 h-3.5" />
+        Kanban
+      </button>
     </div>
   );
 }

--- a/src/components/sessions/KanbanBoard.tsx
+++ b/src/components/sessions/KanbanBoard.tsx
@@ -1,0 +1,256 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Layout, RefreshCw, AlertTriangle, ChevronDown } from "lucide-react";
+import { useKanbanStore } from "../../store/kanbanStore";
+import { KanbanCard } from "./KanbanCard";
+import type { KanbanItem } from "../../store/kanbanStore";
+
+interface KanbanBoardProps {
+  folder: string;
+}
+
+function parseGitHubOwner(remoteUrl: string): string | null {
+  const match = remoteUrl.match(/github\.com[:/]([^/]+)\//);
+  return match ? match[1] : null;
+}
+
+export function KanbanBoard({ folder }: KanbanBoardProps) {
+  const [owner, setOwner] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(true);
+  const [dragOverColumnId, setDragOverColumnId] = useState<string | null>(null);
+
+  const {
+    projects,
+    selectedProject,
+    columns,
+    items,
+    loading,
+    error,
+    loadProjects,
+    selectProject,
+    moveItem,
+    refresh,
+  } = useKanbanStore();
+
+  useEffect(() => {
+    if (!folder) {
+      setResolving(false);
+      return;
+    }
+    setResolving(true);
+    invoke<{ remote_url: string }>("get_git_info", { folder })
+      .then((info) => {
+        const parsed = parseGitHubOwner(info?.remote_url ?? "");
+        setOwner(parsed);
+        setResolving(false);
+      })
+      .catch(() => {
+        setOwner(null);
+        setResolving(false);
+      });
+  }, [folder]);
+
+  useEffect(() => {
+    if (owner) {
+      loadProjects(owner);
+    }
+  }, [owner, loadProjects]);
+
+  const handleProjectSelect = useCallback(
+    (projectNumber: number) => {
+      if (owner) {
+        selectProject(owner, projectNumber);
+      }
+    },
+    [owner, selectProject]
+  );
+
+  const handleRefresh = useCallback(() => {
+    if (owner) {
+      refresh(owner);
+    }
+  }, [owner, refresh]);
+
+  function handleDragOver(e: React.DragEvent, columnId: string) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDragOverColumnId(columnId);
+  }
+
+  function handleDragLeave() {
+    setDragOverColumnId(null);
+  }
+
+  function handleDrop(e: React.DragEvent, columnId: string) {
+    e.preventDefault();
+    setDragOverColumnId(null);
+    const itemId = e.dataTransfer.getData("text/plain");
+    if (itemId) {
+      moveItem(itemId, columnId);
+    }
+  }
+
+  // Group items by their status column, collecting unmatched items separately
+  const { itemsByStatus, uncategorized } = useMemo(() => {
+    const byStatus = new Map<string, KanbanItem[]>();
+    for (const col of columns) {
+      byStatus.set(col.name, []);
+    }
+    const uncat: KanbanItem[] = [];
+    for (const item of items) {
+      const bucket = byStatus.get(item.status);
+      if (bucket) {
+        bucket.push(item);
+      } else {
+        uncat.push(item);
+      }
+    }
+    return { itemsByStatus: byStatus, uncategorized: uncat };
+  }, [columns, items]);
+
+  if (!folder) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-neutral-500 text-sm">
+        Keine aktive Session
+      </div>
+    );
+  }
+
+  if (resolving) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-neutral-500 text-sm">
+        Git-Repository wird erkannt...
+      </div>
+    );
+  }
+
+  if (!owner) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-2 text-neutral-500 text-sm p-8">
+        <AlertTriangle className="w-5 h-5 text-yellow-500" />
+        <span>Kein GitHub-Remote gefunden.</span>
+        <span className="text-xs text-neutral-600">
+          Das Repository muss ein GitHub-Remote haben, um Projects anzuzeigen.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-700 bg-surface-raised shrink-0">
+        <Layout className="w-4 h-4 text-accent" />
+        <span className="text-xs font-medium text-neutral-200">Kanban</span>
+
+        <div className="relative ml-2">
+          <select
+            value={selectedProject ?? ""}
+            onChange={(e) => {
+              const num = Number(e.target.value);
+              if (num) handleProjectSelect(num);
+            }}
+            className="appearance-none bg-surface-base border border-neutral-700 rounded px-2 py-1 pr-6 text-xs text-neutral-200
+                       focus:border-accent focus:outline-none cursor-pointer"
+          >
+            <option value="">Projekt waehlen...</option>
+            {projects.map((p) => (
+              <option key={p.number} value={p.number}>
+                {p.title}
+              </option>
+            ))}
+          </select>
+          <ChevronDown className="absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-neutral-500 pointer-events-none" />
+        </div>
+
+        <button
+          onClick={handleRefresh}
+          disabled={loading}
+          className="ml-auto flex items-center gap-1 text-xs text-neutral-400 hover:text-neutral-200 transition-colors disabled:opacity-50"
+          title="Aktualisieren"
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`} />
+        </button>
+
+        {loading && (
+          <span className="text-[10px] text-neutral-500">Laden...</span>
+        )}
+      </div>
+
+      {error && (
+        <div className="px-3 py-2 bg-red-900/20 border-b border-red-900/40 text-xs text-red-400 flex items-center gap-2">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+          <span className="line-clamp-2">{error}</span>
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0 overflow-x-auto overflow-y-hidden">
+        {selectedProject == null ? (
+          <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+            {projects.length === 0 && !loading
+              ? "Keine GitHub Projects gefunden fuer diesen Owner."
+              : "Bitte ein Projekt auswaehlen."}
+          </div>
+        ) : columns.length === 0 && !loading ? (
+          <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+            Keine Status-Spalten gefunden. Ist ein &quot;Status&quot;-Feld im Projekt konfiguriert?
+          </div>
+        ) : (
+          <div className="flex gap-3 p-3 h-full min-w-min">
+            {columns.map((col) => {
+              const colItems = itemsByStatus.get(col.name) ?? [];
+              const isDropTarget = dragOverColumnId === col.id;
+              return (
+                <div
+                  key={col.id}
+                  onDragOver={(e) => handleDragOver(e, col.id)}
+                  onDragLeave={handleDragLeave}
+                  onDrop={(e) => handleDrop(e, col.id)}
+                  className={`flex flex-col w-64 min-w-[256px] rounded bg-surface-raised border transition-colors
+                    ${isDropTarget ? "border-accent bg-accent-a05" : "border-neutral-700"}`}
+                >
+                  <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-700/50">
+                    <span className="text-xs font-medium text-neutral-200 truncate">
+                      {col.name}
+                    </span>
+                    <span className="text-[10px] text-neutral-500 bg-neutral-800 px-1.5 py-0.5 rounded-full">
+                      {colItems.length}
+                    </span>
+                  </div>
+
+                  <div className="flex-1 overflow-y-auto p-2 space-y-2">
+                    {colItems.map((item) => (
+                      <KanbanCard key={item.id} item={item} />
+                    ))}
+                    {colItems.length === 0 && (
+                      <div className="text-[10px] text-neutral-600 text-center py-4">
+                        Keine Items
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {uncategorized.length > 0 && (
+              <div className="flex flex-col w-64 min-w-[256px] rounded bg-surface-raised border border-neutral-700">
+                <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-700/50">
+                  <span className="text-xs font-medium text-neutral-400 truncate">
+                    Ohne Status
+                  </span>
+                  <span className="text-[10px] text-neutral-500 bg-neutral-800 px-1.5 py-0.5 rounded-full">
+                    {uncategorized.length}
+                  </span>
+                </div>
+                <div className="flex-1 overflow-y-auto p-2 space-y-2">
+                  {uncategorized.map((item) => (
+                    <KanbanCard key={item.id} item={item} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/sessions/KanbanCard.tsx
+++ b/src/components/sessions/KanbanCard.tsx
@@ -1,0 +1,97 @@
+import { GripVertical, ExternalLink } from "lucide-react";
+import type { KanbanItem } from "../../store/kanbanStore";
+
+interface KanbanCardProps {
+  item: KanbanItem;
+}
+
+const TYPE_BADGES: Record<string, { label: string; className: string }> = {
+  Issue: { label: "Issue", className: "bg-green-900/30 text-green-400" },
+  PullRequest: { label: "PR", className: "bg-purple-900/30 text-purple-400" },
+  DraftIssue: { label: "Draft", className: "bg-neutral-700/50 text-neutral-400" },
+};
+
+const LABEL_COLORS: Record<string, string> = {
+  bug: "bg-red-900/40 text-red-300",
+  enhancement: "bg-blue-900/40 text-blue-300",
+  feature: "bg-green-900/40 text-green-300",
+  documentation: "bg-yellow-900/40 text-yellow-300",
+  "good first issue": "bg-purple-900/40 text-purple-300",
+};
+
+function labelClass(label: string): string {
+  return LABEL_COLORS[label.toLowerCase()] ?? "bg-neutral-700/60 text-neutral-300";
+}
+
+export function KanbanCard({ item }: KanbanCardProps) {
+  function handleDragStart(e: React.DragEvent) {
+    e.dataTransfer.setData("text/plain", item.id);
+    e.dataTransfer.effectAllowed = "move";
+  }
+
+  const typeBadge = TYPE_BADGES[item.item_type];
+
+  return (
+    <div
+      draggable="true"
+      onDragStart={handleDragStart}
+      className="group bg-surface-base border border-neutral-700 rounded px-3 py-2 cursor-grab
+                 hover:border-neutral-500 hover:bg-hover-overlay transition-colors active:cursor-grabbing"
+    >
+      <div className="flex items-center gap-1.5 mb-1">
+        <GripVertical className="w-3 h-3 text-neutral-600 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+        {typeBadge && (
+          <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${typeBadge.className}`}>
+            {typeBadge.label}
+          </span>
+        )}
+        {item.number != null && (
+          <span className="text-[10px] text-neutral-500 font-mono">
+            #{item.number}
+          </span>
+        )}
+        {item.url && (
+          <a
+            href={item.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="ml-auto opacity-0 group-hover:opacity-100 text-neutral-500 hover:text-neutral-300 transition-opacity"
+          >
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        )}
+      </div>
+
+      <p className="text-xs text-neutral-200 line-clamp-2 leading-relaxed">
+        {item.title}
+      </p>
+
+      {item.labels.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-1.5">
+          {item.labels.map((label) => (
+            <span
+              key={label}
+              className={`text-[10px] px-1.5 py-0.5 rounded ${labelClass(label)}`}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {item.assignees.length > 0 && (
+        <div className="flex items-center gap-1 mt-1.5">
+          {item.assignees.map((a) => (
+            <span
+              key={a}
+              className="text-[10px] text-neutral-400 bg-neutral-800 px-1.5 py-0.5 rounded"
+            >
+              {a}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sessions/SessionManagerView.tsx
+++ b/src/components/sessions/SessionManagerView.tsx
@@ -22,6 +22,7 @@ const SkillsViewer = lazy(() => import("./SkillsViewer").then(m => ({ default: m
 const HooksViewer = lazy(() => import("./HooksViewer").then(m => ({ default: m.HooksViewer })));
 const GitHubViewer = lazy(() => import("./GitHubViewer").then(m => ({ default: m.GitHubViewer })));
 const LibraryViewer = lazy(() => import("./LibraryViewer").then(m => ({ default: m.LibraryViewer })));
+const KanbanBoard = lazy(() => import("./KanbanBoard").then(m => ({ default: m.KanbanBoard })));
 
 export function SessionManagerView() {
   const [showNewDialog, setShowNewDialog] = useState(false);
@@ -215,6 +216,7 @@ export function SessionManagerView() {
 
   // Determine what content to show
   const showConfig = primaryTab === "config";
+  const showKanban = primaryTab === "kanban";
 
   return (
     <div className="flex flex-col h-full">
@@ -262,6 +264,10 @@ export function SessionManagerView() {
                     ) : configSubTab === "library" ? (
                       <LibraryViewer folder={activeSession?.folder ?? ""} />
                     ) : null}
+                  </Suspense>
+                ) : showKanban ? (
+                  <Suspense fallback={<div className="flex-1 flex items-center justify-center text-neutral-500">Laden...</div>}>
+                    <KanbanBoard folder={activeSession?.folder ?? ""} />
                   </Suspense>
                 ) : (
                   <div className="flex flex-col h-full">

--- a/src/store/kanbanStore.ts
+++ b/src/store/kanbanStore.ts
@@ -1,0 +1,161 @@
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface ProjectInfo {
+  number: number;
+  title: string;
+  id: string;
+}
+
+export interface ProjectColumn {
+  id: string;
+  name: string;
+}
+
+interface ProjectColumnsResult {
+  field_id: string;
+  columns: ProjectColumn[];
+}
+
+export interface KanbanItem {
+  id: string;
+  title: string;
+  number: number | null;
+  status: string;
+  labels: string[];
+  assignees: string[];
+  url: string;
+  item_type: string;
+}
+
+// ── Store ──────────────────────────────────────────────────────────────
+
+interface KanbanState {
+  projects: ProjectInfo[];
+  selectedProject: number | null;
+  columns: ProjectColumn[];
+  items: KanbanItem[];
+  fieldId: string | null;
+  projectId: string | null;
+  loading: boolean;
+  error: string | null;
+  lastFetched: number;
+
+  loadProjects: (owner: string) => Promise<void>;
+  selectProject: (owner: string, projectNumber: number) => Promise<void>;
+  moveItem: (itemId: string, newOptionId: string) => Promise<void>;
+  refresh: (owner: string) => Promise<void>;
+  reset: () => void;
+}
+
+const CACHE_TTL = 60_000; // 60 seconds
+
+export const useKanbanStore = create<KanbanState>((set, get) => ({
+  projects: [],
+  selectedProject: null,
+  columns: [],
+  items: [],
+  fieldId: null,
+  projectId: null,
+  loading: false,
+  error: null,
+  lastFetched: 0,
+
+  loadProjects: async (owner: string) => {
+    const now = Date.now();
+    const state = get();
+    if (state.projects.length > 0 && now - state.lastFetched < CACHE_TTL) return;
+
+    set({ loading: true, error: null });
+    try {
+      const projects = await invoke<ProjectInfo[]>("get_github_projects", { owner });
+      set({ projects, loading: false, lastFetched: Date.now() });
+    } catch (err) {
+      set({ loading: false, error: String(err) });
+    }
+  },
+
+  selectProject: async (owner: string, projectNumber: number) => {
+    set({ loading: true, error: null, selectedProject: projectNumber });
+    try {
+      const [columnsResult, items] = await Promise.all([
+        invoke<ProjectColumnsResult>("get_project_columns", { owner, projectNumber }),
+        invoke<KanbanItem[]>("get_project_items", { owner, projectNumber }),
+      ]);
+
+      // Find the project ID from loaded projects
+      const project = get().projects.find((p) => p.number === projectNumber);
+      const projectId = project?.id ?? null;
+
+      set({
+        columns: columnsResult?.columns ?? [],
+        fieldId: columnsResult?.field_id || null,
+        items,
+        projectId,
+        loading: false,
+        lastFetched: Date.now(),
+      });
+    } catch (err) {
+      set({ loading: false, error: String(err) });
+    }
+  },
+
+  moveItem: async (itemId: string, newOptionId: string) => {
+    const { projectId, fieldId } = get();
+    if (!projectId) {
+      set({ error: "Kein Projekt-ID vorhanden" });
+      return;
+    }
+    if (!fieldId) {
+      set({ error: "Kein Status-Feld-ID vorhanden. Drag & Drop ist erst nach erneutem Laden moeglich." });
+      return;
+    }
+
+    // Optimistic update
+    const prevItems = get().items;
+    const targetColumn = get().columns.find((c) => c.id === newOptionId);
+    if (targetColumn) {
+      set({
+        items: prevItems.map((item) =>
+          item.id === itemId ? { ...item, status: targetColumn.name } : item
+        ),
+      });
+    }
+
+    try {
+      await invoke("update_item_status", {
+        projectId,
+        itemId,
+        fieldId,
+        optionId: newOptionId,
+      });
+    } catch (err) {
+      // Rollback on failure
+      set({ items: prevItems, error: String(err) });
+    }
+  },
+
+  refresh: async (owner: string) => {
+    const { selectedProject } = get();
+    set({ lastFetched: 0 });
+    await get().loadProjects(owner);
+    if (selectedProject != null) {
+      await get().selectProject(owner, selectedProject);
+    }
+  },
+
+  reset: () =>
+    set({
+      projects: [],
+      selectedProject: null,
+      columns: [],
+      items: [],
+      fieldId: null,
+      projectId: null,
+      loading: false,
+      error: null,
+      lastFetched: 0,
+    }),
+}));


### PR DESCRIPTION
## Summary
- Add a new **Kanban** primary tab (peer to Terminal and Config) that displays GitHub Projects as a drag-and-drop board
- New Rust backend commands (`get_github_projects`, `get_project_columns`, `get_project_items`, `update_item_status`) using `gh project` CLI
- Refactor shared `gh` CLI helpers (`silent_command`, `run_command`, `is_command_available`) from `commands.rs` into `github/mod.rs` for cross-module reuse
- New `kanbanStore` (Zustand) with 60s cache TTL, optimistic drag-and-drop moves with rollback on failure
- KanbanBoard: project selector, column layout from Status field, HTML5 native DnD, error/empty states in German
- KanbanCard: type badges (Issue/PR/Draft), label colors, assignee display

Closes #17, closes #24

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `cd src-tauri && cargo check` passes
- [ ] Open a session pointing to a repo with GitHub Projects configured, verify Kanban tab loads projects
- [ ] Select a project, verify columns and cards render
- [ ] Drag a card between columns, verify optimistic update and API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)