### PR TITLE
test(ui): component tests for Kern-UI — SessionCard, SideNav, Toast, ErrorBoundary (#87)

### DIFF
--- a/src/components/layout/SideNav.test.tsx
+++ b/src/components/layout/SideNav.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SideNav } from "./SideNav";
+import { useUIStore } from "../../store/uiStore";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("SideNav", () => {
+  beforeEach(() => {
+    useUIStore.setState({ activeTab: "sessions" });
+    vi.clearAllMocks();
+  });
+
+  it("renders all 7 nav items with aria-labels", () => {
+    render(<SideNav />);
+    expect(screen.getByLabelText("Sessions")).toBeTruthy();
+    expect(screen.getByLabelText("Pipeline")).toBeTruthy();
+    expect(screen.getByLabelText("Kanban")).toBeTruthy();
+    expect(screen.getByLabelText("Library")).toBeTruthy();
+    expect(screen.getByLabelText("Editor")).toBeTruthy();
+    expect(screen.getByLabelText("Logs")).toBeTruthy();
+    expect(screen.getByLabelText("Einstellungen")).toBeTruthy();
+  });
+
+  it("highlights active tab and calls setActiveTab on click", () => {
+    render(<SideNav />);
+
+    const sessionsBtn = screen.getByLabelText("Sessions");
+    // active tab has "text-accent" class
+    expect(sessionsBtn.className).toContain("text-accent");
+
+    const pipelineBtn = screen.getByLabelText("Pipeline");
+    // non-active tab should not have text-accent
+    expect(pipelineBtn.className).not.toContain("text-accent");
+
+    fireEvent.click(pipelineBtn);
+    expect(useUIStore.getState().activeTab).toBe("pipeline");
+  });
+
+  it("renders badge when count > 0 and hides when 0 or undefined", () => {
+    const { rerender } = render(<SideNav badges={{ sessions: 3 }} />);
+    expect(screen.getByText("3")).toBeTruthy();
+
+    rerender(<SideNav badges={{ sessions: 0 }} />);
+    expect(screen.queryByText("0")).toBeNull();
+
+    rerender(<SideNav badges={{}} />);
+    // no badge numerals visible
+    expect(screen.queryByText("3")).toBeNull();
+  });
+
+  it("caps badge at 99+ when count > 99", () => {
+    render(<SideNav badges={{ pipeline: 150 }} />);
+    expect(screen.getByText("99+")).toBeTruthy();
+    expect(screen.queryByText("150")).toBeNull();
+  });
+});

--- a/src/components/sessions/SessionCard.test.tsx
+++ b/src/components/sessions/SessionCard.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SessionCard } from "./SessionCard";
+import type { ClaudeSession } from "../../store/sessionStore";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function makeSession(overrides: Partial<ClaudeSession> = {}): ClaudeSession {
+  const now = Date.now();
+  return {
+    id: "session-1",
+    title: "Test Session",
+    folder: "C:/Projects/foo/bar/baz",
+    shell: "powershell",
+    status: "running",
+    createdAt: now - 65_000, // 1:05
+    finishedAt: null,
+    exitCode: null,
+    lastOutputAt: now - 2_000, // recent → active
+    lastOutputSnippet: "hello output",
+    ...overrides,
+  };
+}
+
+function renderCard(
+  session: ClaudeSession,
+  overrides: {
+    isActive?: boolean;
+    onClick?: (id: string) => void;
+    onClose?: (id: string) => void;
+  } = {},
+) {
+  return render(
+    <SessionCard
+      session={session}
+      isActive={overrides.isActive ?? false}
+      onClick={overrides.onClick ?? vi.fn()}
+      onClose={overrides.onClose ?? vi.fn()}
+    />,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("SessionCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders title, status dot and shortened folder path", () => {
+    const session = makeSession({
+      title: "My Session",
+      folder: "C:/Projects/foo/bar/baz",
+    });
+    const { container } = renderCard(session);
+
+    expect(screen.getByText("My Session")).toBeTruthy();
+    // shortenPath("C:/Projects/foo/bar/baz") → "~/bar/baz" (4 segments)
+    expect(screen.getByText("~/bar/baz")).toBeTruthy();
+    // Status dot: running + active → status-pulse-animation + bg-success
+    const dot = container.querySelector(".status-pulse-animation");
+    expect(dot).toBeTruthy();
+  });
+
+  it("shows 'Laeuft seit' for running status with recent output", () => {
+    renderCard(makeSession({ status: "running" }));
+    // "active" level → "Laeuft seit X:XX"
+    expect(screen.getByText(/Laeuft seit/)).toBeTruthy();
+  });
+
+  it("shows check icon and 'Fertig' for done status", () => {
+    const now = Date.now();
+    const { container } = renderCard(
+      makeSession({
+        status: "done",
+        createdAt: now - 120_000,
+        finishedAt: now - 60_000,
+      }),
+    );
+    expect(screen.getByText(/Fertig/)).toBeTruthy();
+    // Check icon has text-success class
+    const checkIcon = container.querySelector("svg.text-success");
+    expect(checkIcon).toBeTruthy();
+  });
+
+  it("shows alert icon and exit code for error status", () => {
+    const { container } = renderCard(
+      makeSession({ status: "error", exitCode: 42 }),
+    );
+    expect(screen.getByText(/Fehler \(Exit 42\)/)).toBeTruthy();
+    // AlertTriangle icon with text-red-500
+    const alertIcon = container.querySelector("svg.text-red-500");
+    expect(alertIcon).toBeTruthy();
+  });
+
+  it("calls onClick with id on card click and onClose on close button", () => {
+    const onClick = vi.fn();
+    const onClose = vi.fn();
+    renderCard(makeSession({ id: "sess-99" }), { onClick, onClose });
+
+    // Click card body (title) — should trigger onClick
+    fireEvent.click(screen.getByText("Test Session"));
+    expect(onClick).toHaveBeenCalledWith("sess-99");
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Click close button — should trigger onClose, NOT re-trigger onClick
+    // (stopPropagation verified via call count unchanged)
+    const closeBtn = screen.getByLabelText("Session schliessen");
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledWith("sess-99");
+    expect(onClick).toHaveBeenCalledTimes(1); // still 1, not 2
+  });
+
+  it("renders starting status with active dot animation class", () => {
+    const { container } = renderCard(makeSession({ status: "starting" }));
+    // starting + active activity → status-pulse-animation + bg-success
+    const dot = container.querySelector(".status-pulse-animation.bg-success");
+    expect(dot).toBeTruthy();
+  });
+});

