### PR TITLE
refactor(store): use errorLogger instead of console.error

### DIFF
--- a/src/store/libraryStore.ts
+++ b/src/store/libraryStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
+import { logError } from "../utils/errorLogger";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -83,7 +84,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
         lastFetched: Date.now(),
       });
     } catch (err) {
-      console.error("[libraryStore] fetchItems failed:", err);
+      logError("libraryStore.fetchItems", err);
     } finally {
       set({ loading: false });
     }
@@ -102,7 +103,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
       }));
       return item;
     } catch (err) {
-      console.error("[libraryStore] loadItemContent failed:", err);
+      logError("libraryStore.loadItemContent", err);
       return null;
     }
   },
@@ -125,7 +126,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
       });
       return meta;
     } catch (err) {
-      console.error("[libraryStore] saveItem failed:", err);
+      logError("libraryStore.saveItem", err);
       return null;
     }
   },
@@ -145,7 +146,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
         };
       });
     } catch (err) {
-      console.error("[libraryStore] deleteItem failed:", err);
+      logError("libraryStore.deleteItem", err);
     }
   },
 
@@ -160,7 +161,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
         loadedContent: {}, // Invalidate all content caches
       });
     } catch (err) {
-      console.error("[libraryStore] rebuildIndex failed:", err);
+      logError("libraryStore.rebuildIndex", err);
     } finally {
       set({ loading: false });
     }
@@ -181,7 +182,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
         };
       });
     } catch (err) {
-      console.error("[libraryStore] attachToProject failed:", err);
+      logError("libraryStore.attachToProject", err);
     }
   },
 
@@ -203,7 +204,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
         return { usage: { ...state.usage, [itemId]: current } };
       });
     } catch (err) {
-      console.error("[libraryStore] detachFromProject failed:", err);
+      logError("libraryStore.detachFromProject", err);
     }
   },
 }));

--- a/src/store/logParser.ts
+++ b/src/store/logParser.ts
@@ -1,5 +1,6 @@
 import { usePipelineStore } from "./pipelineStore";
 import type { WorktreeStep, WorktreeStatus } from "./pipelineStore";
+import { logError, logWarn } from "../utils/errorLogger";
 
 export interface ParsedEvent {
   type:
@@ -54,7 +55,7 @@ const PATTERNS = [
 export function parseLogLine(line: string, worktreeId?: string): ParsedEvent[] {
   // Defensive: return empty array for null/undefined/non-string input
   if (line == null || typeof line !== "string") {
-    console.error("[logParser] parseLogLine called with non-string input:", typeof line);
+    logWarn("logParser.parseLogLine", `called with non-string input: ${typeof line}`);
     return [];
   }
 
@@ -105,7 +106,7 @@ export function parseLogLine(line: string, worktreeId?: string): ParsedEvent[] {
 
     return events;
   } catch (err) {
-    console.error("[logParser] parseLogLine threw unexpectedly:", err);
+    logError("logParser.parseLogLine", err);
     return [];
   }
 }
@@ -159,10 +160,10 @@ export function applyParsedEvents(events: ParsedEvent[]): void {
             break;
         }
       } catch (eventErr) {
-        console.error(`[logParser] Error applying event ${event.type}:`, eventErr);
+        logError(`logParser.applyParsedEvents[${event.type}]`, eventErr);
       }
     }
   } catch (err) {
-    console.error("[logParser] applyParsedEvents threw unexpectedly:", err);
+    logError("logParser.applyParsedEvents", err);
   }
 }

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { logWarn } from "../utils/errorLogger";
 
 // ============================================================================
 // Types
