### PR TITLE
refactor(ui): replace console.error with errorLogger in components

### DIFF
--- a/src/components/logs/LogViewer.tsx
+++ b/src/components/logs/LogViewer.tsx
@@ -12,7 +12,7 @@ import {
   type LogSeverity,
   type LogSource,
 } from "../../store/logViewerStore";
-import { getRecentLogs, subscribeToLogs } from "../../utils/errorLogger";
+import { getRecentLogs, subscribeToLogs, logError } from "../../utils/errorLogger";
 import { LogEntryRow } from "./LogEntry";
 
 const SEVERITY_OPTIONS: { key: LogSeverity; label: string; color: string }[] = [
@@ -53,7 +53,7 @@ export function LogViewer() {
           .filter((e): e is NonNullable<typeof e> => e !== null);
         if (parsed.length > 0) addEntries(parsed);
       })
-      .catch((err) => console.error("[LogViewer] Failed to read backend log:", err));
+      .catch((err) => logError("LogViewer", err));
   }, [addEntries]);
 
   useEffect(() => {

--- a/src/components/pipeline/WorkflowLauncher.tsx
+++ b/src/components/pipeline/WorkflowLauncher.tsx
@@ -16,6 +16,7 @@ import { useUIStore } from "../../store/uiStore";
 import type { DetectedWorkflow, WorkflowType } from "../../store/workflowStore";
 import type { SessionShell } from "../../store/sessionStore";
 import { DURATION, EASE, staggerDelay } from "../../utils/motion";
+import { logError } from "../../utils/errorLogger";
 
 // ============================================================================
 // Constants
@@ -171,10 +172,7 @@ export function WorkflowLauncher() {
           setTimeout(() => {
             invoke("write_session", { id: sessionId, data: prompt }).catch(
               (err) =>
-                console.error(
-                  "[WorkflowLauncher] write_session failed:",
-                  err
-                )
+                logError("WorkflowLauncher.write_session", err)
             );
           }, 1500);
         }
@@ -182,7 +180,7 @@ export function WorkflowLauncher() {
         // Switch to sessions tab
         setActiveTab("sessions");
       } catch (err) {
-        console.error("[WorkflowLauncher] Launch failed:", err);
+        logError("WorkflowLauncher.launch", err);
       }
     },
     [folder, setActiveTab]

--- a/src/components/sessions/ClaudeMdViewer.tsx
+++ b/src/components/sessions/ClaudeMdViewer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { RefreshCw, FileText } from "lucide-react";
+import { logError } from "../../utils/errorLogger";
 
 interface ClaudeMdViewerProps {
   folder: string;
@@ -19,7 +20,7 @@ export function ClaudeMdViewer({ folder }: ClaudeMdViewerProps) {
       });
       setContent(text || null);
     } catch (err) {
-      console.error("[ClaudeMdViewer] Failed to load:", err);
+      logError("ClaudeMdViewer", err);
       setContent(null);
     } finally {
       setLoading(false);

--- a/src/components/sessions/FavoritesList.tsx
+++ b/src/components/sessions/FavoritesList.tsx
@@ -2,6 +2,7 @@ import { FolderPlus } from "lucide-react";
 import { AnimatePresence } from "framer-motion";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useSettingsStore } from "../../store/settingsStore";
+import { logError } from "../../utils/errorLogger";
 import { FavoriteCard } from "./FavoriteCard";
 import type { FavoriteFolder } from "../../store/settingsStore";
 
@@ -31,7 +32,7 @@ export function FavoritesList({ onQuickStart }: FavoritesListProps) {
         addFavorite(selected);
       }
     } catch (err) {
-      console.error("[FavoritesList] Folder picker error:", err);
+      logError("FavoritesList.folderPicker", err);
     }
   }
 

--- a/src/components/sessions/GitHubViewer.tsx
+++ b/src/components/sessions/GitHubViewer.tsx
@@ -10,6 +10,7 @@ import {
   ExternalLink,
   Github,
 } from "lucide-react";
+import { logWarn } from "../../utils/errorLogger";
 
 interface GitHubViewerProps {
   folder: string;
@@ -83,7 +84,7 @@ async function openUrl(url: string) {
     await open(url);
   } catch {
     // Fallback: try window.open (won't work in Tauri, but harmless)
-    console.warn("shell.open failed for:", url);
+    logWarn("GitHubViewer", `shell.open failed for: ${url}`);
   }
 }
 

