### PR TITLE
fix(ui): sort log entries and filter noise (#118)

### DIFF
--- a/src/store/logViewerStore.test.ts
+++ b/src/store/logViewerStore.test.ts
@@ -144,6 +144,96 @@ describe("filters", () => {
 });
 
 // ---------------------------------------------------------------------------
+// sorting (chronological order)
+// ---------------------------------------------------------------------------
+
+describe("sorting", () => {
+  it("sorts entries by timestamp after addEntries", () => {
+    const entries = [
+      makeEntry({ timestamp: "2025-01-15T10:35:00.000Z", message: "third" }),
+      makeEntry({ timestamp: "2025-01-15T10:30:00.000Z", message: "first" }),
+      makeEntry({ timestamp: "2025-01-15T10:32:00.000Z", message: "second" }),
+    ];
+    useLogViewerStore.getState().addEntries(entries);
+
+    const stored = useLogViewerStore.getState().entries;
+    expect(stored.map((e) => e.message)).toEqual(["first", "second", "third"]);
+  });
+
+  it("sorts mixed historical and live entries chronologically", () => {
+    // Simulate: first add a live entry, then load historical backend logs
+    useLogViewerStore
+      .getState()
+      .addEntries([
+        makeEntry({
+          timestamp: "2025-01-15T12:00:00.000Z",
+          source: "frontend",
+          message: "live",
+        }),
+      ]);
+
+    // Historical logs arrive later but have earlier timestamps
+    useLogViewerStore
+      .getState()
+      .addEntries([
+        makeEntry({
+          timestamp: "2025-01-15T08:00:00.000Z",
+          source: "backend",
+          message: "historical",
+        }),
+      ]);
+
+    const stored = useLogViewerStore.getState().entries;
+    expect(stored[0].message).toBe("historical");
+    expect(stored[1].message).toBe("live");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// noise filtering
+// ---------------------------------------------------------------------------
+
+describe("noise filtering", () => {
+  it("downgrades updater error messages to info severity", () => {
+    useLogViewerStore.getState().addEntries([
+      makeEntry({
+        severity: "error",
+        message:
+          "tauri_plugin_updater::updater — update endpoint did not respond with a successful status code",
+      }),
+    ]);
+
+    const stored = useLogViewerStore.getState().entries;
+    expect(stored[0].severity).toBe("info");
+  });
+
+  it("downgrades Windows Ctrl+C exit code warnings to info", () => {
+    useLogViewerStore.getState().addEntries([
+      makeEntry({
+        severity: "warn",
+        message:
+          "Session abc123 child process exited with unexpected code: -1073741510",
+      }),
+    ]);
+
+    const stored = useLogViewerStore.getState().entries;
+    expect(stored[0].severity).toBe("info");
+  });
+
+  it("does not downgrade genuine error messages", () => {
+    useLogViewerStore.getState().addEntries([
+      makeEntry({
+        severity: "error",
+        message: "Failed to spawn shell for session abc: permission denied",
+      }),
+    ]);
+
+    const stored = useLogViewerStore.getState().entries;
+    expect(stored[0].severity).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // parseBackendLogLine
 // ---------------------------------------------------------------------------
 

--- a/src/store/logViewerStore.ts
+++ b/src/store/logViewerStore.ts
@@ -16,6 +16,17 @@ export interface UnifiedLogEntry {
 const MAX_ENTRIES = 1000;
 let entryCounter = 0;
 
+/**
+ * Noise patterns that should be downgraded from error/warn to info.
+ * Each pattern is tested against the log message (case-insensitive).
+ */
+const NOISE_PATTERNS: readonly string[] = [
+  "update endpoint did not respond",
+  "updater endpoint did not respond",
+  "exited with unexpected code: -1073741510", // Windows Ctrl+C (0xC000013A)
+  "exited with unexpected code: -1073741509", // Windows Ctrl+Break (0xC000013B)
+];
+
 interface LogViewerState {
   entries: UnifiedLogEntry[];
   severityFilter: Set<LogSeverity>;
@@ -40,8 +51,20 @@ export const useLogViewerStore = create<LogViewerState>((set) => ({
 
   addEntries: (newEntries) =>
     set((state) => {
-      const withIds = newEntries.map((e) => ({ ...e, id: ++entryCounter }));
-      const merged = [...state.entries, ...withIds];
+      const processed = newEntries.map((e) => {
+        // Downgrade noisy log messages to info severity
+        const isNoise = NOISE_PATTERNS.some((p) =>
+          e.message.toLowerCase().includes(p),
+        );
+        return {
+          ...e,
+          severity: isNoise ? ("info" as LogSeverity) : e.severity,
+          id: ++entryCounter,
+        };
+      });
+      const merged = [...state.entries, ...processed];
+      // Sort by timestamp to ensure chronological order
+      merged.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
       return { entries: merged.slice(-MAX_ENTRIES) };
     }),
 


### PR DESCRIPTION
## Summary
- **Chronological sorting**: Log entries are now sorted by timestamp after merging, fixing the issue where historical backend logs appeared mixed with live entries in random order.
- **Updater-spam filter**: Messages matching "update endpoint did not respond" are downgraded from error to info severity, preventing updater errors from dominating the log view.
- **Exit-code noise reduction**: Windows Ctrl+C exit codes (-1073741510, -1073741509) logged as warnings are downgraded to info, since they represent normal user-initiated session termination.

All three fixes are implemented in `logViewerStore.ts` via a `NOISE_PATTERNS` array and a `merged.sort()` call in `addEntries`.

Closes #118

## Test plan
- [x] Test: unsorted timestamps are sorted chronologically after `addEntries`
- [x] Test: mixed historical + live entries maintain chronological order
- [x] Test: updater error messages are downgraded to info severity
- [x] Test: Windows Ctrl+C exit code warnings are downgraded to info
- [x] Test: genuine error messages are NOT downgraded
- [x] All 629 existing tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)