### PR TITLE
chore: complete AgenticExplorer rebranding (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# AgenticExplorer
+
+Desktop-App zum Verwalten und Ueberwachen von Claude CLI Sessions. Multi-Session-Terminal mit Projekt-Kontext (CLAUDE.md, Skills, Hooks, GitHub), Favoriten-System und Notizen.
+
+## Tech Stack
+
+- **Frontend**: React 18, TypeScript, Vite, Zustand, Tailwind CSS, Framer Motion
+- **Backend**: Tauri v2, Rust
+- **Terminal**: xterm.js mit PTY-Sessions
+
+## Voraussetzungen
+
+- [Node.js](https://nodejs.org/) (v18+)
+- [Rust](https://rustup.rs/) (stable)
+- [Tauri v2 Prerequisites](https://v2.tauri.app/start/prerequisites/)
+- [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli) installiert und konfiguriert
+
+## Setup
+
+```bash
+npm install
+```
+
+## Entwicklung
+
+```bash
+npm run tauri dev
+```
+
+Startet die Desktop-App im Entwicklungsmodus (Vite Dev-Server + Tauri).
+
+## Build
+
+```bash
+npm run tauri build
+```
+
+Erstellt einen produktionsfertigen Desktop-Build (Frontend + Rust).
+
+## Weitere Befehle
+
+```bash
+npm run dev          # Nur Vite Dev-Server (Port 5173, ohne Tauri)
+npm run build        # Nur Frontend-Build (TypeScript-Check + Vite)
+npx tsc --noEmit     # Type-Checking ohne Build
+```
+
+## Lizenz
+
+Proprietaer. Alle Rechte vorbehalten.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentic-dashboard",
+  "name": "agenticexplorer",
   "private": true,
   "version": "1.2.4",
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agentic-dashboard"
+name = "agenticexplorer"
 version = "1.2.4"
 description = "AgenticExplorer - Manage and monitor Claude CLI sessions"
 authors = []
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-name = "agentic_dashboard_lib"
+name = "agenticexplorer_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    agentic_dashboard_lib::run()
+    agenticexplorer_lib::run()
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -60,7 +60,7 @@ export function Header() {
       <div className="flex items-center gap-3">
         <Cpu className="w-6 h-6 text-accent" />
         <span className="text-accent font-bold text-lg tracking-wider font-display">
-          AGENTIC DASHBOARD
+          AGENTICEXPLORER
         </span>
         <button
           onClick={() => setShowChangelog(true)}

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -281,7 +281,7 @@ export const useSettingsStore = create<SettingsState>()(
         })),
     }),
     {
-      name: "agentic-dashboard-settings",
+      name: "agenticexplorer-settings",
       storage: createJSONStorage(() => tauriStorage),
       onRehydrateStorage: () => (_state, error) => {
         if (error) {

--- a/src/store/tauriStorage.ts
+++ b/src/store/tauriStorage.ts
@@ -31,7 +31,7 @@ export function initTauriStorage(): Promise<void> {
   ])
     .then(([settingsData, favoritesData, notesData]) => {
       if (settingsData) {
-        cache.set("agentic-dashboard-settings", settingsData);
+        cache.set("agenticexplorer-settings", settingsData);
       }
 
       // Parse favorites from dedicated file
@@ -80,9 +80,19 @@ export function getLoadedNotes(): { global: string; project: Record<string, stri
 export const tauriStorage: StateStorage = {
   getItem(name: string): string | null {
     if (!isTauri) {
-      return localStorage.getItem(name);
+      const value = localStorage.getItem(name);
+      // Migration: fall back to old persist key if new key has no data
+      if (value === null && name === "agenticexplorer-settings") {
+        return localStorage.getItem("agentic-dashboard-settings");
+      }
+      return value;
     }
-    return cache.get(name) ?? null;
+    const cached = cache.get(name);
+    // Migration: fall back to old persist key if new key has no data
+    if (cached === undefined && name === "agenticexplorer-settings") {
+      return cache.get("agentic-dashboard-settings") ?? null;
+    }
+    return cached ?? null;
   },
 
   setItem(name: string, value: string): void {


### PR DESCRIPTION
## Summary
- Renamed all remaining `agentic-dashboard` references to `agenticexplorer` across package.json, Cargo.toml, main.rs, Header.tsx, and settingsStore.ts
- Added settings migration fallback in tauriStorage.ts so existing user data (saved under old persist key) is seamlessly carried over
- Created README.md with project overview, tech stack, and setup instructions

## Test plan
- [x] All 251 unit tests pass (`npm run test`)
- [x] TypeScript check passes (`npx tsc --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [ ] Verify header displays "AGENTICEXPLORER" in dev mode
- [ ] Verify settings persist correctly after upgrade (migration path)
- [ ] Verify `cargo check` passes with renamed crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)