--- a/src/components/sessions/HooksViewer.tsx
+++ b/src/components/sessions/HooksViewer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { RefreshCw, Webhook, ChevronDown, ChevronRight } from "lucide-react";
+import { logError } from "../../utils/errorLogger";
 
 interface HooksViewerProps {
   folder: string;
@@ -142,7 +143,7 @@ export function HooksViewer({ folder }: HooksViewerProps) {
         return next;
       });
     } catch (err) {
-      console.error("[HooksViewer] Failed to load:", err);
+      logError("HooksViewer", err);
       setSections([]);
     } finally {
       setLoading(false);

--- a/src/components/sessions/LibraryViewer.tsx
+++ b/src/components/sessions/LibraryViewer.tsx
@@ -10,6 +10,7 @@ import {
   Plus,
   FolderOpen,
 } from "lucide-react";
+import { logError } from "../../utils/errorLogger";
 import {
   useLibraryStore,
   type LibraryItemMeta,
@@ -314,7 +315,7 @@ function ItemDetail({
         message: path,
       });
     } catch (err) {
-      console.error("Failed to copy path:", err);
+      logError("LibraryViewer.copyPath", err);
     }
   };
 

--- a/src/components/sessions/NewSessionDialog.tsx
+++ b/src/components/sessions/NewSessionDialog.tsx
@@ -4,6 +4,7 @@ import { X, FolderOpen, Play } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useSessionStore } from "../../store/sessionStore";
+import { logError } from "../../utils/errorLogger";
 import type { SessionShell } from "../../store/sessionStore";
 
 interface NewSessionDialogProps {
@@ -44,7 +45,7 @@ export function NewSessionDialog({ onClose }: NewSessionDialogProps) {
         }
       }
     } catch (err) {
-      console.error("[NewSessionDialog] Folder picker error:", err);
+      logError("NewSessionDialog.folderPicker", err);
     }
   }
 
@@ -74,7 +75,7 @@ export function NewSessionDialog({ onClose }: NewSessionDialogProps) {
       });
       onClose();
     } catch (err) {
-      console.error("[NewSessionDialog] create_session error:", err);
+      logError("NewSessionDialog.createSession", err);
       const message = err instanceof Error ? err.message : String(err ?? "Unbekannter Fehler");
       setCreateError(`Session konnte nicht erstellt werden: ${message}`);
       setIsCreating(false);

--- a/src/components/sessions/SessionList.tsx
+++ b/src/components/sessions/SessionList.tsx
@@ -3,6 +3,7 @@ import { Plus } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useSessionStore } from "../../store/sessionStore";
 import { useSettingsStore } from "../../store/settingsStore";
+import { logError } from "../../utils/errorLogger";
 import { SessionCard } from "./SessionCard";
 import { FavoritesList } from "./FavoritesList";
 import type { ClaudeSession } from "../../store/sessionStore";
@@ -51,7 +52,7 @@ export function SessionList({ onNewSession, onQuickStart }: SessionListProps) {
 
   const handleClose = useCallback((sessionId: string) => {
     invoke("close_session", { id: sessionId }).catch((err) =>
-      console.error("[SessionList] close_session failed:", err)
+      logError("SessionList.closeSession", err)
     );
     useSessionStore.getState().removeSession(sessionId);
   }, []);

--- a/src/components/sessions/SessionManagerView.tsx
+++ b/src/components/sessions/SessionManagerView.tsx
@@ -16,6 +16,7 @@ import { useUIStore } from "../../store/uiStore";
 import { useAgentStore } from "../../store/agentStore";
 import type { FavoriteFolder } from "../../store/settingsStore";
 import type { SessionShell } from "../../store/sessionStore";
+import { logError } from "../../utils/errorLogger";
 
 const ClaudeMdViewer = lazy(() => import("./ClaudeMdViewer").then(m => ({ default: m.ClaudeMdViewer })));
 const SkillsViewer = lazy(() => import("./SkillsViewer").then(m => ({ default: m.SkillsViewer })));
@@ -64,7 +65,7 @@ export function SessionManagerView() {
           const snippet = data.slice(-200);
           useSessionStore.getState().updateLastOutput(id, snippet);
         } catch (err) {
-          console.error("[SessionManagerView] session-output handler error:", err);
+          logError("SessionManagerView.sessionOutput", err);
         }
       })
     );
