### PR TITLE
style(pipeline): polish empty state and idle displays (#12)

### DIFF
--- a/src/components/DashboardMap.tsx
+++ b/src/components/DashboardMap.tsx
@@ -24,11 +24,7 @@ function EmptyState() {
           Keine Agenten erkannt
         </h2>
         <p className="text-sm text-neutral-500 max-w-md leading-relaxed">
-          Starte eine Claude-Session mit parallelen Agenten oder Worktrees,
-          um sie hier in Echtzeit zu verfolgen.
-        </p>
-        <p className="text-xs text-neutral-600 mt-2">
-          Erkannte Agenten und Worktrees werden automatisch in der Pipeline-View angezeigt.
+          Starte eine Session mit Claude CLI
         </p>
       </motion.div>
     </div>

--- a/src/components/OrchestratorNode.tsx
+++ b/src/components/OrchestratorNode.tsx
@@ -96,7 +96,7 @@ export function OrchestratorNode({ orchestratorStatus, orchestratorLog, summary 
             </motion.div>
           ))}
           {orchestratorLog.length === 0 && (
-            <div className="text-neutral-600 text-xs italic">Waiting to start...</div>
+            <div className="text-neutral-600 text-xs italic">Warte auf Start...</div>
           )}
         </AnimatePresence>
       </div>

--- a/src/components/QAGateNode.tsx
+++ b/src/components/QAGateNode.tsx
@@ -46,27 +46,33 @@ export function QAGateNode({ qaGate }: Props) {
 
       {/* Checks table */}
       <div className="px-4 py-3 space-y-2">
-        {(Object.entries(checks) as [keyof typeof checks, QACheckStatus][]).map(([key, status]) => {
-          const Icon = QA_STATUS_ICONS[status];
-          const label = QA_CHECK_LABELS[key];
-          const checkStyle = getStatusStyle(status);
-          return (
-            <div key={key} className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <motion.div
-                  animate={{ rotate: status === "running" ? 360 : 0 }}
-                  transition={{ duration: DURATION.base * 3, repeat: status === "running" ? Infinity : 0, ease: "linear" }}
-                >
-                  <Icon className={`w-4 h-4 ${checkStyle.text}`} />
-                </motion.div>
-                <span className="text-sm text-neutral-300">{label}</span>
+        {overallStatus === "idle" ? (
+          <div className="text-center text-neutral-600 text-xs italic py-2">
+            Keine aktiven Checks
+          </div>
+        ) : (
+          (Object.entries(checks) as [keyof typeof checks, QACheckStatus][]).map(([key, status]) => {
+            const Icon = QA_STATUS_ICONS[status];
+            const label = QA_CHECK_LABELS[key];
+            const checkStyle = getStatusStyle(status);
+            return (
+              <div key={key} className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <motion.div
+                    animate={{ rotate: status === "running" ? 360 : 0 }}
+                    transition={{ duration: DURATION.base * 3, repeat: status === "running" ? Infinity : 0, ease: "linear" }}
+                  >
+                    <Icon className={`w-4 h-4 ${checkStyle.text}`} />
+                  </motion.div>
+                  <span className="text-sm text-neutral-300">{label}</span>
+                </div>
+                <div className={`text-xs font-mono px-2 py-0.5 rounded-none border ${checkStyle.border} ${checkStyle.text} ${checkStyle.bg}/10`}>
+                  {status.toUpperCase()}
+                </div>
               </div>
-              <div className={`text-xs font-mono px-2 py-0.5 rounded-none border ${checkStyle.border} ${checkStyle.text} ${checkStyle.bg}/10`}>
-                {status.toUpperCase()}
-              </div>
-            </div>
-          );
-        })}
+            );
+          })
+        )}
       </div>
 
       {/* Status bar */}


### PR DESCRIPTION
## Summary
- Simplified DashboardMap empty state to concise German subtitle ("Starte eine Session mit Claude CLI")
- Translated OrchestratorNode fallback text from English to German ("Warte auf Start...")
- QAGateNode now shows "Keine aktiven Checks" when idle instead of listing all checks as PENDING

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] All 251 unit tests pass
- [ ] Visual check: Pipeline view empty state shows clean German text
- [ ] Visual check: QA Gate idle state shows single centered message

🤖 Generated with [Claude Code](https://claude.com/claude-code)