### PR TITLE
refactor(tauri): unify path resolution helpers in file_reader

### DIFF
--- a/src-tauri/src/session/file_reader.rs
+++ b/src-tauri/src/session/file_reader.rs
@@ -1,8 +1,35 @@
 // src-tauri/src/session/file_reader.rs
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use serde::Serialize;
 use serde_json::Value;
+
+/// Shared path-traversal protection: resolve `sub` inside `base` and verify
+/// the result stays within `base` after canonicalization.
+fn safe_resolve_with_base(base: &Path, sub: &str) -> Result<PathBuf, String> {
+    let target = base.join(sub);
+
+    let canon_base = base
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve base '{}': {}", base.display(), e))?;
+
+    if target.exists() {
+        let canon_target = target
+            .canonicalize()
+            .map_err(|e| format!("Failed to resolve target '{}': {}", sub, e))?;
+
+        if !canon_target.starts_with(&canon_base) {
+            return Err(format!(
+                "Path traversal detected: target is outside {}",
+                base.display()
+            ));
+        }
+        Ok(canon_target)
+    } else {
+        // File doesn't exist — that's okay, caller handles empty result
+        Ok(target)
+    }
+}
 
 /// Canonicalize and validate that resolved_path is inside base_folder.
 fn safe_resolve(folder: &str, relative_path: &str) -> Result<PathBuf, String> {
@@ -13,28 +40,7 @@ fn safe_resolve(folder: &str, relative_path: &str) -> Result<PathBuf, String> {
             folder
         ));
     }
-
-    let target = base.join(relative_path);
-
-    // Canonicalize base; target may not exist yet so we canonicalize its parent
-    let canon_base = base
-        .canonicalize()
-        .map_err(|e| format!("Failed to resolve base folder '{}': {}", folder, e))?;
-
-    // For the target, check if it exists first
-    if target.exists() {
-        let canon_target = target
-            .canonicalize()
-            .map_err(|e| format!("Failed to resolve target path '{}': {}", relative_path, e))?;
-
-        if !canon_target.starts_with(&canon_base) {
-            return Err("Path traversal detected: target is outside project folder".to_string());
-        }
-        Ok(canon_target)
-    } else {
-        // File doesn't exist — that's okay, caller handles empty result
-        Ok(target)
-    }
+    safe_resolve_with_base(&base, relative_path)
 }
 
 /// Resolve a path inside ~/.claude/ with traversal protection.
@@ -46,24 +52,7 @@ fn safe_resolve_user_claude(relative_path: &str) -> Result<PathBuf, String> {
         // ~/.claude/ doesn't exist — return non-existent path, caller handles empty result
         return Ok(claude_dir.join(relative_path));
     }
-
-    let target = claude_dir.join(relative_path);
-
-    let canon_base = claude_dir
-        .canonicalize()
-        .map_err(|e| format!("Cannot resolve ~/.claude: {}", e))?;
-
-    if target.exists() {
-        let canon_target = target
-            .canonicalize()
-            .map_err(|e| format!("Cannot resolve target: {}", e))?;
-        if !canon_target.starts_with(&canon_base) {
-            return Err("Path traversal detected: target is outside ~/.claude".to_string());
-        }
-        Ok(canon_target)
-    } else {
-        Ok(target)
-    }
+    safe_resolve_with_base(&claude_dir, relative_path)
 }
 
 /// Entry for a skill directory containing a SKILL.md file.


### PR DESCRIPTION
## Summary
- Extracted shared path-traversal protection logic from `safe_resolve()` and `safe_resolve_user_claude()` into a common `safe_resolve_with_base(base: &Path, sub: &str)` helper
- Both public functions now delegate to the shared helper, eliminating ~20 lines of duplicated canonicalization and `starts_with` checks
- Public API signatures unchanged; behavior identical

## Test plan
- [x] `cargo check` passes
- [ ] Manual verification in `npm run tauri dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)