### PR TITLE
chore(config): remove unused CSS class and deregister unused commands

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agenticexplorer"
-version = "1.2.51"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,16 +151,11 @@ pub fn run() {
         .manage(session_manager)
         .invoke_handler(tauri::generate_handler![
             commands::open_log_window,
-            // Bestehend
-            pipeline::commands::start_pipeline,
-            pipeline::commands::stop_pipeline,
-            pipeline::commands::pick_project_folder,
             // Session-Commands
             session::commands::commands::create_session,
             session::commands::commands::write_session,
             session::commands::commands::resize_session,
             session::commands::commands::close_session,
-            session::commands::commands::list_sessions,
             // Folder actions
             session::folder_actions::commands::open_folder_in_explorer,
             session::folder_actions::commands::open_terminal_in_folder,

--- a/src/index.css
+++ b/src/index.css
@@ -204,14 +204,6 @@ code, pre, kbd,
    Component Styles
    ============================================ */
 
-/* ── Grid Background ── */
-.grid-bg {
-  background-image:
-    linear-gradient(var(--color-accent-subtle) 1px, transparent 1px),
-    linear-gradient(90deg, var(--color-accent-subtle) 1px, transparent 1px);
-  background-size: 40px 40px;
-}
-
 /* ── Terminal Block ── */
 .retro-terminal {
   background: var(--neutral-950);


### PR DESCRIPTION
## Summary
- Remove `.grid-bg` CSS class from `src/index.css` (confirmed zero usages in all ts/tsx files)
- Deregister 4 unused Tauri commands from `generate_handler![]` in `src-tauri/src/lib.rs`: `start_pipeline`, `stop_pipeline`, `pick_project_folder`, `list_sessions`
- Function implementations and imports are kept intact — only the handler registration is removed

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)