--- a/src/components/shared/ErrorBoundary.test.tsx
+++ b/src/components/shared/ErrorBoundary.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { MockInstance } from "vitest";
+import { ErrorBoundary } from "./ErrorBoundary";
+import { useUIStore } from "../../store/uiStore";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("../../utils/errorLogger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+// Helper component that throws on demand
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Kaboom!");
+  }
+  return <div>All good</div>;
+}
+
+describe("ErrorBoundary", () => {
+  let errSpy: MockInstance;
+
+  beforeEach(() => {
+    useUIStore.setState({ toasts: [] });
+    vi.clearAllMocks();
+    // React logs caught errors via console.error — silence for all tests
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it("renders children when no error", () => {
+    render(
+      <ErrorBoundary>
+        <div>child content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("child content")).toBeTruthy();
+  });
+
+  it("catches child error and shows default fallback UI with error message", () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("RUNTIME ERROR")).toBeTruthy();
+    expect(screen.getByText("Kaboom!")).toBeTruthy();
+    expect(screen.getByText("RELOAD")).toBeTruthy();
+  });
+
+  it("adds error toast to uiStore when error caught", () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    const toasts = useUIStore.getState().toasts;
+    expect(toasts.length).toBe(1);
+    expect(toasts[0].type).toBe("error");
+    expect(toasts[0].title).toBe("Fehler");
+    expect(toasts[0].message).toBe("Kaboom!");
+    expect(toasts[0].duration).toBe(8000);
+  });
+
+  it("renders custom fallback prop when provided instead of default UI", () => {
+    render(
+      <ErrorBoundary fallback={<div>custom fallback here</div>}>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("custom fallback here")).toBeTruthy();
+    expect(screen.queryByText("RUNTIME ERROR")).toBeNull();
+  });
+
+  it("resets error state when RELOAD button clicked", () => {
+    // Use a ref-controlled child so flipping its behavior doesn't require
+    // passing new children through rerender (which would race with setState).
+    let shouldThrow = true;
+    function ControlledBomb() {
+      if (shouldThrow) throw new Error("Kaboom!");
+      return <div>All good</div>;
+    }
+    render(
+      <ErrorBoundary>
+        <ControlledBomb />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("RUNTIME ERROR")).toBeTruthy();
+
+    // Flip behavior FIRST, then click RELOAD so re-render uses new behavior
+    shouldThrow = false;
+    fireEvent.click(screen.getByText("RELOAD"));
+
+    expect(screen.queryByText("RUNTIME ERROR")).toBeNull();
+    expect(screen.getByText("All good")).toBeTruthy();
+  });
+});

