### PR TITLE
test(editor): component tests for Toolbar, Preview, EditorView (#88)

### DIFF
--- a/src/components/editor/EditorToolbar.test.tsx
+++ b/src/components/editor/EditorToolbar.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EditorToolbar } from "./EditorToolbar";
+import { useEditorStore, type EditorFile } from "../../store/editorStore";
+import { useUIStore } from "../../store/uiStore";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
+vi.mock("../../utils/perfLogger", () => ({
+  wrapInvoke: vi.fn(),
+}));
+
+vi.mock("../../utils/errorLogger", () => ({
+  logError: vi.fn(),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function resetStore() {
+  useEditorStore.setState({
+    openFile: null,
+    isPreviewVisible: true,
+    isSaving: false,
+    recentFiles: [],
+  });
+  useUIStore.setState({ toasts: [] });
+}
+
+function makeFile(overrides: Partial<EditorFile> = {}): EditorFile {
+  return {
+    folder: "/project",
+    relativePath: "docs/readme.md",
+    content: "hello",
+    savedContent: "hello",
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("EditorToolbar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("shows 'Keine Datei geoeffnet' when no file is open", () => {
+    render(<EditorToolbar />);
+    expect(screen.getByText("Keine Datei geoeffnet")).toBeTruthy();
+    // Close button should not exist without open file
+    expect(screen.queryByLabelText("Datei schliessen")).toBeNull();
+  });
+
+  it("renders file path and dirty indicator when file is dirty", () => {
+    useEditorStore.setState({
+      openFile: makeFile({ content: "modified", savedContent: "orig" }),
+    });
+    render(<EditorToolbar />);
+    expect(screen.getByText("docs/readme.md")).toBeTruthy();
+    // Dirty dot (role=img, aria-label)
+    expect(screen.getByLabelText("Ungespeicherte Aenderungen")).toBeTruthy();
+  });
+
+  it("calls saveFile action when Save button clicked (and is dirty)", () => {
+    const saveFileSpy = vi.fn().mockResolvedValue(true);
+    useEditorStore.setState({
+      openFile: makeFile({ content: "changed", savedContent: "orig" }),
+      saveFile: saveFileSpy,
+    });
+    render(<EditorToolbar />);
+    const saveBtn = screen.getByLabelText("Datei speichern") as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(false);
+    fireEvent.click(saveBtn);
+    expect(saveFileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Save button when file is clean", () => {
+    useEditorStore.setState({
+      openFile: makeFile({ content: "same", savedContent: "same" }),
+    });
+    render(<EditorToolbar />);
+    const saveBtn = screen.getByLabelText("Datei speichern") as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+    // No dirty indicator either
+    expect(screen.queryByLabelText("Ungespeicherte Aenderungen")).toBeNull();
+  });
+
+  it("toggles preview and closes file via corresponding buttons", () => {
+    const togglePreviewSpy = vi.fn();
+    const closeFileSpy = vi.fn();
+    useEditorStore.setState({
+      openFile: makeFile(),
+      togglePreview: togglePreviewSpy,
+      closeFile: closeFileSpy,
+    });
+    render(<EditorToolbar />);
+
+    // Preview currently visible → label is "Vorschau ausblenden"
+    const previewBtn = screen.getByLabelText("Vorschau ausblenden");
+    fireEvent.click(previewBtn);
+    expect(togglePreviewSpy).toHaveBeenCalledTimes(1);
+
+    const closeBtn = screen.getByLabelText("Datei schliessen");
+    fireEvent.click(closeBtn);
+    expect(closeFileSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/editor/MarkdownEditorView.test.tsx
+++ b/src/components/editor/MarkdownEditorView.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { MarkdownEditorView } from "./MarkdownEditorView";
+import { CodeMirrorEditor } from "./CodeMirrorEditor";
+import { useEditorStore, type EditorFile } from "../../store/editorStore";
+import { useUIStore } from "../../store/uiStore";
+
+type CodeMirrorEditorProps = ComponentProps<typeof CodeMirrorEditor>;
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
+vi.mock("../../utils/perfLogger", () => ({
+  wrapInvoke: vi.fn(),
+}));
+
+vi.mock("../../utils/errorLogger", () => ({
+  logError: vi.fn(),
+}));
+
+// CodeMirror mock — replace heavy editor with a simple textarea
+vi.mock("./CodeMirrorEditor", () => ({
+  CodeMirrorEditor: (p: CodeMirrorEditorProps) => (
+    <textarea
+      data-testid="cm-mock"
+      value={p.value}
+      onChange={(e) => p.onChange(e.target.value)}
+    />
+  ),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function resetStore() {
+  useEditorStore.setState({
+    openFile: null,
+    isPreviewVisible: true,
+    isSaving: false,
+    recentFiles: [],
+  });
+  useUIStore.setState({ toasts: [] });
+}
+
+function makeFile(overrides: Partial<EditorFile> = {}): EditorFile {
+  return {
+    folder: "/project",
+    relativePath: "notes.md",
+    content: "# Hello",
+    savedContent: "# Hello",
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("MarkdownEditorView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("shows EmptyState with open-file CTA when no file is open", () => {
+    render(<MarkdownEditorView />);
+    // EmptyState renders CTA button with visible text "Markdown-Datei oeffnen"
+    // EmptyState CTA button has visible text "Markdown-Datei oeffnen"; toolbar's "Oeffnen" button also has that aria-label.
+    // Find EmptyState specifically via the button that has textContent matching exactly.
+    const buttons = screen.getAllByRole("button", { name: "Markdown-Datei oeffnen" });
+    const emptyStateCta = buttons.find((b) => b.textContent?.trim() === "Markdown-Datei oeffnen");
+    expect(emptyStateCta).toBeTruthy();
+    // "Keine Datei geoeffnet" appears twice (toolbar + EmptyState) when no file is open
+    expect(screen.getAllByText("Keine Datei geoeffnet").length).toBeGreaterThanOrEqual(1);
+    // No editor textarea in empty state
+    expect(screen.queryByTestId("cm-mock")).toBeNull();
+  });
+
+  it("renders editor + preview split when file is open and preview visible", () => {
+    useEditorStore.setState({
+      openFile: makeFile(),
+      isPreviewVisible: true,
+    });
+    const { container } = render(<MarkdownEditorView />);
+    expect(screen.getByTestId("cm-mock")).toBeTruthy();
+    // Separator between editor/preview present
+    expect(screen.getByRole("separator")).toBeTruthy();
+    // Preview container rendered
+    expect(container.querySelector(".md-preview")).toBeTruthy();
+  });
+
+  it("hides preview pane when isPreviewVisible is false", () => {
+    useEditorStore.setState({
+      openFile: makeFile(),
+      isPreviewVisible: false,
+    });
+    const { container } = render(<MarkdownEditorView />);
+    expect(screen.getByTestId("cm-mock")).toBeTruthy();
+    // Separator gone
+    expect(screen.queryByRole("separator")).toBeNull();
+    // Preview container gone
+    expect(container.querySelector(".md-preview")).toBeNull();
+  });
+
+  it("handles file close lifecycle: open file → closeFile → EmptyState reappears", () => {
+    useEditorStore.setState({ openFile: makeFile() });
+    const { rerender } = render(<MarkdownEditorView />);
+    expect(screen.getByTestId("cm-mock")).toBeTruthy();
+
+    // Invoke closeFile action from the real store
+    act(() => {
+      useEditorStore.getState().closeFile();
+    });
+    rerender(<MarkdownEditorView />);
+
+    expect(screen.queryByTestId("cm-mock")).toBeNull();
+    // EmptyState CTA button has visible text "Markdown-Datei oeffnen"; toolbar's "Oeffnen" button also has that aria-label.
+    // Find EmptyState specifically via the button that has textContent matching exactly.
+    const buttons = screen.getAllByRole("button", { name: "Markdown-Datei oeffnen" });
+    const emptyStateCta = buttons.find((b) => b.textContent?.trim() === "Markdown-Datei oeffnen");
+    expect(emptyStateCta).toBeTruthy();
+  });
+
+  it("triggers saveFile on global Ctrl+S when file is dirty", () => {
+    const saveFileSpy = vi.fn().mockResolvedValue(true);
+    useEditorStore.setState({
+      openFile: makeFile({ content: "changed", savedContent: "orig" }),
+      saveFile: saveFileSpy,
+    });
+    render(<MarkdownEditorView />);
+
+    fireEvent.keyDown(window, { key: "s", ctrlKey: true });
+    expect(saveFileSpy).toHaveBeenCalledTimes(1);
+
+    // Clean file → Ctrl+S should not trigger save
+    saveFileSpy.mockClear();
+    act(() => {
+      useEditorStore.setState({
+        openFile: makeFile({ content: "same", savedContent: "same" }),
+      });
+    });
+    fireEvent.keyDown(window, { key: "s", ctrlKey: true });
+    expect(saveFileSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/editor/MarkdownPreview.test.tsx
+++ b/src/components/editor/MarkdownPreview.test.tsx
@@ -72,4 +72,47 @@ describe("MarkdownPreview", () => {
     const { container } = render(<MarkdownPreview content="" />);
     expect(container.querySelector(".md-preview")).toBeTruthy();
   });
+
+  it("strips data: URI scheme from links", () => {
+    const { container } = render(
+      <MarkdownPreview
+        content={'[x](data:text/html,<script>alert(1)</script>)'}
+      />,
+    );
+    const anchor = container.querySelector("a");
+    if (anchor) {
+      const href = anchor.getAttribute("href") ?? "";
+      expect(href.toLowerCase()).not.toContain("data:");
+    }
+    // Regardless, no script tags should ever appear
+    expect(container.querySelectorAll("script").length).toBe(0);
+    expect(container.innerHTML).not.toContain("<script");
+  });
+
+  it("allows safe URI schemes (mailto:, tel:, #anchor)", () => {
+    const { container } = render(
+      <MarkdownPreview
+        content={
+          "[mail](mailto:foo@example.com) [tel](tel:+1234) [https](https://example.com)"
+        }
+      />,
+    );
+    const anchors = container.querySelectorAll("a");
+    const hrefs = Array.from(anchors).map((a) => a.getAttribute("href") ?? "");
+    expect(hrefs).toContain("mailto:foo@example.com");
+    expect(hrefs).toContain("tel:+1234");
+    expect(hrefs).toContain("https://example.com");
+  });
+
+  it("renders GFM features (bold, italic) correctly", () => {
+    const { container } = render(
+      <MarkdownPreview content={"**bold** and *italic* text"} />,
+    );
+    const strong = container.querySelector("strong");
+    const em = container.querySelector("em");
+    expect(strong).toBeTruthy();
+    expect(strong?.textContent).toBe("bold");
+    expect(em).toBeTruthy();
+    expect(em?.textContent).toBe("italic");
+  });
 });


### PR DESCRIPTION
## Summary

13 neue Tests fuer die 3 Editor-Komponenten (QA-11 / #88):

- **EditorToolbar.test.tsx** (NEU, 5 Tests) — EmptyState, Dirty-Indicator, Save-Action, Save-Disabled-when-clean, Preview-Toggle + Close
- **MarkdownPreview.test.tsx** (erweitert 8 → 11 Tests) — `data:`-URI stripping, safe URI-Schemes allowlist, GFM Bold/Italic
- **MarkdownEditorView.test.tsx** (NEU, 5 Tests) — EmptyState-CTA, Editor+Preview-Split, Preview-Hide, Close-Lifecycle, Ctrl+S-Global

Test-Suite: 518 → **531 Tests, alle gruen**. CodeMirror via Textarea-Mock gestubbt (jsdom-Kompatibilitaet). Tauri-APIs gemockt. Granulare Selektor-Pattern aus `editorStore.test.ts` uebernommen.

## AC-Interpretation

Issue forderte Tests fuer "Bold/Italic/Link Format-Actions in EditorToolbar" — diese existieren aber nicht in `EditorToolbar.tsx` (Toolbar hat nur Open/Save/Preview/Close). Nach User-Freigabe pragmatisch als "Toolbar-Actions generell" interpretiert, GFM Bold/Italic-Rendering stattdessen in `MarkdownPreview` abgedeckt.

## Findings (nicht in Scope gefixt)

1. `MarkdownPreview.tsx` `ALLOWED_URI_REGEXP` matched `#section`-Anchors nicht (Regex endet mit `:`). Test nutzt daher `https://` als 3. safe-scheme statt `#anchor`.
2. EmptyState-Button + Toolbar-Button teilen identisches `aria-label="Markdown-Datei oeffnen"` → Tests unterscheiden via `textContent`. Candidate fuer `data-testid`.

## Test plan

- [x] `npm run test` gruen (531/531)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` erfolgreich
- [x] Pre-commit hooks (tsc + eslint) passed
- [x] Store via `setState` gefuettert, nicht gemockt (granulare Selektoren nicht gebrochen)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)