### PR TITLE
fix(ui): show favorite projects in Library view (#117)

### DIFF
--- a/src/components/library/LibraryView.test.tsx
+++ b/src/components/library/LibraryView.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from "@testing-library/react";
 import { LibraryView } from "./LibraryView";
 import { useConfigDiscoveryStore } from "../../store/configDiscoveryStore";
 import type { ScopeConfig } from "../../store/configDiscoveryStore";
+import { useSettingsStore } from "../../store/settingsStore";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUseSettingsStore = useSettingsStore as any;
 
 // ── Mocks ─────────────────────────────────────────────────────────────
 
@@ -15,6 +19,12 @@ vi.mock("../../store/sessionStore", () => ({
     sel({ sessions: [], activeSessionId: null }),
   ),
   selectActiveSession: () => null,
+}));
+
+vi.mock("../../store/settingsStore", () => ({
+  useSettingsStore: vi.fn((sel: CallableFunction) =>
+    sel({ favorites: [] }),
+  ),
 }));
 
 const makeConfig = (overrides?: Partial<ScopeConfig>): ScopeConfig => ({
@@ -32,6 +42,8 @@ beforeEach(() => {
     globalConfig: null,
     projectConfig: null,
     projectPath: null,
+    favoriteConfigs: {},
+    favoritesLoading: {},
     loading: false,
     error: null,
     contentCache: {},
@@ -132,5 +144,76 @@ describe("LibraryView", () => {
     render(<LibraryView />);
     const refreshBtn = screen.getByTitle("Neu laden");
     expect(refreshBtn).toBeTruthy();
+  });
+
+  it("renders favorite project panels when favorites exist", () => {
+    // Override settingsStore mock to return favorites
+    mockUseSettingsStore.mockImplementation(
+      (sel: CallableFunction) =>
+        sel({
+          favorites: [
+            {
+              id: "fav-1",
+              path: "C:/Projects/my-app",
+              label: "My App",
+              shell: "powershell",
+              addedAt: 1000,
+              lastUsedAt: 2000,
+            },
+          ],
+        }),
+    );
+
+    useConfigDiscoveryStore.setState({
+      globalConfig: makeConfig(),
+      favoriteConfigs: {
+        "C:/Projects/my-app": makeConfig({
+          skills: [
+            {
+              name: "deploy",
+              dirName: "deploy",
+              description: "Deploy app",
+              args: [],
+              hasReference: false,
+              scope: "project",
+            },
+          ],
+          claudeMd: "# My App Config",
+        }),
+      },
+      discoverFavorites: vi.fn(async () => {}),
+    });
+
+    render(<LibraryView />);
+    expect(screen.getByText(/My App/)).toBeTruthy();
+    expect(screen.getByText("deploy")).toBeTruthy();
+  });
+
+  it("does not render favorite panel when config is not yet loaded", () => {
+    mockUseSettingsStore.mockImplementation(
+      (sel: CallableFunction) =>
+        sel({
+          favorites: [
+            {
+              id: "fav-2",
+              path: "C:/Projects/other-app",
+              label: "Other App",
+              shell: "powershell",
+              addedAt: 1000,
+              lastUsedAt: 2000,
+            },
+          ],
+        }),
+    );
+
+    useConfigDiscoveryStore.setState({
+      globalConfig: makeConfig(),
+      favoriteConfigs: {}, // Config not loaded yet
+      discoverFavorites: vi.fn(async () => {}),
+    });
+
+    render(<LibraryView />);
+    // "Other App" should not appear since config is not loaded
+    expect(screen.queryByText(/Other App/)).toBeNull();
   });
 });

--- a/src/components/library/LibraryView.tsx
+++ b/src/components/library/LibraryView.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useSessionStore, selectActiveSession } from "../../store/sessionStore";
+import { useSettingsStore } from "../../store/settingsStore";
 import {
   useConfigDiscoveryStore,
   type ScopeConfig,
@@ -399,9 +400,13 @@ export function LibraryView() {
 
   const globalConfig = useConfigDiscoveryStore((s) => s.globalConfig);
   const projectConfig = useConfigDiscoveryStore((s) => s.projectConfig);
+  const favoriteConfigs = useConfigDiscoveryStore((s) => s.favoriteConfigs);
   const loading = useConfigDiscoveryStore((s) => s.loading);
   const discoverGlobal = useConfigDiscoveryStore((s) => s.discoverGlobal);
   const discoverProject = useConfigDiscoveryStore((s) => s.discoverProject);
+  const discoverFavorites = useConfigDiscoveryStore((s) => s.discoverFavorites);
+
+  const favorites = useSettingsStore((s) => s.favorites);
 
   useEffect(() => {
     discoverGlobal();
@@ -413,12 +418,28 @@ export function LibraryView() {
     }
   }, [folder, discoverProject]);
 
+  // Discover configs for all favorite projects (excluding the active session folder)
+  useEffect(() => {
+    const favPaths = favorites
+      .map((f) => f.path)
+      .filter((p) => p !== folder);
+    if (favPaths.length > 0) {
+      discoverFavorites(favPaths);
+    }
+  }, [favorites, folder, discoverFavorites]);
+
   const handleRefresh = useCallback(() => {
     discoverGlobal();
     if (folder) {
       discoverProject(folder);
     }
-  }, [discoverGlobal, discoverProject, folder]);
+    const favPaths = favorites
+      .map((f) => f.path)
+      .filter((p) => p !== folder);
+    if (favPaths.length > 0) {
+      discoverFavorites(favPaths);
+    }
+  }, [discoverGlobal, discoverProject, discoverFavorites, folder, favorites]);
 
   return (
     <div className="flex flex-col h-full">
@@ -466,7 +487,7 @@ export function LibraryView() {
               />
             )}
 
-            {/* Project scope */}
+            {/* Active session project scope */}
             {projectConfig && folder && (
               <ScopePanel
                 scope="project"
@@ -476,7 +497,24 @@ export function LibraryView() {
               />
             )}
 
-            {!globalConfig && !projectConfig && !loading && (
+            {/* Favorite projects */}
+            {favorites
+              .filter((f) => f.path !== folder)
+              .map((fav) => {
+                const config = favoriteConfigs[fav.path];
+                if (!config) return null;
+                return (
+                  <ScopePanel
+                    key={fav.id}
+                    scope="project"
+                    config={config}
+                    label={`${fav.label} (${fav.path.split(/[\\/]/).pop() ?? fav.path})`}
+                    icon={FolderOpen}
+                  />
+                );
+              })}
+
+            {!globalConfig && !projectConfig && Object.keys(favoriteConfigs).length === 0 && !loading && (
               <div className="flex flex-col items-center justify-center h-64 gap-3 text-neutral-500">
                 <BookOpen className="w-10 h-10 text-neutral-600" />
                 <span className="text-sm">Keine Konfigurationen gefunden</span>

--- a/src/store/configDiscoveryStore.ts
+++ b/src/store/configDiscoveryStore.ts
@@ -50,6 +50,10 @@ interface ConfigDiscoveryState {
   globalConfig: ScopeConfig | null;
   projectConfig: ScopeConfig | null;
   projectPath: string | null;
+  /** Configs for favorite projects, keyed by folder path */
+  favoriteConfigs: Record<string, ScopeConfig>;
+  /** Paths currently being scanned */
+  favoritesLoading: Record<string, boolean>;
   loading: boolean;
   error: string | null;
 
@@ -59,6 +63,7 @@ interface ConfigDiscoveryState {
 
   discoverGlobal: () => Promise<void>;
   discoverProject: (folder: string) => Promise<void>;
+  discoverFavorites: (folders: string[]) => Promise<void>;
   loadContent: (key: string, loader: () => Promise<string>) => Promise<string>;
   clearProject: () => void;
 }
@@ -157,6 +162,8 @@ export const useConfigDiscoveryStore = create<ConfigDiscoveryState>((set, get) =
   globalConfig: null,
   projectConfig: null,
   projectPath: null,
+  favoriteConfigs: {},
+  favoritesLoading: {},
   loading: false,
   error: null,
   contentCache: {},
@@ -283,6 +290,57 @@ export const useConfigDiscoveryStore = create<ConfigDiscoveryState>((set, get) =
     }
   },
 
+  discoverFavorites: async (folders: string[]) => {
+    if (folders.length === 0) return;
+
+    // Mark all as loading
+    const loadingMap: Record<string, boolean> = {};
+    for (const f of folders) loadingMap[f] = true;
+    set({ favoritesLoading: loadingMap });
+
+    const results: Record<string, ScopeConfig> = {};
+
+    await Promise.allSettled(
+      folders.map(async (folder) => {
+        try {
+          const config: ScopeConfig = { ...EMPTY_SCOPE, skills: [], agents: [], hooks: [], memoryFiles: [] };
+
+          const [claudeMdResult, skillsResult, settingsResult, localSettingsResult] =
+            await Promise.allSettled([
+              invoke<string>("read_project_file", { folder, relativePath: "CLAUDE.md" }),
+              invoke<SkillDirEntry[]>("list_skill_dirs", { folder }),
+              invoke<string>("read_project_file", { folder, relativePath: ".claude/settings.json" }),
+              invoke<string>("read_project_file", { folder, relativePath: ".claude/settings.local.json" }),
+            ]);
+
+          if (claudeMdResult.status === "fulfilled") {
+            config.claudeMd = claudeMdResult.value;
+          }
+          if (skillsResult.status === "fulfilled") {
+            config.skills = parseSkillEntries(skillsResult.value, "project");
+          }
+          if (settingsResult.status === "fulfilled" && settingsResult.value) {
+            config.settingsRaw = settingsResult.value;
+            config.agents = parseAgentsFromSettings(settingsResult.value, "project");
+            config.hooks = parseHooksFromSettings(settingsResult.value, "project", "settings.json");
+          }
+          if (localSettingsResult.status === "fulfilled" && localSettingsResult.value) {
+            const localHooks = parseHooksFromSettings(localSettingsResult.value, "project", "settings.local.json");
+            config.hooks = [...config.hooks, ...localHooks];
+            const localAgents = parseAgentsFromSettings(localSettingsResult.value, "project");
+            config.agents = [...config.agents, ...localAgents];
+          }
+
+          results[folder] = config;
+        } catch (err) {
+          logError(`configDiscoveryStore.discoverFavorite(${folder})`, err);
+        }
+      }),
+    );
+
+    set({ favoriteConfigs: results, favoritesLoading: {} });
+  },
+
   loadContent: async (key: string, loader: () => Promise<string>) => {
     const cached = get().contentCache[key];
     if (cached !== undefined) return cached;
@@ -318,6 +376,7 @@ export const useConfigDiscoveryStore = create<ConfigDiscoveryState>((set, get) =
 
 export const selectGlobalConfig = (s: ConfigDiscoveryState) => s.globalConfig;
 export const selectProjectConfig = (s: ConfigDiscoveryState) => s.projectConfig;
+export const selectFavoriteConfigs = (s: ConfigDiscoveryState) => s.favoriteConfigs;
 export const selectDiscoveryLoading = (s: ConfigDiscoveryState) => s.loading;
 export const selectContentCache = (s: ConfigDiscoveryState) => s.contentCache;
 export const selectContentLoading = (s: ConfigDiscoveryState) => s.contentLoading;


### PR DESCRIPTION
## Summary
- Library-Ansicht zeigte nur Global (~/.claude/) Bereich — Projekt-Konfigurationen fehlten komplett
- **Root Cause**: `LibraryView` las nur die aktive Session, nicht die Favoriten aus `settingsStore`
- **Fix**: `configDiscoveryStore` um `discoverFavorites()` erweitert (paralleler Multi-Projekt-Scan), `LibraryView` liest Favoriten und rendert je Projekt ein eigenes collapsible Panel mit Skills, Agents, Hooks, CLAUDE.md, Settings

## Geaenderte Dateien
- `src/store/configDiscoveryStore.ts` — `favoriteConfigs` State + `discoverFavorites()` Action
- `src/components/library/LibraryView.tsx` — Favoriten-Integration mit Dedup gegen aktive Session
- `src/components/library/LibraryView.test.tsx` — 2 neue Tests (Happy Path + Edge Case)

## Test plan
- [x] `npx tsc --noEmit` — keine Fehler
- [x] `npm run lint` — keine Warnings
- [x] `npm run test -- --run` — 626 Tests bestanden
- [x] `npm run build` — erfolgreich

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)