### PR TITLE
feat(ui): add Worktree overview tab in session config (#22)

### DIFF
--- a/src/components/sessions/ContentTabs.tsx
+++ b/src/components/sessions/ContentTabs.tsx
@@ -1,8 +1,8 @@
 import { useState, useRef, useEffect } from "react";
-import { Terminal, FileText, Puzzle, Webhook, Github, ChevronDown, Settings2 } from "lucide-react";
+import { Terminal, FileText, Puzzle, Webhook, Github, GitBranch, ChevronDown, Settings2 } from "lucide-react";
 
 export type PrimaryTab = "terminal" | "config";
-export type ConfigSubTab = "claude-md" | "skills" | "hooks" | "github";
+export type ConfigSubTab = "claude-md" | "skills" | "hooks" | "github" | "worktrees";
 
 // Combined type for backwards compatibility with SessionManagerView
 export type ContentTab = "terminal" | ConfigSubTab;
@@ -18,6 +18,7 @@ const configItems: { id: ConfigSubTab; label: string; icon: typeof FileText }[] 
   { id: "skills", label: "Skills", icon: Puzzle },
   { id: "hooks", label: "Hooks", icon: Webhook },
   { id: "github", label: "GitHub", icon: Github },
+  { id: "worktrees", label: "Worktrees", icon: GitBranch },
 ];
 
 export function ContentTabs({ activeTab, configSubTab, onTabChange }: ContentTabsProps) {

--- a/src/components/sessions/SessionManagerView.tsx
+++ b/src/components/sessions/SessionManagerView.tsx
@@ -21,6 +21,7 @@ const ClaudeMdViewer = lazy(() => import("./ClaudeMdViewer").then(m => ({ defaul
 const SkillsViewer = lazy(() => import("./SkillsViewer").then(m => ({ default: m.SkillsViewer })));
 const HooksViewer = lazy(() => import("./HooksViewer").then(m => ({ default: m.HooksViewer })));
 const GitHubViewer = lazy(() => import("./GitHubViewer").then(m => ({ default: m.GitHubViewer })));
+const WorktreeViewer = lazy(() => import("./WorktreeViewer").then(m => ({ default: m.WorktreeViewer })));
 
 export function SessionManagerView() {
   const [showNewDialog, setShowNewDialog] = useState(false);
@@ -258,6 +259,8 @@ export function SessionManagerView() {
                       <HooksViewer folder={activeSession?.folder ?? ""} />
                     ) : configSubTab === "github" ? (
                       <GitHubViewer folder={activeSession?.folder ?? ""} />
+                    ) : configSubTab === "worktrees" ? (
+                      <WorktreeViewer folder={activeSession?.folder ?? ""} />
                     ) : null}
                   </Suspense>
                 ) : (

--- a/src/components/sessions/WorktreeViewer.tsx
+++ b/src/components/sessions/WorktreeViewer.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { RefreshCw, GitBranch } from "lucide-react";
+
+interface WorktreeViewerProps {
+  folder: string;
+}
+
+interface WorktreeInfo {
+  path: string;
+  branch: string | null;
+  is_main: boolean;
+}
+
+// Simple in-memory cache to avoid re-fetching on tab switches
+interface CacheEntry {
+  worktrees: WorktreeInfo[];
+  timestamp: number;
+}
+const cache = new Map<string, CacheEntry>();
+const CACHE_TTL = 60_000; // 1 minute
+
+export function WorktreeViewer({ folder }: WorktreeViewerProps) {
+  const [worktrees, setWorktrees] = useState<WorktreeInfo[]>([]);
+  const [error, setError] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const mountedRef = useRef(true);
+
+  const load = useCallback(async (forceRefresh = false) => {
+    if (!forceRefresh) {
+      const cached = cache.get(folder);
+      if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+        setWorktrees(cached.worktrees);
+        setError("");
+        setLoading(false);
+        return;
+      }
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      const result = await invoke<WorktreeInfo[]>("scan_worktrees", { folder });
+      cache.set(folder, { worktrees: result, timestamp: Date.now() });
+      if (!mountedRef.current) return;
+      setWorktrees(result);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(String(err));
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }, [folder]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    load();
+    return () => { mountedRef.current = false; };
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+        Laden...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-3 text-neutral-500">
+        <GitBranch className="w-10 h-10 text-neutral-600" />
+        <span className="text-sm text-error">{error}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 shrink-0">
+        <div className="flex items-center gap-1.5">
+          <GitBranch className="w-3.5 h-3.5 text-neutral-400" />
+          <span className="text-xs text-neutral-400 font-medium">
+            Worktrees ({worktrees.length})
+          </span>
+        </div>
+        <button
+          onClick={() => load(true)}
+          className="p-1 text-neutral-500 hover:text-neutral-300 transition-colors"
+          title="Neu laden"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-auto p-4">
+        {worktrees.length === 0 ? (
+          <div className="text-xs text-neutral-600">Keine Worktrees gefunden</div>
+        ) : (
+          <div className="space-y-1.5">
+            {worktrees.map((wt) => (
+              <div
+                key={wt.path}
+                className="flex items-center gap-2 bg-surface-base border border-neutral-700 rounded-sm px-3 py-2 hover:border-neutral-600 transition-colors"
+              >
+                <GitBranch className="w-4 h-4 text-accent shrink-0" />
+                <div className="flex flex-col flex-1 min-w-0">
+                  <span className="text-xs text-neutral-200 font-medium">
+                    {wt.branch ?? "detached"}
+                  </span>
+                  <span className="text-[11px] text-neutral-500 truncate">
+                    {wt.path}
+                  </span>
+                </div>
+                {wt.is_main && (
+                  <span className="text-[10px] px-1.5 py-0.5 bg-accent-a10 text-accent rounded-sm shrink-0">
+                    Haupt
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 export type ActiveTab = "sessions" | "pipeline" | "logs" | "library" | "settings";
 
-export type ConfigSubTab = "claude-md" | "skills" | "hooks" | "github";
+export type ConfigSubTab = "claude-md" | "skills" | "hooks" | "github" | "worktrees";
 
 export type ToastType = "achievement" | "error" | "info";
 


### PR DESCRIPTION
## Summary
- New `WorktreeViewer` component that calls `scan_worktrees` Tauri command and displays git worktrees with branch name, path, and "Haupt" badge for the main worktree
- Added "Worktrees" as a new config sub-tab (with GitBranch icon) in ContentTabs dropdown and SessionManagerView
- Extended `ConfigSubTab` type in both `uiStore.ts` and `ContentTabs.tsx`

## Test plan
- [ ] Open a session for a project with git worktrees, switch to Konfig > Worktrees tab
- [ ] Verify worktrees list loads with branch names, paths, and "Haupt" badge on main
- [ ] Verify refresh button reloads data
- [ ] Verify empty state shows "Keine Worktrees gefunden" for non-git folders
- [ ] Verify error state displays red message for invalid folders
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)