### PR TITLE
perf(editor): reduce @codemirror/language-data to ~20 languages (#113)

### DIFF
--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { markdown } from "@codemirror/lang-markdown";
-import { languages } from "@codemirror/language-data";
+import { codeLanguages } from "./languageSupport";
 import { keymap } from "@codemirror/view";
 import { neonEditorTheme } from "./editorTheme";
 
@@ -25,7 +25,7 @@ export function CodeMirrorEditor({
 
   const extensions = useMemo(() => {
     const ext = [
-      markdown({ codeLanguages: languages }),
+      markdown({ codeLanguages }),
       neonEditorTheme,
     ];
 

--- a/src/components/editor/languageSupport.test.ts
+++ b/src/components/editor/languageSupport.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { codeLanguages } from "./languageSupport";
+
+describe("codeLanguages (trimmed language list)", () => {
+  it("exports between 15 and 25 language descriptions", () => {
+    // We target ~20 languages; guard against accidental bloat or removal
+    expect(codeLanguages.length).toBeGreaterThanOrEqual(15);
+    expect(codeLanguages.length).toBeLessThanOrEqual(25);
+  });
+
+  it("includes all required languages for markdown code blocks", () => {
+    const names = codeLanguages.map((l) => l.name);
+
+    // Must-have languages per issue #113
+    const required = [
+      "JavaScript",
+      "TypeScript",
+      "JSON",
+      "HTML",
+      "CSS",
+      "Rust",
+      "YAML",
+      "TOML",
+      "Shell",
+      "Python",
+      "SQL",
+      "Markdown",
+    ];
+
+    for (const lang of required) {
+      expect(names).toContain(lang);
+    }
+  });
+
+  it("resolves aliases correctly (e.g. 'bash' maps to Shell)", () => {
+    const shell = codeLanguages.find((l) => l.name === "Shell");
+    expect(shell).toBeDefined();
+    // LanguageDescription stores aliases — verify 'bash' can be matched
+    const matched = codeLanguages.find(
+      (l) => l.name === "Shell" && l.alias.includes("bash"),
+    );
+    expect(matched).toBeDefined();
+  });
+
+  it("does not include bloat languages (e.g. APL, Brainfuck, Cobol)", () => {
+    const names = codeLanguages.map((l) => l.name);
+    const bloat = ["APL", "Brainfuck", "Cobol", "Fortran", "Haskell", "Perl"];
+
+    for (const lang of bloat) {
+      expect(names).not.toContain(lang);
+    }
+  });
+
+  it("every entry has a load() function for lazy loading", () => {
+    for (const lang of codeLanguages) {
+      expect(typeof lang.load).toBe("function");
+    }
+  });
+});

--- a/src/components/editor/languageSupport.ts
+++ b/src/components/editor/languageSupport.ts
@@ -1,0 +1,200 @@
+/**
+ * Trimmed language list for CodeMirror markdown code blocks.
+ *
+ * Replaces the full `@codemirror/language-data` export (~120 languages)
+ * with only the ~20 languages relevant for this app's markdown editor.
+ * Saves ~400-600 KB in the production build.
+ *
+ * Each language uses dynamic import() so chunks are only loaded when
+ * a matching fenced code block is encountered.
+ */
+import {
+  LanguageDescription,
+  LanguageSupport,
+  StreamLanguage,
+} from "@codemirror/language";
+
+function legacy(
+  parser: Parameters<typeof StreamLanguage.define>[0],
+): LanguageSupport {
+  return new LanguageSupport(StreamLanguage.define(parser));
+}
+
+/**
+ * Curated list of ~20 languages for markdown code block highlighting.
+ * Covers: web (JS/TS/HTML/CSS/JSON), systems (Rust, C/C++, Go, Python, Java),
+ * config (YAML, TOML, XML, SQL), scripting (Shell/Bash), and containers (Dockerfile).
+ */
+export const codeLanguages: LanguageDescription[] = [
+  // ── Web ────────────────────────────────────────────────────────────
+  LanguageDescription.of({
+    name: "JavaScript",
+    alias: ["ecmascript", "js", "node"],
+    extensions: ["js", "mjs", "cjs"],
+    load() {
+      return import("@codemirror/lang-javascript").then((m) =>
+        m.javascript(),
+      );
+    },
+  }),
+  LanguageDescription.of({
+    name: "JSX",
+    extensions: ["jsx"],
+    load() {
+      return import("@codemirror/lang-javascript").then((m) =>
+        m.javascript({ jsx: true }),
+      );
+    },
+  }),
+  LanguageDescription.of({
+    name: "TypeScript",
+    alias: ["ts"],
+    extensions: ["ts", "mts", "cts"],
+    load() {
+      return import("@codemirror/lang-javascript").then((m) =>
+        m.javascript({ typescript: true }),
+      );
+    },
+  }),
+  LanguageDescription.of({
+    name: "TSX",
+    extensions: ["tsx"],
+    load() {
+      return import("@codemirror/lang-javascript").then((m) =>
+        m.javascript({ jsx: true, typescript: true }),
+      );
+    },
+  }),
+  LanguageDescription.of({
+    name: "JSON",
+    alias: ["json5"],
+    extensions: ["json", "map"],
+    load() {
+      return import("@codemirror/lang-json").then((m) => m.json());
+    },
+  }),
+  LanguageDescription.of({
+    name: "HTML",
+    alias: ["xhtml"],
+    extensions: ["html", "htm", "handlebars", "hbs"],
+    load() {
+      return import("@codemirror/lang-html").then((m) => m.html());
+    },
+  }),
+  LanguageDescription.of({
+    name: "CSS",
+    extensions: ["css"],
+    load() {
+      return import("@codemirror/lang-css").then((m) => m.css());
+    },
+  }),
+
+  // ── Systems ────────────────────────────────────────────────────────
+  LanguageDescription.of({
+    name: "Rust",
+    extensions: ["rs"],
+    load() {
+      return import("@codemirror/lang-rust").then((m) => m.rust());
+    },
+  }),
+  LanguageDescription.of({
+    name: "C",
+    extensions: ["c", "h", "ino"],
+    load() {
+      return import("@codemirror/lang-cpp").then((m) => m.cpp());
+    },
+  }),
+  LanguageDescription.of({
+    name: "C++",
+    alias: ["cpp"],
+    extensions: ["cpp", "c++", "cc", "cxx", "hpp", "h++", "hh", "hxx"],
+    load() {
+      return import("@codemirror/lang-cpp").then((m) => m.cpp());
+    },
+  }),
+  LanguageDescription.of({
+    name: "Go",
+    extensions: ["go"],
+    load() {
+      return import("@codemirror/lang-go").then((m) => m.go());
+    },
+  }),
+  LanguageDescription.of({
+    name: "Java",
+    extensions: ["java"],
+    load() {
+      return import("@codemirror/lang-java").then((m) => m.java());
+    },
+  }),
+  LanguageDescription.of({
+    name: "Python",
+    alias: ["py"],
+    extensions: ["py", "pyi", "pyc", "pyd", "pyw"],
+    load() {
+      return import("@codemirror/lang-python").then((m) => m.python());
+    },
+  }),
+
+  // ── Config / Data ──────────────────────────────────────────────────
+  LanguageDescription.of({
+    name: "YAML",
+    alias: ["yml"],
+    extensions: ["yaml", "yml"],
+    load() {
+      return import("@codemirror/lang-yaml").then((m) => m.yaml());
+    },
+  }),
+  LanguageDescription.of({
+    name: "XML",
+    alias: ["rss", "wsdl", "xsd"],
+    extensions: ["xml", "xsl", "xsd", "svg"],
+    load() {
+      return import("@codemirror/lang-xml").then((m) => m.xml());
+    },
+  }),
+  LanguageDescription.of({
+    name: "SQL",
+    extensions: ["sql"],
+    load() {
+      return import("@codemirror/lang-sql").then((m) => m.sql());
+    },
+  }),
+  LanguageDescription.of({
+    name: "Markdown",
+    extensions: ["md", "markdown", "mkd"],
+    load() {
+      return import("@codemirror/lang-markdown").then((m) => m.markdown());
+    },
+  }),
+
+  // ── Legacy modes (StreamLanguage) ──────────────────────────────────
+  LanguageDescription.of({
+    name: "Shell",
+    alias: ["bash", "sh", "zsh"],
+    extensions: ["sh", "ksh", "bash"],
+    filename: /^PKGBUILD$/,
+    load() {
+      return import("@codemirror/legacy-modes/mode/shell").then((m) =>
+        legacy(m.shell),
+      );
+    },
+  }),
+  LanguageDescription.of({
+    name: "TOML",
+    extensions: ["toml"],
+    load() {
+      return import("@codemirror/legacy-modes/mode/toml").then((m) =>
+        legacy(m.toml),
+      );
+    },
+  }),
+  LanguageDescription.of({
+    name: "Dockerfile",
+    filename: /^Dockerfile$/,
+    load() {
+      return import("@codemirror/legacy-modes/mode/dockerfile").then((m) =>
+        legacy(m.dockerFile),
+      );
+    },
+  }),
+];


### PR DESCRIPTION
## Summary

- Replace full `@codemirror/language-data` import (~120 languages) with curated `languageSupport.ts` (~20 languages)
- Keeps only languages relevant for markdown code blocks: JS/TS/JSX/TSX, JSON, HTML, CSS, Rust, C/C++, Go, Java, Python, YAML, TOML, XML, SQL, Shell/Bash, Dockerfile, Markdown
- **Build size: 2,676 KB → 2,007 KB (−669 KB, −25%)**
- CodeMirrorEditor chunk: 22.27 KB → 6.76 KB

## Test plan

- [x] 5 new unit tests in `languageSupport.test.ts` (count, required langs, aliases, no bloat, lazy load)
- [x] All 641 existing tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` successful
- [x] Pre-commit hooks (tsc + eslint) pass

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)