### PR TITLE
feat(ui): add project config detection in Library view (#35)

### DIFF
--- a/src/components/library/LibraryView.tsx
+++ b/src/components/library/LibraryView.tsx
@@ -1,10 +1,145 @@
-import { BookOpen } from "lucide-react";
+import { useState, useEffect } from "react";
+import { BookOpen, FolderSearch, ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
 import { LibraryViewer } from "../sessions/LibraryViewer";
 import { useSessionStore, selectActiveSession } from "../../store/sessionStore";
+import { useProjectConfigStore, type ProjectConfig } from "../../store/projectConfigStore";
+import { useSettingsStore } from "../../store/settingsStore";
+
+// ── Project Config Card ───────────────────────────────────────────────
+
+function ConfigCard({
+  config,
+  expanded,
+  onToggle,
+}: {
+  config: ProjectConfig;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const hasAny = config.hasClaude || config.skillCount > 0 || config.hookCount > 0;
+
+  return (
+    <button
+      onClick={onToggle}
+      className="w-full text-left p-3 bg-surface-raised rounded-lg border border-neutral-700 hover:border-neutral-600 transition-colors"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            {hasAny ? (
+              expanded ? (
+                <ChevronDown className="w-3.5 h-3.5 text-neutral-500 shrink-0" />
+              ) : (
+                <ChevronRight className="w-3.5 h-3.5 text-neutral-500 shrink-0" />
+              )
+            ) : (
+              <span className="w-3.5" />
+            )}
+            <span className="text-sm font-semibold text-neutral-200 truncate">
+              {config.label}
+            </span>
+          </div>
+          <p className="text-xs text-neutral-500 truncate mt-0.5 ml-5">
+            {config.path}
+          </p>
+        </div>
+
+        {/* Badges */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          {config.error ? (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-red-500/15 text-red-400">
+              Fehler
+            </span>
+          ) : (
+            <>
+              {config.hasClaude && (
+                <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-green-500/15 text-green-400">
+                  CLAUDE.md
+                </span>
+              )}
+              {config.skillCount > 0 && (
+                <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-blue-500/15 text-blue-400">
+                  {config.skillCount} Skill{config.skillCount !== 1 ? "s" : ""}
+                </span>
+              )}
+              {config.hookCount > 0 && (
+                <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-amber-500/15 text-amber-400">
+                  {config.hookCount} Hook{config.hookCount !== 1 ? "s" : ""}
+                </span>
+              )}
+              {!config.hasClaude && config.skillCount === 0 && config.hookCount === 0 && (
+                <span className="text-[10px] text-neutral-600">Keine Konfiguration</span>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded details */}
+      {expanded && hasAny && !config.error && (
+        <div className="mt-2 ml-5 space-y-1.5 border-t border-neutral-700 pt-2">
+          {config.skills.length > 0 && (
+            <div>
+              <span className="text-[10px] text-neutral-500 uppercase tracking-wider">Skills</span>
+              <div className="flex flex-wrap gap-1 mt-0.5">
+                {config.skills.map((s) => (
+                  <span key={s} className="px-1.5 py-0.5 text-[10px] rounded bg-blue-500/10 text-blue-400">
+                    {s}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          {config.hooks.length > 0 && (
+            <div>
+              <span className="text-[10px] text-neutral-500 uppercase tracking-wider">Hook-Events</span>
+              <div className="flex flex-wrap gap-1 mt-0.5">
+                {config.hooks.map((h) => (
+                  <span key={h} className="px-1.5 py-0.5 text-[10px] rounded bg-amber-500/10 text-amber-400">
+                    {h}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Error message */}
+      {expanded && config.error && (
+        <p className="mt-2 ml-5 text-xs text-red-400">{config.error}</p>
+      )}
+    </button>
+  );
+}
+
+// ── Main View ─────────────────────────────────────────────────────────
 
 export function LibraryView() {
   const activeSession = useSessionStore(selectActiveSession);
   const folder = activeSession?.folder;
+
+  const favorites = useSettingsStore((s) => s.favorites);
+  const configs = useProjectConfigStore((s) => s.configs);
+  const globalConfig = useProjectConfigStore((s) => s.globalConfig);
+  const loading = useProjectConfigStore((s) => s.loading);
+  const scanAllFavorites = useProjectConfigStore((s) => s.scanAllFavorites);
+
+  const [expandedPath, setExpandedPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    scanAllFavorites();
+  }, []);
+
+  const toggleExpand = (path: string) => {
+    setExpandedPath((prev) => (prev === path ? null : path));
+  };
+
+  const handleRescan = () => {
+    // Force rescan by resetting lastScanned
+    useProjectConfigStore.setState({ lastScanned: null });
+    scanAllFavorites();
+  };
 
   return (
     <div className="flex flex-col h-full">
@@ -21,9 +156,66 @@ export function LibraryView() {
         )}
       </div>
 
-      {/* Content */}
-      <div className="flex-1 min-h-0">
-        <LibraryViewer folder={folder} />
+      {/* Scrollable content */}
+      <div className="flex-1 min-h-0 flex flex-col">
+        {/* Project Configs Section */}
+        <div className="shrink-0 border-b border-neutral-700">
+          <div className="flex items-center justify-between px-4 py-2">
+            <div className="flex items-center gap-2">
+              <FolderSearch className="w-4 h-4 text-neutral-400" />
+              <h2 className="text-xs font-medium text-neutral-400 uppercase tracking-wider">
+                Projekt-Konfigurationen
+              </h2>
+            </div>
+            <button
+              onClick={handleRescan}
+              className={`p-1 text-neutral-500 hover:text-neutral-300 transition-colors ${loading ? "animate-spin" : ""}`}
+              title="Neu scannen"
+            >
+              <RefreshCw className="w-3.5 h-3.5" />
+            </button>
+          </div>
+
+          <div className="px-4 pb-3 space-y-2">
+            {loading && Object.keys(configs).length === 0 ? (
+              <div className="text-xs text-neutral-500 py-2">Scanne Projekte...</div>
+            ) : favorites.length === 0 ? (
+              <div className="text-xs text-neutral-500 py-2">
+                Keine Favoriten-Projekte vorhanden — fuege Projekte als Favoriten hinzu
+              </div>
+            ) : (
+              <>
+                {/* Global config */}
+                {globalConfig && (
+                  <ConfigCard
+                    config={globalConfig}
+                    expanded={expandedPath === globalConfig.path}
+                    onToggle={() => toggleExpand(globalConfig.path)}
+                  />
+                )}
+
+                {/* Per-project configs */}
+                {favorites.map((fav) => {
+                  const config = configs[fav.path];
+                  if (!config) return null;
+                  return (
+                    <ConfigCard
+                      key={fav.id}
+                      config={config}
+                      expanded={expandedPath === config.path}
+                      onToggle={() => toggleExpand(config.path)}
+                    />
+                  );
+                })}
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Library Items */}
+        <div className="flex-1 min-h-0">
+          <LibraryViewer folder={folder} />
+        </div>
       </div>
     </div>
   );

--- a/src/store/projectConfigStore.ts
+++ b/src/store/projectConfigStore.ts
@@ -1,0 +1,166 @@
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+import { useSettingsStore } from "./settingsStore";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface SkillDirEntry {
+  dir_name: string;
+  content: string;
+  has_reference_dir: boolean;
+}
+
+interface HookEntry {
+  matcher?: string;
+  command: string;
+}
+
+export interface ProjectConfig {
+  path: string;
+  label: string;
+  hasClaude: boolean;
+  skillCount: number;
+  hookCount: number;
+  skills: string[];
+  hooks: string[];
+  error?: string;
+}
+
+interface ProjectConfigState {
+  configs: Record<string, ProjectConfig>;
+  globalConfig: ProjectConfig | null;
+  loading: boolean;
+  lastScanned: number | null;
+
+  scanAllFavorites: () => Promise<void>;
+  scanProject: (path: string, label: string) => Promise<ProjectConfig>;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const CACHE_TTL = 60_000; // 60 seconds
+
+function extractHookInfo(raw: string): { hooks: string[]; hookCount: number } {
+  try {
+    const parsed = JSON.parse(raw);
+    const hooksObj = parsed?.hooks;
+    if (!hooksObj || typeof hooksObj !== "object") return { hooks: [], hookCount: 0 };
+
+    const hookNames: string[] = [];
+    for (const [eventName, hookList] of Object.entries(hooksObj)) {
+      const entries = hookList as HookEntry[];
+      if (Array.isArray(entries) && entries.length > 0) {
+        hookNames.push(eventName);
+      }
+    }
+    return { hooks: hookNames, hookCount: hookNames.length };
+  } catch {
+    return { hooks: [], hookCount: 0 };
+  }
+}
+
+// ── Store ──────────────────────────────────────────────────────────────
+
+export const useProjectConfigStore = create<ProjectConfigState>((set, get) => ({
+  configs: {},
+  globalConfig: null,
+  loading: false,
+  lastScanned: null,
+
+  scanProject: async (path: string, label: string): Promise<ProjectConfig> => {
+    const config: ProjectConfig = {
+      path,
+      label,
+      hasClaude: false,
+      skillCount: 0,
+      hookCount: 0,
+      skills: [],
+      hooks: [],
+    };
+
+    const [claudeResult, skillsResult, hooksResult] = await Promise.allSettled([
+      invoke<string>("read_project_file", { folder: path, relativePath: "CLAUDE.md" }),
+      invoke<SkillDirEntry[]>("list_skill_dirs", { folder: path }),
+      invoke<string>("read_project_file", { folder: path, relativePath: ".claude/settings.json" }),
+    ]);
+
+    if (claudeResult.status === "fulfilled" && claudeResult.value) {
+      config.hasClaude = true;
+    }
+
+    if (skillsResult.status === "fulfilled") {
+      config.skills = skillsResult.value.map((d) => d.dir_name);
+      config.skillCount = config.skills.length;
+    }
+
+    if (hooksResult.status === "fulfilled" && hooksResult.value) {
+      const { hooks, hookCount } = extractHookInfo(hooksResult.value);
+      config.hooks = hooks;
+      config.hookCount = hookCount;
+    }
+
+    // If all three failed, the path is likely invalid
+    if (
+      claudeResult.status === "rejected" &&
+      skillsResult.status === "rejected" &&
+      hooksResult.status === "rejected"
+    ) {
+      config.error = "Pfad nicht gefunden";
+    }
+
+    return config;
+  },
+
+  scanAllFavorites: async () => {
+    const { lastScanned, loading } = get();
+    if (loading) return;
+    if (lastScanned && Date.now() - lastScanned < CACHE_TTL) return;
+
+    set({ loading: true });
+
+    const favorites = useSettingsStore.getState().favorites;
+    const configs: Record<string, ProjectConfig> = {};
+
+    // Scan all favorite projects in parallel
+    const results = await Promise.allSettled(
+      favorites.map((fav) => get().scanProject(fav.path, fav.label))
+    );
+
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        configs[result.value.path] = result.value;
+      }
+    }
+
+    // Scan global ~/.claude/ for hooks
+    let globalConfig: ProjectConfig | null = null;
+    try {
+      const raw = await invoke<string>("read_user_claude_file", {
+        relativePath: "settings.json",
+      });
+      if (raw) {
+        const { hooks, hookCount } = extractHookInfo(raw);
+        if (hookCount > 0) {
+          globalConfig = {
+            path: "~/.claude",
+            label: "Global",
+            hasClaude: false,
+            skillCount: 0,
+            hookCount,
+            skills: [],
+            hooks,
+          };
+        }
+      }
+    } catch {
+      // Global settings not available
+    }
+
+    set({
+      configs,
+      globalConfig,
+      loading: false,
+      lastScanned: Date.now(),
+    });
+  },
+}));


### PR DESCRIPTION
## Summary
- **New store** `projectConfigStore.ts`: Scans all favorite projects for Claude configuration (CLAUDE.md, skills, hooks) using parallel `Promise.allSettled` calls, with 60s cache
- **Updated** `LibraryView.tsx`: Shows "Projekt-Konfigurationen" section with expandable cards for each favorite project and global `~/.claude/` settings, above the existing library items
- Badges show CLAUDE.md (green), Skills count (blue), Hooks count (amber); cards expand to show individual skill names and hook event names

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes  
- [x] `npm run test` — all 251 tests pass
- [ ] Visual test: verify cards render correctly in Library tab with favorite projects
- [ ] Verify scan caching (tab switch within 60s should not re-scan)
- [ ] Verify error state for favorites with deleted/invalid paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)