### PR TITLE
perf(ui): debounce DashboardMap resize observer

### DIFF
--- a/src/components/DashboardMap.tsx
+++ b/src/components/DashboardMap.tsx
@@ -38,6 +38,8 @@ export function DashboardMap() {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     const update = () => {
       if (containerRef.current) {
         setDimensions({
@@ -46,9 +48,18 @@ export function DashboardMap() {
         });
       }
     };
-    update();
-    window.addEventListener("resize", update);
-    return () => window.removeEventListener("resize", update);
+
+    const debouncedUpdate = () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(update, 150);
+    };
+
+    update(); // initial measurement
+    window.addEventListener("resize", debouncedUpdate);
+    return () => {
+      window.removeEventListener("resize", debouncedUpdate);
+      if (timeoutId) clearTimeout(timeoutId);
+    };
   }, []);
 
   // Empty state when no agents detected


### PR DESCRIPTION
## Summary
- Add 150ms debounce to the `DashboardMap` resize event handler using native `setTimeout`/`clearTimeout`
- Prevents unnecessary `setDimensions` state updates and re-renders during continuous window resizing
- Properly cleans up the timeout in the useEffect cleanup function

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] Visual check: resize the window and verify the dashboard map updates smoothly after resizing stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)