@@ -78,7 +79,7 @@ export function SessionManagerView() {
           if (typeof id !== "string" || exitCode == null) return;
           useSessionStore.getState().setExitCode(id, exitCode);
         } catch (err) {
-          console.error("[SessionManagerView] session-exit handler error:", err);
+          logError("SessionManagerView.sessionExit", err);
         }
       })
     );
@@ -100,7 +101,7 @@ export function SessionManagerView() {
             useSessionStore.getState().updateStatus(id, status);
           }
         } catch (err) {
-          console.error("[SessionManagerView] session-status handler error:", err);
+          logError("SessionManagerView.sessionStatus", err);
         }
       })
     );
@@ -129,7 +130,7 @@ export function SessionManagerView() {
             worktreePath: null,
           });
         } catch (err) {
-          console.error("[SessionManagerView] agent-detected handler error:", err);
+          logError("SessionManagerView.agentDetected", err);
         }
       })
     );
@@ -152,7 +153,7 @@ export function SessionManagerView() {
             p.completed_at ?? Date.now()
           );
         } catch (err) {
-          console.error("[SessionManagerView] agent-completed handler error:", err);
+          logError("SessionManagerView.agentCompleted", err);
         }
       })
     );
@@ -176,13 +177,13 @@ export function SessionManagerView() {
             active: true,
           });
         } catch (err) {
-          console.error("[SessionManagerView] worktree-detected handler error:", err);
+          logError("SessionManagerView.worktreeDetected", err);
         }
       })
     );
 
     return () => {
-      unlisteners.forEach((p) => p.then((unlisten) => unlisten()).catch(console.error));
+      unlisteners.forEach((p) => p.then((unlisten) => unlisten()).catch((err) => logError("SessionManagerView.cleanup", err)));
     };
   }, []);
 
@@ -209,7 +210,7 @@ export function SessionManagerView() {
       });
       useSettingsStore.getState().updateFavoriteLastUsed(favorite.id);
     } catch (err) {
-      console.error("[SessionManagerView] Quick start failed:", err);
+      logError("SessionManagerView.quickStart", err);
     }
   }
 

--- a/src/components/sessions/SessionTerminal.tsx
+++ b/src/components/sessions/SessionTerminal.tsx
@@ -5,6 +5,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
+import { logError } from "../../utils/errorLogger";
 
 interface SessionTerminalProps {
   sessionId: string;
@@ -40,7 +41,7 @@ export function SessionTerminal({ sessionId }: SessionTerminalProps) {
     // Input: User types -> send to backend
     term.onData((data: string) => {
       invoke("write_session", { id: sessionId, data }).catch((err) => {
-        console.error("[SessionTerminal] write_session failed:", err);
+        logError("SessionTerminal.writeSession", err);
       });
     });
 

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Component } from "react";
 import type { ErrorInfo, ReactNode } from "react";
 import { AlertTriangle, RotateCcw } from "lucide-react";
-import { logError } from "../../utils/errorLogger";
+import { logError, logWarn } from "../../utils/errorLogger";
 import { useUIStore } from "../../store/uiStore";
 
 interface ErrorBoundaryProps {
@@ -26,7 +26,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     logError("ErrorBoundary", error);
-    console.error("[ErrorBoundary] Component stack:", errorInfo.componentStack);
+    logWarn("ErrorBoundary", `Component stack: ${errorInfo.componentStack ?? "unknown"}`);
     useUIStore.getState().addToast({
       type: "error",
       title: "Fehler",


### PR DESCRIPTION
## Summary
- Replace all `console.error` and `console.warn` calls in 12 component files with structured `logError`/`logWarn` from `utils/errorLogger`
- Adds errorLogger imports to each modified file; no new utilities introduced
- All frontend errors now flow through the centralized log buffer, visible in the LogViewer UI

## Files changed (12)
LogViewer, WorkflowLauncher, ClaudeMdViewer, ErrorBoundary, FavoritesList, GitHubViewer, HooksViewer, LibraryViewer, NewSessionDialog, SessionList, SessionManagerView, SessionTerminal

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Zero `console.error`/`console.warn` remaining in `src/components/`
- [ ] Manual: verify errors appear in LogViewer panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)