### PR TITLE
fix(ui): remove Framer Motion ease type assertions

### DIFF
--- a/src/components/OrchestratorNode.tsx
+++ b/src/components/OrchestratorNode.tsx
@@ -30,7 +30,7 @@ export function OrchestratorNode({ orchestratorStatus, orchestratorLog, summary 
     <motion.div
       aria-label={`Orchestrator – ${config.label}`}
       animate={VARIANTS.breathe(isActive)}
-      transition={{ duration: DURATION.ambient / 4, repeat: isActive ? Infinity : 0, ease: EASE.out as unknown as string }}
+      transition={{ duration: DURATION.ambient / 4, repeat: isActive ? Infinity : 0, ease: EASE.out }}
       className={`w-80 rounded-none border-2 ${style.border} bg-surface-raised ${glowClass} overflow-hidden`}
     >
       {/* Header */}
@@ -88,7 +88,7 @@ export function OrchestratorNode({ orchestratorStatus, orchestratorLog, summary 
               key={`${log}-${i}`}
               initial={VARIANTS.fadeInLeft.initial}
               animate={VARIANTS.fadeInLeft.animate}
-              transition={{ duration: DURATION.fast, ease: EASE.out as unknown as string }}
+              transition={{ duration: DURATION.fast, ease: EASE.out }}
               className="text-xs text-neutral-300 py-0.5"
             >
               <span className="text-success mr-1">{"›"}</span>

--- a/src/components/QAGateNode.tsx
+++ b/src/components/QAGateNode.tsx
@@ -32,7 +32,7 @@ export function QAGateNode({ qaGate }: Props) {
       animate={{
         scale: isRunning ? [1, 1.01, 1] : 1,
       }}
-      transition={{ duration: DURATION.ambient / 5, repeat: isRunning ? Infinity : 0, ease: EASE.out as unknown as string }}
+      transition={{ duration: DURATION.ambient / 5, repeat: isRunning ? Infinity : 0, ease: EASE.out }}
       className={`rounded-none border-2 bg-surface-raised overflow-hidden w-96 retro-terminal ${overallStyle.border} ${overallStyle.text} ${glowClass}`}
     >
       {/* Header */}

--- a/src/components/WorktreeNode.tsx
+++ b/src/components/WorktreeNode.tsx
@@ -37,7 +37,7 @@ export function WorktreeNode({ worktree }: Props) {
       animate={{
         scale: isActive ? [1, 1.01, 1] : 1,
       }}
-      transition={{ duration: DURATION.ambient / 4, repeat: isActive ? Infinity : 0, ease: EASE.out as unknown as string }}
+      transition={{ duration: DURATION.ambient / 4, repeat: isActive ? Infinity : 0, ease: EASE.out }}
       className={`w-52 rounded-none border-2 ${style.border} ${glowClass} bg-surface-raised overflow-hidden flex flex-col`}
     >
       {/* Header */}
@@ -89,7 +89,7 @@ export function WorktreeNode({ worktree }: Props) {
                 key={step}
                 initial={{ opacity: 0, x: -8 }}
                 animate={{ opacity: 1, x: 0 }}
-                transition={{ duration: DURATION.fast, delay: staggerDelay(index), ease: EASE.out as unknown as string }}
+                transition={{ duration: DURATION.fast, delay: staggerDelay(index), ease: EASE.out }}
                 className="flex items-center gap-1.5"
               >
                 {spinning ? (

--- a/src/components/pipeline/AgentMetricsPanel.tsx
+++ b/src/components/pipeline/AgentMetricsPanel.tsx
@@ -149,7 +149,7 @@ export function AgentMetricsPanel() {
     <motion.div
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: DURATION.fast, ease: EASE.out as unknown as string }}
+      transition={{ duration: DURATION.fast, ease: EASE.out }}
       className="border-t border-neutral-700"
     >
       {/* Header */}

--- a/src/components/pipeline/WorkflowLauncher.tsx
+++ b/src/components/pipeline/WorkflowLauncher.tsx
@@ -66,7 +66,7 @@ function WorkflowCard({
       transition={{
         duration: DURATION.fast,
         delay: staggerDelay(index),
-        ease: EASE.out as unknown as string,
+        ease: EASE.out,
       }}
       className="bg-surface-raised border border-neutral-700 rounded-sm p-3 flex flex-col gap-2 min-w-[200px]"
     >

--- a/src/utils/motion.ts
+++ b/src/utils/motion.ts
@@ -8,6 +8,8 @@
  * - Respect `prefers-reduced-motion` (handled in CSS)
  */
 
+import type { BezierDefinition } from "framer-motion";
+
 /* ── Durations (100/300/500 rule) ── */
 export const DURATION = {
   /** Instant feedback: button press, toggle, color change */
@@ -23,14 +25,14 @@ export const DURATION = {
 } as const;
 
 /* ── Easing curves (exponential, no bounce) ── */
-export const EASE = {
+export const EASE: Record<"out" | "in" | "inOut", BezierDefinition> = {
   /** Elements entering — smooth deceleration (default) */
-  out: [0.16, 1, 0.3, 1] as const,
+  out: [0.16, 1, 0.3, 1],
   /** Elements leaving — smooth acceleration */
-  in: [0.7, 0, 0.84, 0] as const,
+  in: [0.7, 0, 0.84, 0],
   /** State toggles — symmetric */
-  inOut: [0.65, 0, 0.35, 1] as const,
-} as const;
+  inOut: [0.65, 0, 0.35, 1],
+};
 
 /* ── Spring presets (gentle, no visible bounce) ── */
 export const SPRING = {


### PR DESCRIPTION
## Summary
- Type `EASE` values in `src/utils/motion.ts` as `BezierDefinition` (imported from framer-motion) instead of `as const` literal tuples
- Remove all 7 `as unknown as string` casts from 5 consumer components
- No animation behavior changes -- purely type-level fix

## Files changed
- `src/utils/motion.ts` — root cause fix: explicit `BezierDefinition` type
- `src/components/OrchestratorNode.tsx` — remove 2 casts
- `src/components/QAGateNode.tsx` — remove 1 cast
- `src/components/WorktreeNode.tsx` — remove 2 casts
- `src/components/pipeline/AgentMetricsPanel.tsx` — remove 1 cast
- `src/components/pipeline/WorkflowLauncher.tsx` — remove 1 cast

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)