@@ -83,7 +84,7 @@ export const useSessionStore = create<SessionState>((set) => ({
     set((state) => {
       if (state.sessions.some((s) => s.id === params.id)) return state;
       if (state.sessions.length >= MAX_SESSIONS) {
-        console.warn(`[sessionStore] Max sessions (${MAX_SESSIONS}) erreicht.`);
+        logWarn("sessionStore.addSession", `Max sessions (${MAX_SESSIONS}) erreicht.`);
         return state;
       }
       const session: ClaudeSession = {

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { tauriStorage, getLoadedFavorites, getLoadedNotes } from "./tauriStorage";
+import { logError } from "../utils/errorLogger";
 
 // ============================================================================
 // Types
@@ -133,14 +134,14 @@ const isTauri = "__TAURI_INTERNALS__" in window;
 function saveNoteFile(noteKey: string, content: string): void {
   if (!isTauri) return;
   invoke("save_note_file", { noteKey, content }).catch((err) => {
-    console.error("[settingsStore] Failed to save note file:", err);
+    logError("settingsStore.saveNoteFile", err);
   });
 }
 
 function saveFavoritesFile(favorites: FavoriteFolder[]): void {
   if (!isTauri) return;
   invoke("save_favorites_file", { data: JSON.stringify(favorites, null, 2) }).catch((err) => {
-    console.error("[settingsStore] Failed to save favorites file:", err);
+    logError("settingsStore.saveFavoritesFile", err);
   });
 }
 
@@ -285,7 +286,7 @@ export const useSettingsStore = create<SettingsState>()(
       storage: createJSONStorage(() => tauriStorage),
       onRehydrateStorage: () => (_state, error) => {
         if (error) {
-          console.error("[settingsStore] Hydration error:", error);
+          logError("settingsStore.onRehydrate", error);
           return;
         }
         // Merge favorites and notes from their dedicated files.

--- a/src/store/tauriStorage.ts
+++ b/src/store/tauriStorage.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { StateStorage } from "zustand/middleware";
+import { logError, logWarn } from "../utils/errorLogger";
 
 /**
  * Custom Zustand storage adapter that persists to Documents/AgenticExplorer/settings.json
@@ -39,7 +40,7 @@ export function initTauriStorage(): Promise<void> {
         try {
           loadedFavorites = JSON.parse(favoritesData);
         } catch {
-          console.warn("[tauriStorage] Failed to parse favorites.json");
+          logWarn("tauriStorage.init", "Failed to parse favorites.json");
         }
       }
 
@@ -56,12 +57,12 @@ export function initTauriStorage(): Promise<void> {
           }
           loadedNotes = { global: globalNotes, project: projectNotes };
         } catch {
-          console.warn("[tauriStorage] Failed to parse notes");
+          logWarn("tauriStorage.init", "Failed to parse notes");
         }
       }
     })
     .catch((err) => {
-      console.warn("[tauriStorage] Failed to load settings from disk:", err);
+      logWarn("tauriStorage.init", `Failed to load settings from disk: ${err}`);
     });
 
   return initPromise;
@@ -103,7 +104,7 @@ export const tauriStorage: StateStorage = {
     cache.set(name, value);
     // Fire-and-forget save to disk
     invoke("save_user_settings", { data: value }).catch((err) => {
-      console.error("[tauriStorage] Failed to save settings:", err);
+      logError("tauriStorage.setItem", err);
     });
   },
 
@@ -114,7 +115,7 @@ export const tauriStorage: StateStorage = {
     }
     cache.delete(name);
     invoke("save_user_settings", { data: "{}" }).catch((err) => {
-      console.error("[tauriStorage] Failed to clear settings:", err);
+      logError("tauriStorage.removeItem", err);
     });
   },
 };


### PR DESCRIPTION
## Summary
- Replace all `console.error` and `console.warn` calls in 5 store files with structured `logError`/`logWarn` from `errorLogger` utility
- Adds import of `errorLogger` to: `libraryStore.ts`, `logParser.ts`, `sessionStore.ts`, `settingsStore.ts`, `tauriStorage.ts`
- Source strings follow consistent `storeName.methodName` convention for traceability

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Grep confirms zero remaining `console.error`/`console.warn` in `src/store/`
- [ ] Manual: verify errors appear in Log Viewer panel at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)