### PR TITLE
fix(ui): show project Claude settings in Config Panel (#116)

### DIFF
--- a/src/components/sessions/SettingsViewer.test.tsx
+++ b/src/components/sessions/SettingsViewer.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { buildSettingsSections, parseSettings, SettingsViewer } from "./SettingsViewer";
+
+// Mock @tauri-apps/api/core
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+// ── Unit tests: parseSettings ──
+
+describe("parseSettings", () => {
+  it("parses valid JSON object", () => {
+    const result = parseSettings(JSON.stringify({ allowedTools: ["Bash"] }));
+    expect(result).toEqual({ allowedTools: ["Bash"] });
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseSettings("not json")).toBeNull();
+  });
+
+  it("returns null for arrays", () => {
+    expect(parseSettings("[]")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseSettings("")).toBeNull();
+  });
+});
+
+// ── Unit tests: buildSettingsSections ──
+
+describe("buildSettingsSections", () => {
+  it("groups settings by key with source attribution", () => {
+    const raws = {
+      project: JSON.stringify({
+        allowedTools: ["Bash", "Edit"],
+        mcpServers: { playwright: { command: "npx" } },
+      }),
+      "project-local": "",
+      user: JSON.stringify({
+        allowedTools: ["Read"],
+        model: "opus",
+      }),
+    };
+
+    const sections = buildSettingsSections(raws);
+
+    // allowedTools appears first (known section order)
+    expect(sections[0].title).toBe("Erlaubte Tools");
+    expect(sections[0].entries).toHaveLength(2);
+    expect(sections[0].entries[0].source).toBe("project");
+    expect(sections[0].entries[1].source).toBe("user");
+
+    // mcpServers
+    const mcpSection = sections.find((s) => s.title === "MCP-Server");
+    expect(mcpSection).toBeDefined();
+    expect(mcpSection!.entries[0].source).toBe("project");
+
+    // model
+    const modelSection = sections.find((s) => s.title === "Modell");
+    expect(modelSection).toBeDefined();
+    expect(modelSection!.entries[0].value).toBe("opus");
+    expect(modelSection!.entries[0].source).toBe("user");
+  });
+
+  it("excludes hooks key (shown in Hooks tab)", () => {
+    const raws = {
+      project: JSON.stringify({
+        hooks: { PreToolUse: [] },
+        allowedTools: ["Bash"],
+      }),
+      "project-local": "",
+      user: "",
+    };
+
+    const sections = buildSettingsSections(raws);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].title).toBe("Erlaubte Tools");
+  });
+
+  it("returns empty array when no settings exist", () => {
+    const sections = buildSettingsSections({ project: "", "project-local": "", user: "" });
+    expect(sections).toHaveLength(0);
+  });
+
+  it("handles invalid JSON gracefully", () => {
+    const sections = buildSettingsSections({
+      project: "broken{",
+      "project-local": "",
+      user: JSON.stringify({ model: "sonnet" }),
+    });
+    expect(sections).toHaveLength(1);
+    expect(sections[0].entries[0].source).toBe("user");
+  });
+
+  it("handles unknown keys with fallback title", () => {
+    const raws = {
+      project: JSON.stringify({ customKey: "value" }),
+      "project-local": "",
+      user: "",
+    };
+
+    const sections = buildSettingsSections(raws);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].title).toBe("customKey");
+  });
+});
+
+// ── Component tests: SettingsViewer ──
+
+describe("SettingsViewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows empty state when no settings configured", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    // All sources return only hooks (excluded) or empty
+    vi.mocked(invoke).mockResolvedValue(JSON.stringify({ hooks: {} }));
+
+    render(<SettingsViewer folder="/test" />);
+
+    expect(await screen.findByText("Keine Settings konfiguriert")).toBeTruthy();
+  });
+
+  it("renders settings sections with source badges", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const projectJson = JSON.stringify({
+      allowedTools: ["Bash", "Edit", "Read"],
+      mcpServers: { playwright: { command: "npx playwright" } },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: any) => {
+      if (cmd === "read_project_file" && args?.relativePath === ".claude/settings.json") {
+        return projectJson;
+      }
+      return "";
+    });
+
+    render(<SettingsViewer folder="/test" />);
+
+    // Wait for structured view
+    expect(await screen.findByText("Erlaubte Tools")).toBeTruthy();
+    expect(screen.getByText("MCP-Server")).toBeTruthy();
+    expect(screen.getByText("2 Kategorien")).toBeTruthy();
+
+    // Source badge
+    expect(screen.getAllByText("Projekt").length).toBeGreaterThanOrEqual(1);
+
+    // Tool list items
+    expect(screen.getByText("Bash")).toBeTruthy();
+    expect(screen.getByText("Edit")).toBeTruthy();
+    expect(screen.getByText("Read")).toBeTruthy();
+  });
+
+  it("toggles between structured and raw view", async () => {
+    const rawJson = JSON.stringify({ allowedTools: ["Bash"] });
+    const { invoke } = await import("@tauri-apps/api/core");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: any) => {
+      if (cmd === "read_project_file" && args?.relativePath === ".claude/settings.json") {
+        return rawJson;
+      }
+      return "";
+    });
+
+    render(<SettingsViewer folder="/test" />);
+
+    // Wait for structured view
+    expect(await screen.findByText("Erlaubte Tools")).toBeTruthy();
+
+    // Toggle to raw
+    const rawButton = screen.getByTitle("Raw JSON");
+    fireEvent.click(rawButton);
+
+    // Raw JSON should show the full JSON
+    expect(screen.getByText(rawJson)).toBeTruthy();
+  });
+
+  it("shows settings from multiple sources with correct attribution", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const projectJson = JSON.stringify({ allowedTools: ["Bash"] });
+    const userJson = JSON.stringify({ allowedTools: ["Read"], model: "opus" });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: any) => {
+      if (cmd === "read_project_file" && args?.relativePath === ".claude/settings.json") {
+        return projectJson;
+      }
+      if (cmd === "read_user_claude_file") {
+        return userJson;
+      }
+      return "";
+    });
+
+    render(<SettingsViewer folder="/test" />);
+
+    expect(await screen.findByText("Erlaubte Tools")).toBeTruthy();
+    expect(screen.getByText("Modell")).toBeTruthy();
+
+    // Both sources visible
+    expect(screen.getAllByText("Projekt").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("User").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/sessions/SettingsViewer.tsx
+++ b/src/components/sessions/SettingsViewer.tsx
@@ -1,0 +1,363 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { RefreshCw, Settings, Code2, Shield, ShieldOff, Server, Cpu } from "lucide-react";
+import { logError } from "../../utils/errorLogger";
+
+interface SettingsViewerProps {
+  folder: string;
+}
+
+type SettingsSource = "project" | "project-local" | "user";
+
+const SETTINGS_SOURCES: SettingsSource[] = ["project", "project-local", "user"];
+
+const SOURCE_META: Record<
+  SettingsSource,
+  { label: string; color: string; dot: string; path: string }
+> = {
+  project: {
+    label: "Projekt",
+    color: "bg-accent/15 text-accent",
+    dot: "bg-accent",
+    path: ".claude/settings.json",
+  },
+  "project-local": {
+    label: "Lokal",
+    color: "bg-yellow-500/15 text-yellow-400",
+    dot: "bg-yellow-500",
+    path: ".claude/settings.local.json",
+  },
+  user: {
+    label: "User",
+    color: "bg-purple-400/15 text-purple-300",
+    dot: "bg-purple-400",
+    path: "~/.claude/settings.json",
+  },
+};
+
+interface SettingsEntry {
+  key: string;
+  value: unknown;
+  source: SettingsSource;
+}
+
+interface SettingsSection {
+  title: string;
+  icon: typeof Shield;
+  entries: SettingsEntry[];
+}
+
+/** Known top-level keys and their display config */
+const SECTION_CONFIG: Record<string, { title: string; icon: typeof Shield }> = {
+  allowedTools: { title: "Erlaubte Tools", icon: Shield },
+  disallowedTools: { title: "Verbotene Tools", icon: ShieldOff },
+  mcpServers: { title: "MCP-Server", icon: Server },
+  model: { title: "Modell", icon: Cpu },
+  permissions: { title: "Berechtigungen", icon: Shield },
+};
+
+/** Keys that are displayed in dedicated tabs (Hooks) or not relevant for the overview */
+const EXCLUDED_KEYS = new Set(["hooks"]);
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function parseSettings(raw: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function buildSettingsSections(
+  raws: Record<SettingsSource, string>,
+): SettingsSection[] {
+  /** Collect entries grouped by key */
+  const keyMap = new Map<string, SettingsEntry[]>();
+
+  for (const source of SETTINGS_SOURCES) {
+    const raw = raws[source];
+    if (!raw) continue;
+    const parsed = parseSettings(raw);
+    if (!parsed) continue;
+
+    for (const [key, value] of Object.entries(parsed)) {
+      if (EXCLUDED_KEYS.has(key)) continue;
+      const existing = keyMap.get(key) ?? [];
+      existing.push({ key, value, source });
+      keyMap.set(key, existing);
+    }
+  }
+
+  const sections: SettingsSection[] = [];
+  for (const [key, entries] of keyMap) {
+    const config = SECTION_CONFIG[key] ?? { title: key, icon: Settings };
+    sections.push({ title: config.title, icon: config.icon, entries });
+  }
+
+  // Sort: known sections first (by SECTION_CONFIG order), then alphabetical
+  const knownOrder = Object.keys(SECTION_CONFIG);
+  sections.sort((a, b) => {
+    const aIdx = knownOrder.indexOf(
+      a.entries[0]?.key ?? "",
+    );
+    const bIdx = knownOrder.indexOf(
+      b.entries[0]?.key ?? "",
+    );
+    if (aIdx !== -1 && bIdx !== -1) return aIdx - bIdx;
+    if (aIdx !== -1) return -1;
+    if (bIdx !== -1) return 1;
+    return a.title.localeCompare(b.title);
+  });
+
+  return sections;
+}
+
+export function SettingsViewer({ folder }: SettingsViewerProps) {
+  const [raws, setRaws] = useState<Record<SettingsSource, string>>({
+    project: "",
+    "project-local": "",
+    user: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const [showRaw, setShowRaw] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const results = await Promise.allSettled([
+        invoke<string>("read_project_file", {
+          folder,
+          relativePath: ".claude/settings.json",
+        }),
+        invoke<string>("read_project_file", {
+          folder,
+          relativePath: ".claude/settings.local.json",
+        }),
+        invoke<string>("read_user_claude_file", {
+          relativePath: "settings.json",
+        }),
+      ]);
+
+      const values = results.map((r) =>
+        r.status === "fulfilled" ? (r.value ?? "") : "",
+      );
+
+      setRaws({
+        project: values[0],
+        "project-local": values[1],
+        user: values[2],
+      });
+    } catch (err) {
+      logError("SettingsViewer.load", err);
+      setRaws({ project: "", "project-local": "", user: "" });
+    } finally {
+      setLoading(false);
+    }
+  }, [folder]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const sections = useMemo(() => buildSettingsSections(raws), [raws]);
+
+  const activeSources = useMemo(() => {
+    const sources: { source: SettingsSource; raw: string }[] = [];
+    for (const s of SETTINGS_SOURCES) {
+      if (raws[s]) sources.push({ source: s, raw: raws[s] });
+    }
+    return sources;
+  }, [raws]);
+
+  const visibleSources = useMemo(
+    () => new Set(sections.flatMap((s) => s.entries.map((e) => e.source))),
+    [sections],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+        Lade Settings...
+      </div>
+    );
+  }
+
+  if (sections.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-3 text-neutral-500 px-6">
+        <Settings className="w-10 h-10 text-neutral-600" />
+        <span className="text-sm font-medium">Keine Settings konfiguriert</span>
+        <p className="text-xs text-neutral-600 text-center max-w-xs leading-relaxed">
+          Claude-Settings werden in{" "}
+          <code className="text-neutral-400">.claude/settings.json</code>{" "}
+          konfiguriert. Hooks werden im separaten{" "}
+          <code className="text-neutral-400">Hooks</code>-Tab angezeigt.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 shrink-0">
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-neutral-400 font-medium">
+            {sections.length}{" "}
+            {sections.length === 1 ? "Kategorie" : "Kategorien"}
+          </span>
+          {/* Source legend */}
+          <div className="flex items-center gap-2">
+            {SETTINGS_SOURCES.map((s) => {
+              const meta = SOURCE_META[s];
+              if (!visibleSources.has(s)) return null;
+              return (
+                <div
+                  key={s}
+                  className="flex items-center gap-1"
+                  title={meta.path}
+                >
+                  <span
+                    className={`w-1.5 h-1.5 rounded-full ${meta.dot}`}
+                  />
+                  <span className="text-[10px] text-neutral-500">
+                    {meta.label}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setShowRaw(!showRaw)}
+            className={`p-1 transition-colors rounded-sm ${
+              showRaw
+                ? "text-accent bg-accent-a10"
+                : "text-neutral-500 hover:text-neutral-300"
+            }`}
+            title={showRaw ? "Strukturierte Ansicht" : "Raw JSON"}
+          >
+            <Code2 className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={load}
+            className="p-1 text-neutral-500 hover:text-neutral-300 transition-colors"
+            title="Neu laden"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-4">
+        {showRaw ? (
+          <div className="space-y-3">
+            {activeSources.map(({ source, raw }) => (
+              <div key={source}>
+                <div className="flex items-center gap-2 mb-1.5">
+                  <span
+                    className={`w-1.5 h-1.5 rounded-full ${SOURCE_META[source].dot}`}
+                  />
+                  <span className="text-xs text-neutral-400 font-medium">
+                    {SOURCE_META[source].label}
+                  </span>
+                  <span className="text-[10px] text-neutral-600">
+                    {SOURCE_META[source].path}
+                  </span>
+                </div>
+                <pre className="text-xs text-neutral-200 whitespace-pre-wrap font-mono leading-relaxed bg-surface-raised rounded-sm p-3 border border-neutral-700">
+                  {raw}
+                </pre>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {sections.map((section) => (
+              <SectionCard key={section.title} section={section} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SourceBadge({ source }: { source: SettingsSource }) {
+  const meta = SOURCE_META[source];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded-sm ${meta.color}`}
+      title={meta.path}
+    >
+      <span className={`w-1.5 h-1.5 rounded-full ${meta.dot}`} />
+      {meta.label}
+    </span>
+  );
+}
+
+function SectionCard({ section }: { section: SettingsSection }) {
+  const Icon = section.icon;
+  return (
+    <div>
+      <div className="flex items-center gap-2 text-xs text-accent font-bold mb-2">
+        <Icon className="w-3.5 h-3.5" />
+        {section.title}
+      </div>
+      <div className="space-y-2">
+        {section.entries.map((entry, i) => (
+          <div
+            key={`${entry.source}-${i}`}
+            className="bg-surface-raised border border-neutral-700 rounded-sm px-3 py-2.5"
+          >
+            <div className="flex items-center gap-2 mb-1.5">
+              <SourceBadge source={entry.source} />
+            </div>
+            <SettingsValue value={entry.value} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SettingsValue({ value }: { value: unknown }) {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return (
+        <span className="text-xs text-neutral-500 italic">Leer</span>
+      );
+    }
+    return (
+      <ul className="space-y-1">
+        {value.map((item, i) => (
+          <li
+            key={i}
+            className="text-xs text-neutral-200 font-mono bg-neutral-900 px-2.5 py-1.5 rounded-sm"
+          >
+            {typeof item === "string" ? item : JSON.stringify(item)}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (value !== null && typeof value === "object") {
+    return (
+      <pre className="text-xs text-neutral-200 whitespace-pre-wrap font-mono leading-relaxed bg-neutral-900 rounded-sm px-3 py-2">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+
+  return (
+    <span className="text-xs text-neutral-200 font-mono">
+      {String(value)}
+    </span>
+  );
+}

--- a/src/components/sessions/configPanelShared.tsx
+++ b/src/components/sessions/configPanelShared.tsx
@@ -1,11 +1,12 @@
 import { lazy, Suspense } from "react";
-import { FileText, Puzzle, Webhook, Github, GitBranch, Columns3, Clock } from "lucide-react";
+import { FileText, Puzzle, Webhook, Settings, Github, GitBranch, Columns3, Clock } from "lucide-react";
 import type { ConfigSubTab } from "../../store/uiStore";
 import { isPinTab, getPinIdFromTab } from "../../store/uiStore";
 
 export const ClaudeMdViewer = lazy(() => import("./ClaudeMdViewer").then(m => ({ default: m.ClaudeMdViewer })));
 export const SkillsViewer = lazy(() => import("./SkillsViewer").then(m => ({ default: m.SkillsViewer })));
 export const HooksViewer = lazy(() => import("./HooksViewer").then(m => ({ default: m.HooksViewer })));
+export const SettingsViewer = lazy(() => import("./SettingsViewer").then(m => ({ default: m.SettingsViewer })));
 export const GitHubViewer = lazy(() => import("./GitHubViewer").then(m => ({ default: m.GitHubViewer })));
 export const WorktreeViewer = lazy(() => import("./WorktreeViewer").then(m => ({ default: m.WorktreeViewer })));
 export const KanbanBoard = lazy(() => import("../kanban/KanbanBoard").then(m => ({ default: m.KanbanBoard })));
@@ -26,6 +27,7 @@ export const CONFIG_TABS: ConfigTab[] = [
   { id: "claude-md", label: "CLAUDE.md", icon: FileText, group: "context" },
   { id: "skills", label: "Skills", icon: Puzzle, group: "context" },
   { id: "hooks", label: "Hooks", icon: Webhook, group: "context" },
+  { id: "settings", label: "Settings", icon: Settings, group: "context" },
   { id: "github", label: "GitHub", icon: Github, group: "project" },
   { id: "worktrees", label: "Worktrees", icon: GitBranch, group: "project" },
   { id: "kanban", label: "Kanban", icon: Columns3, group: "project" },
@@ -57,6 +59,8 @@ export function ConfigPanelContent({ folder, activeTab, onResumeSession }: Confi
         <SkillsViewer folder={folder} />
       ) : activeTab === "hooks" ? (
         <HooksViewer folder={folder} />
+      ) : activeTab === "settings" ? (
+        <SettingsViewer folder={folder} />
       ) : activeTab === "github" ? (
         <GitHubViewer folder={folder} />
       ) : activeTab === "worktrees" ? (

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -6,6 +6,7 @@ export type ConfigSubTab =
   | "claude-md"
   | "skills"
   | "hooks"
+  | "settings"
   | "github"
   | "worktrees"
   | "kanban"


### PR DESCRIPTION
## Summary
- Add new **Settings** tab to Config Panel displaying project-specific Claude settings
- Loads settings from 3 sources: `.claude/settings.json` (project), `.claude/settings.local.json` (project-local), `~/.claude/settings.json` (user-global)
- Structured view with sections for allowedTools, disallowedTools, mcpServers, model, permissions + raw JSON toggle
- Source badges (Projekt/Lokal/User) indicate where each setting comes from
- Hooks excluded from display (already shown in dedicated Hooks tab)

## Test plan
- [x] 9 unit tests for `parseSettings` and `buildSettingsSections`
- [x] 4 component tests for SettingsViewer (empty state, structured view, raw toggle, multi-source)
- [x] All 649 existing tests pass
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] ESLint clean (max-warnings=0)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)