### PR TITLE
fix(ui): show hook name and command in Hooks tab (#114)

### DIFF
--- a/src/components/sessions/HooksViewer.test.tsx
+++ b/src/components/sessions/HooksViewer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { buildEventGroups, HooksViewer } from "./HooksViewer";
+import { buildEventGroups, extractHookName, HooksViewer } from "./HooksViewer";
 
 // Mock @tauri-apps/api/core
 vi.mock("@tauri-apps/api/core", () => ({
@@ -89,6 +89,88 @@ describe("buildEventGroups", () => {
   });
 });
 
+// ── Unit tests: extractHookName ──
+
+describe("extractHookName", () => {
+  it("extracts filename from a path-based command", () => {
+    expect(extractHookName("node .claude/hooks/safe-guard.mjs")).toBe("safe-guard.mjs");
+  });
+
+  it("returns short commands as-is", () => {
+    expect(extractHookName("npx tsc --noEmit")).toBe("npx tsc --noEmit");
+  });
+
+  it("handles backslash paths", () => {
+    expect(extractHookName("node C:\\hooks\\check.js")).toBe("check.js");
+  });
+});
+
+// ── Unit tests: buildEventGroups with nested format ──
+
+describe("buildEventGroups (nested hooks format)", () => {
+  it("parses the real Claude settings.json nested format", () => {
+    const raws = {
+      project: JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [
+                { type: "command", command: "node .claude/hooks/safe-guard.mjs", timeout: 5000 },
+              ],
+            },
+          ],
+          PostToolUse: [
+            {
+              matcher: "Edit|Write",
+              hooks: [
+                { type: "command", command: "npx tsc --noEmit --skipLibCheck 2>&1 | head -20" },
+              ],
+            },
+          ],
+        },
+      }),
+      "project-local": "",
+      user: "",
+    };
+
+    const groups = buildEventGroups(raws);
+    expect(groups).toHaveLength(2);
+
+    const postGroup = groups.find((g) => g.eventName === "PostToolUse")!;
+    expect(postGroup.hooks).toHaveLength(1);
+    expect(postGroup.hooks[0].command).toBe("npx tsc --noEmit --skipLibCheck 2>&1 | head -20");
+    expect(postGroup.hooks[0].matcher).toBe("Edit|Write");
+
+    const preGroup = groups.find((g) => g.eventName === "PreToolUse")!;
+    expect(preGroup.hooks).toHaveLength(1);
+    expect(preGroup.hooks[0].command).toBe("node .claude/hooks/safe-guard.mjs");
+    expect(preGroup.hooks[0].timeout).toBe(5000);
+    expect(preGroup.hooks[0].matcher).toBe("Bash");
+  });
+
+  it("handles mixed nested and flat formats", () => {
+    const raws = {
+      project: JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { matcher: "Bash", hooks: [{ type: "command", command: "nested-cmd" }] },
+            { matcher: "Edit", command: "flat-cmd" },
+          ],
+        },
+      }),
+      "project-local": "",
+      user: "",
+    };
+
+    const groups = buildEventGroups(raws);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].hooks).toHaveLength(2);
+    expect(groups[0].hooks[0].command).toBe("nested-cmd");
+    expect(groups[0].hooks[1].command).toBe("flat-cmd");
+  });
+});
+
 // ── Component tests: HooksViewer ──
 
 describe("HooksViewer", () => {
@@ -107,10 +189,17 @@ describe("HooksViewer", () => {
     expect(screen.getByText(/\.claude\/settings\.json/)).toBeTruthy();
   });
 
-  it("renders event groups with source badges", async () => {
+  it("renders event groups with source badges and hook names", async () => {
     const { invoke } = await import("@tauri-apps/api/core");
     const projectJson = JSON.stringify({
-      hooks: { PreToolUse: [{ matcher: "Bash", command: "node safe-guard.mjs" }] },
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "node .claude/hooks/safe-guard.mjs", timeout: 5000 }],
+          },
+        ],
+      },
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(invoke).mockImplementation(async (cmd: string, args?: any) => {
@@ -125,13 +214,18 @@ describe("HooksViewer", () => {
     expect(await screen.findByText("PreToolUse")).toBeTruthy();
     // "Projekt" appears in legend and badge — use getAllByText
     expect(screen.getAllByText("Projekt").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("node safe-guard.mjs")).toBeTruthy();
+    // Hook name extracted from command path
+    expect(screen.getByText("safe-guard.mjs")).toBeTruthy();
+    // Full command shown in code block
+    expect(screen.getByText("node .claude/hooks/safe-guard.mjs")).toBeTruthy();
+    // Timeout displayed
+    expect(screen.getByText("5s")).toBeTruthy();
     expect(screen.getByText("1 Event")).toBeTruthy();
   });
 
   it("toggles between structured and raw view", async () => {
     const rawJson = JSON.stringify({
-      hooks: { PostToolUse: [{ command: "tsc --noEmit" }] },
+      hooks: { PostToolUse: [{ hooks: [{ type: "command", command: "tsc --noEmit" }] }] },
     });
     const { invoke } = await import("@tauri-apps/api/core");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/sessions/HooksViewer.tsx
+++ b/src/components/sessions/HooksViewer.tsx
@@ -7,9 +7,16 @@ interface HooksViewerProps {
   folder: string;
 }
 
+interface NestedHookDef {
+  type?: string;
+  command: string;
+  timeout?: number;
+}
+
 interface HookEntry {
   matcher?: string;
-  command: string;
+  command?: string;
+  hooks?: NestedHookDef[];
 }
 
 type HookSource = "project" | "project-local" | "user";
@@ -17,6 +24,7 @@ type HookSource = "project" | "project-local" | "user";
 interface ResolvedHook {
   matcher?: string;
   command: string;
+  timeout?: number;
   source: HookSource;
 }
 
@@ -74,8 +82,25 @@ export function buildEventGroups(raws: Record<HookSource, string>): EventGroup[]
 
     for (const [eventName, hooks] of Object.entries(parsed)) {
       const existing = eventMap.get(eventName) ?? [];
-      for (const hook of Array.isArray(hooks) ? hooks : []) {
-        existing.push({ matcher: hook.matcher, command: hook.command, source });
+      for (const entry of Array.isArray(hooks) ? hooks : []) {
+        if (entry.hooks && Array.isArray(entry.hooks)) {
+          // Nested format: { matcher, hooks: [{ type, command, timeout }] }
+          for (const nested of entry.hooks) {
+            existing.push({
+              matcher: entry.matcher,
+              command: nested.command,
+              timeout: nested.timeout,
+              source,
+            });
+          }
+        } else if (entry.command) {
+          // Flat format: { matcher, command }
+          existing.push({
+            matcher: entry.matcher,
+            command: entry.command,
+            source,
+          });
+        }
       }
       eventMap.set(eventName, existing);
     }
@@ -274,6 +299,20 @@ function SourceBadge({ source }: { source: HookSource }) {
   );
 }
 
+/** Extract a short display name from a command string (e.g. last path segment or first token). */
+// eslint-disable-next-line react-refresh/only-export-components
+export function extractHookName(command: string): string {
+  const trimmed = command.trim();
+  // Try to find a file path (e.g. "node .claude/hooks/safe-guard.mjs" → "safe-guard.mjs")
+  const parts = trimmed.split(/\s+/);
+  for (const part of parts) {
+    const match = part.match(/[/\\]([^/\\]+)$/);
+    if (match) return match[1];
+  }
+  // Fallback: return the whole command if short, or first meaningful token
+  return trimmed.length <= 30 ? trimmed : parts.slice(0, 2).join(" ");
+}
+
 function EventGroupCard({ group }: { group: EventGroup }) {
   return (
     <div>
@@ -287,15 +326,27 @@ function EventGroupCard({ group }: { group: EventGroup }) {
             className="bg-surface-raised border border-neutral-700 rounded-sm px-3 py-2.5"
           >
             <div className="flex items-center justify-between gap-2 mb-1.5">
-              <SourceBadge source={hook.source} />
-              {hook.matcher && (
-                <span className="text-[11px] text-neutral-500">
-                  Matcher:{" "}
-                  <code className="text-neutral-300 font-mono">
-                    {hook.matcher}
-                  </code>
+              <div className="flex items-center gap-2">
+                <SourceBadge source={hook.source} />
+                <span className="text-xs text-neutral-200 font-semibold">
+                  {extractHookName(hook.command)}
                 </span>
-              )}
+              </div>
+              <div className="flex items-center gap-2">
+                {hook.timeout != null && (
+                  <span className="text-[10px] text-neutral-600">
+                    {(hook.timeout / 1000).toFixed(0)}s
+                  </span>
+                )}
+                {hook.matcher && (
+                  <span className="text-[11px] text-neutral-500">
+                    Matcher:{" "}
+                    <code className="text-neutral-300 font-mono">
+                      {hook.matcher}
+                    </code>
+                  </span>
+                )}
+              </div>
             </div>
             <div className="bg-neutral-900 font-mono text-xs px-3 py-2 rounded-sm text-neutral-200">
               {hook.command}


### PR DESCRIPTION
## Summary
- **Root cause**: The Hooks tab parser only handled a flat `{matcher, command}` format, but the real Claude `settings.json` uses a nested format: `{matcher, hooks: [{type, command, timeout}]}`. This caused `hook.command` to be `undefined`, resulting in empty hook cards showing only the source badge.
- **Fix**: Support both nested and flat hook entry formats in `buildEventGroups()`. Each hook card now displays an extracted hook name (e.g. `safe-guard.mjs`), the full command, matcher, source badge, and timeout when configured.
- **Tests**: Added 6 new tests covering nested format parsing, mixed format handling, and `extractHookName` utility.

Closes #114

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run test -- --run` — 629 tests pass (13 HooksViewer tests)
- [x] `npm run build` succeeds
- [ ] Visual check: Hooks tab shows hook name, command, matcher, timeout for project hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)