--- a/src/components/shared/Toast.test.tsx
+++ b/src/components/shared/Toast.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { Toast } from "./Toast";
+import { ToastContainer } from "./ToastContainer";
+import { useUIStore } from "../../store/uiStore";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: () => {
+        return ({ children, ...props }: { children?: React.ReactNode }) => {
+          const filteredProps: Record<string, unknown> = {};
+          for (const [k, v] of Object.entries(props)) {
+            // Drop framer-motion-only props that React complains about
+            if (
+              ![
+                "layout",
+                "initial",
+                "animate",
+                "exit",
+                "transition",
+                "whileHover",
+                "whileTap",
+              ].includes(k)
+            ) {
+              filteredProps[k] = v;
+            }
+          }
+          return <div {...filteredProps}>{children}</div>;
+        };
+      },
+    },
+  ),
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("Toast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useUIStore.setState({ toasts: [] });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders title and message for success toast", () => {
+    render(
+      <Toast
+        toast={{
+          id: "t1",
+          type: "success",
+          title: "Gespeichert",
+          message: "Datei wurde erfolgreich gespeichert",
+        }}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Gespeichert")).toBeTruthy();
+    expect(screen.getByText("Datei wurde erfolgreich gespeichert")).toBeTruthy();
+  });
+
+  it("auto-dismisses after default 5000ms", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Toast
+        toast={{ id: "t1", type: "info", title: "Hi" }}
+        onDismiss={onDismiss}
+      />,
+    );
+    expect(onDismiss).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(4999);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(onDismiss).toHaveBeenCalledWith("t1");
+  });
+
+  it("does not auto-dismiss when duration is 0", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Toast
+        toast={{ id: "t1", type: "info", title: "Persistent", duration: 0 }}
+        onDismiss={onDismiss}
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("calls onDismiss when close button clicked", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Toast
+        toast={{ id: "t1", type: "error", title: "Oops" }}
+        onDismiss={onDismiss}
+      />,
+    );
+    // Close button = the button containing the X icon (no aria-label in source)
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[0]);
+    expect(onDismiss).toHaveBeenCalledWith("t1");
+  });
+
+  it("ToastContainer renders only last 5 toasts from uiStore", () => {
+    useUIStore.setState({
+      toasts: [
+        { id: "1", type: "info", title: "T1", duration: 0 },
+        { id: "2", type: "info", title: "T2", duration: 0 },
+        { id: "3", type: "info", title: "T3", duration: 0 },
+        { id: "4", type: "info", title: "T4", duration: 0 },
+        { id: "5", type: "info", title: "T5", duration: 0 },
+        { id: "6", type: "info", title: "T6", duration: 0 },
+        { id: "7", type: "info", title: "T7", duration: 0 },
+      ],
+    });
+    render(<ToastContainer />);
+    // First two should be clipped (slice(-5)) → T3..T7 visible
+    expect(screen.queryByText("T1")).toBeNull();
+    expect(screen.queryByText("T2")).toBeNull();
+    expect(screen.getByText("T3")).toBeTruthy();
+    expect(screen.getByText("T4")).toBeTruthy();
+    expect(screen.getByText("T5")).toBeTruthy();
+    expect(screen.getByText("T6")).toBeTruthy();
+    expect(screen.getByText("T7")).toBeTruthy();
+  });
+
+  it("ToastContainer subscribes to store updates (adding toast appears)", () => {
+    render(<ToastContainer />);
+    expect(screen.queryByText("Hello")).toBeNull();
+    act(() => {
+      useUIStore.getState().addToast({
+        type: "success",
+        title: "Hello",
+        duration: 0,
+      });
+    });
+    expect(screen.getByText("Hello")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

21 neue Component-Tests fuer die 4 Kern-UI-Komponenten (QA-10 / #87):

- **SessionCard.test.tsx** (NEU, 6 Tests) — Status-Matrix (starting/running/done/error), Click+Close Handler mit stopPropagation, shortened folder path
- **SideNav.test.tsx** (NEU, 4 Tests) — 7 aria-labeled Nav-Items, active-tab Highlight + setActiveTab via uiStore, Badge-Logik inkl. 99+-Cap
- **Toast.test.tsx** (NEU, 6 Tests) — 5000ms Auto-Dismiss, duration:0 deaktiviert Timer, onDismiss, ToastContainer MAX_VISIBLE=5 Clipping, Store-Reaktivitaet
- **ErrorBoundary.test.tsx** (NEU, 5 Tests) — Children-Passthrough, Fallback-UI, uiStore-Toast-Emission, Custom-Fallback-Override, RELOAD-Recovery

Test-Suite: 531 → **552 Tests, alle gruen**. AC-Ziel von min. 15 Tests deutlich uebererfuellt (21). Fake-Timers fuer Toast, `framer-motion` via Proxy-Mock gestubbt. Granulare Selektor-Pattern aus vorherigen Tests uebernommen (Store via setState).

## Findings (nicht in Scope gefixt)

1. `Toast.tsx` Close-Button ohne `aria-label` bzw. `title` → a11y-Verbesserung ("Toast schliessen") empfohlen, Tests nutzen `getAllByRole("button")[0]` als Workaround
2. `ToastContainer.tsx` `mapToastType` ist identische 1:1-Mapping-Funktion → Dead-Code-Kandidat

## Test plan

- [x] `npm run test` gruen (552/552)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` erfolgreich
- [x] Pre-commit hooks (tsc + eslint) passed
- [x] Stores via `setState` gefuettert (granulare Selektoren nicht gebrochen)
- [x] Code-Quality-Review: DRY-Verbesserungen umgesetzt (renderCard-Helper, console.error-Spy in beforeEach)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)