### PR TITLE
refactor(ui): extract shortenPath utility to reduce duplication

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,12 +7,7 @@ import { ChangelogDialog } from "./shared/ChangelogDialog";
 import { UpdateNotification } from "./shared/UpdateNotification";
 import { useAutoUpdate } from "../hooks/useAutoUpdate";
 import { version } from "../../package.json";
-
-function shortenPath(path: string): string {
-  const parts = path.replace(/\\/g, "/").split("/").filter(Boolean);
-  if (parts.length <= 3) return path;
-  return parts.slice(-2).join("/");
-}
+import { shortenPath } from "../utils/pathUtils";
 
 function getStatusDot(status: string): { dotClass: string; title: string } {
   switch (status) {

--- a/src/components/sessions/FavoriteCard.tsx
+++ b/src/components/sessions/FavoriteCard.tsx
@@ -2,17 +2,12 @@ import { Play, X, FolderOpen, Terminal } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { motion } from "framer-motion";
 import type { FavoriteFolder } from "../../store/settingsStore";
+import { shortenPath } from "../../utils/pathUtils";
 
 interface FavoriteCardProps {
   favorite: FavoriteFolder;
   onStart: () => void;
   onRemove: () => void;
-}
-
-function shortenPath(path: string): string {
-  const parts = path.replace(/\\/g, "/").split("/").filter(Boolean);
-  if (parts.length <= 3) return path;
-  return "~/" + parts.slice(-2).join("/");
 }
 
 export function FavoriteCard({ favorite, onStart, onRemove }: FavoriteCardProps) {

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { ClaudeSession } from "../../store/sessionStore";
 import { getActivityLevel, type ActivityLevel } from "./activityLevel";
 import { useNowTick } from "../../hooks/useNowTick";
+import { shortenPath } from "../../utils/pathUtils";
 
 interface SessionCardProps {
   session: ClaudeSession;
@@ -96,13 +97,6 @@ function TimeDisplay({
         </span>
       );
   }
-}
-
-function shortenPath(path: string): string {
-  // Show last 2-3 segments for readability
-  const parts = path.replace(/\\/g, "/").split("/").filter(Boolean);
-  if (parts.length <= 3) return path;
-  return "~/" + parts.slice(-2).join("/");
 }
 
 const SessionCardInner = ({ session, isActive, isInGrid, onClick, onClose }: SessionCardProps) => {

--- a/src/components/shared/NotesPanel.tsx
+++ b/src/components/shared/NotesPanel.tsx
@@ -2,18 +2,13 @@ import { useState, useRef, useEffect, useMemo } from "react";
 import { StickyNote, ChevronDown, FolderOpen } from "lucide-react";
 import { useSettingsStore } from "../../store/settingsStore";
 import { useSessionStore, selectActiveSession } from "../../store/sessionStore";
+import { folderLabel } from "../../utils/pathUtils";
 
 type NotesTab = "project" | "global";
 
 /** Normalize folder path for consistent lookup */
 function normalizePath(p: string) {
   return p.replace(/\\/g, "/").toLowerCase();
-}
-
-/** Extract short label from a folder path */
-function folderLabel(p: string) {
-  const parts = p.replace(/\\/g, "/").split("/").filter(Boolean);
-  return parts[parts.length - 1] ?? p;
 }
 
 export function NotesPanel() {

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -1,0 +1,20 @@
+/** Split a path into normalized segments (handles both `/` and `\`). */
+function pathSegments(path: string): string[] {
+  return path.replace(/\\/g, "/").split("/").filter(Boolean);
+}
+
+/**
+ * Shorten a file-system path to the last 2 segments for readability.
+ * Paths with 3 or fewer segments are returned as-is.
+ */
+export function shortenPath(path: string): string {
+  const parts = pathSegments(path);
+  if (parts.length <= 3) return path;
+  return "~/" + parts.slice(-2).join("/");
+}
+
+/** Extract the last segment of a folder path as a short label. */
+export function folderLabel(path: string): string {
+  const parts = pathSegments(path);
+  return parts[parts.length - 1] ?? path;
+}


### PR DESCRIPTION
## Summary
- Created `src/utils/pathUtils.ts` with shared `shortenPath` and `folderLabel` functions
- Removed duplicated inline definitions from Header.tsx, SessionCard.tsx, FavoriteCard.tsx, and NotesPanel.tsx
- Standardized path shortening to use `~/` prefix for consistency across all consumers

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] Visual verification in `npm run tauri dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)