### PR TITLE
fix(ui): show agents from .claude/agents/ in Config Panel (#115)

### DIFF
--- a/src/components/sessions/AgentsViewer.test.tsx
+++ b/src/components/sessions/AgentsViewer.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { AgentsViewer } from "./AgentsViewer";
+
+// Mock @tauri-apps/api/core
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+describe("AgentsViewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders agent list when agents exist", async () => {
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "list_project_dir") {
+        return Promise.resolve(["architect.md", "test-engineer.md"]);
+      }
+      if (cmd === "read_project_file") {
+        const path = args?.relativePath as string;
+        if (path.includes("architect")) {
+          return Promise.resolve(
+            "---\nmodel: opus\nmax-turns: 20\n---\n\n# Architect Agent\n\nPlanning agent.",
+          );
+        }
+        if (path.includes("test-engineer")) {
+          return Promise.resolve(
+            "---\nmodel: sonnet\n---\n\n# Test Engineer\n\nWrites tests.",
+          );
+        }
+      }
+      return Promise.reject(new Error("unknown command"));
+    });
+
+    render(<AgentsViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Agents (2)")).toBeInTheDocument();
+    });
+
+    // "architect" appears in both list and detail pane (auto-selected first item)
+    expect(screen.getAllByText("architect").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("test-engineer")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no agents directory exists", async () => {
+    mockInvoke.mockRejectedValue(new Error("directory not found"));
+
+    render(<AgentsViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Keine Agents in diesem Projekt konfiguriert"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when directory has no .md files", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_project_dir") {
+        return Promise.resolve(["readme.txt", "config.json"]);
+      }
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<AgentsViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Keine Agents in diesem Projekt konfiguriert"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/sessions/AgentsViewer.tsx
+++ b/src/components/sessions/AgentsViewer.tsx
@@ -1,0 +1,267 @@
+import { useState, useEffect, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { RefreshCw, Bot } from "lucide-react";
+import {
+  parseAgentFrontmatter,
+  type ParsedAgent,
+} from "../../utils/parseAgentFrontmatter";
+
+interface AgentsViewerProps {
+  folder: string;
+}
+
+interface AgentEntry {
+  id: string;
+  fileName: string;
+  parsed: ParsedAgent;
+}
+
+export function AgentsViewer({ folder }: AgentsViewerProps) {
+  const [agents, setAgents] = useState<AgentEntry[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+
+  const loadAgents = async () => {
+    setLoading(true);
+    try {
+      const files = await invoke<string[]>("list_project_dir", {
+        folder,
+        relativePath: ".claude/agents",
+      });
+      const mdFiles = files.filter((f) => f.endsWith(".md"));
+
+      const entries: AgentEntry[] = [];
+      for (const name of mdFiles) {
+        try {
+          const content = await invoke<string>("read_project_file", {
+            folder,
+            relativePath: `.claude/agents/${name}`,
+          });
+          const parsed = parseAgentFrontmatter(content, name);
+          entries.push({ id: name, fileName: name, parsed });
+        } catch {
+          // Skip unreadable files
+        }
+      }
+
+      setAgents(entries);
+      if (entries.length > 0 && !selectedId) {
+        setSelectedId(entries[0].id);
+      }
+    } catch {
+      setAgents([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    setSelectedId(null);
+    setSearch("");
+    loadAgents();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reload only on folder change
+  }, [folder]);
+
+  const filteredAgents = useMemo(() => {
+    if (!search.trim()) return agents;
+    const q = search.toLowerCase();
+    return agents.filter(
+      (a) =>
+        a.parsed.metadata.name.toLowerCase().includes(q) ||
+        a.parsed.metadata.description.toLowerCase().includes(q) ||
+        a.parsed.metadata.model.toLowerCase().includes(q),
+    );
+  }, [agents, search]);
+
+  const selectedAgent = useMemo(
+    () => agents.find((a) => a.id === selectedId) ?? null,
+    [agents, selectedId],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+        Lade Agents...
+      </div>
+    );
+  }
+
+  if (agents.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-3 text-neutral-500">
+        <Bot className="w-10 h-10 text-neutral-600" />
+        <span className="text-sm">Keine Agents in diesem Projekt konfiguriert</span>
+        <span className="text-xs text-neutral-600">.claude/agents/</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full">
+      {/* Left column — agent list */}
+      <div className="w-64 min-w-[256px] border-r border-neutral-700 flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-700 shrink-0">
+          <span className="text-xs text-neutral-400 font-medium">
+            Agents ({agents.length})
+          </span>
+          <button
+            onClick={loadAgents}
+            className="p-1 text-neutral-500 hover:text-neutral-300 transition-colors"
+            title="Neu laden"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="px-3 py-2 border-b border-neutral-700 shrink-0">
+          <input
+            type="text"
+            placeholder="Suchen..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full bg-surface-base border border-neutral-700 rounded px-2 py-1 text-xs text-neutral-200 placeholder-neutral-500 focus:outline-none focus:border-neutral-500"
+          />
+        </div>
+
+        {/* Agent cards */}
+        <div className="flex-1 overflow-auto">
+          {filteredAgents.length === 0 ? (
+            <div className="px-3 py-4 text-xs text-neutral-500 text-center">
+              Keine Agents gefunden
+            </div>
+          ) : (
+            filteredAgents.map((entry) => {
+              const { metadata } = entry.parsed;
+              const isActive = selectedId === entry.id;
+              return (
+                <button
+                  key={entry.id}
+                  onClick={() => setSelectedId(entry.id)}
+                  className={`w-full text-left px-3 py-2 transition-colors border-l-2 ${
+                    isActive
+                      ? "border-accent bg-accent-a10"
+                      : "border-transparent hover:bg-hover-overlay"
+                  }`}
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className={`text-xs font-semibold truncate ${
+                        isActive ? "text-accent" : "text-neutral-200"
+                      }`}
+                    >
+                      {metadata.name}
+                    </span>
+                  </div>
+                  {metadata.description && (
+                    <div className="text-xs text-neutral-400 truncate mt-0.5">
+                      {metadata.description}
+                    </div>
+                  )}
+                  {metadata.model && (
+                    <div className="mt-1">
+                      <span className="inline-block px-1.5 py-0 text-[10px] rounded-full bg-neutral-800 text-neutral-500">
+                        {metadata.model}
+                      </span>
+                    </div>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      {/* Right column — detail */}
+      <div className="flex-1 overflow-auto p-4">
+        {selectedAgent ? (
+          <AgentDetail entry={selectedAgent} />
+        ) : (
+          <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+            Agent auswaehlen
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AgentDetail({ entry }: { entry: AgentEntry }) {
+  const { metadata, body } = entry.parsed;
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <h2 className="text-base font-semibold text-neutral-200">
+            {metadata.name}
+          </h2>
+          {metadata.model && (
+            <span className="inline-block px-1.5 py-0 text-[10px] rounded-full bg-neutral-800 text-neutral-400">
+              {metadata.model}
+            </span>
+          )}
+        </div>
+        {metadata.description && (
+          <p className="text-sm text-neutral-400">{metadata.description}</p>
+        )}
+      </div>
+
+      {/* Metadata fields */}
+      <div className="grid grid-cols-2 gap-2">
+        {metadata.maxTurns !== null && (
+          <div className="bg-surface-raised rounded px-3 py-2">
+            <span className="text-[10px] text-neutral-500 uppercase tracking-wider">
+              Max Turns
+            </span>
+            <div className="text-xs text-neutral-200 font-mono mt-0.5">
+              {metadata.maxTurns}
+            </div>
+          </div>
+        )}
+        <div className="bg-surface-raised rounded px-3 py-2">
+          <span className="text-[10px] text-neutral-500 uppercase tracking-wider">
+            Datei
+          </span>
+          <div className="text-xs text-neutral-200 font-mono mt-0.5 truncate">
+            .claude/agents/{entry.fileName}
+          </div>
+        </div>
+      </div>
+
+      {/* Allowed Tools */}
+      {metadata.allowedTools.length > 0 && (
+        <div>
+          <h3 className="text-xs font-medium text-neutral-400 uppercase tracking-wider mb-2">
+            Erlaubte Tools
+          </h3>
+          <div className="flex flex-wrap gap-1.5">
+            {metadata.allowedTools.map((tool) => (
+              <span
+                key={tool}
+                className="inline-block px-2 py-0.5 text-xs rounded-full bg-surface-raised text-neutral-300 font-mono"
+              >
+                {tool}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Body */}
+      {body && (
+        <div>
+          <h3 className="text-xs font-medium text-neutral-400 uppercase tracking-wider mb-2">
+            Inhalt
+          </h3>
+          <pre className="text-sm text-neutral-200 whitespace-pre-wrap font-mono leading-relaxed bg-surface-raised rounded p-3">
+            {body}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sessions/configPanelShared.tsx
+++ b/src/components/sessions/configPanelShared.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react";
-import { FileText, Puzzle, Webhook, Settings, Github, GitBranch, Columns3, Clock } from "lucide-react";
+import { FileText, Puzzle, Webhook, Settings, Bot, Github, GitBranch, Columns3, Clock } from "lucide-react";
 import type { ConfigSubTab } from "../../store/uiStore";
 import { isPinTab, getPinIdFromTab } from "../../store/uiStore";
 
@@ -7,6 +7,7 @@ export const ClaudeMdViewer = lazy(() => import("./ClaudeMdViewer").then(m => ({
 export const SkillsViewer = lazy(() => import("./SkillsViewer").then(m => ({ default: m.SkillsViewer })));
 export const HooksViewer = lazy(() => import("./HooksViewer").then(m => ({ default: m.HooksViewer })));
 export const SettingsViewer = lazy(() => import("./SettingsViewer").then(m => ({ default: m.SettingsViewer })));
+export const AgentsViewer = lazy(() => import("./AgentsViewer").then(m => ({ default: m.AgentsViewer })));
 export const GitHubViewer = lazy(() => import("./GitHubViewer").then(m => ({ default: m.GitHubViewer })));
 export const WorktreeViewer = lazy(() => import("./WorktreeViewer").then(m => ({ default: m.WorktreeViewer })));
 export const KanbanBoard = lazy(() => import("../kanban/KanbanBoard").then(m => ({ default: m.KanbanBoard })));
@@ -28,6 +29,7 @@ export const CONFIG_TABS: ConfigTab[] = [
   { id: "skills", label: "Skills", icon: Puzzle, group: "context" },
   { id: "hooks", label: "Hooks", icon: Webhook, group: "context" },
   { id: "settings", label: "Settings", icon: Settings, group: "context" },
+  { id: "agents", label: "Agents", icon: Bot, group: "context" },
   { id: "github", label: "GitHub", icon: Github, group: "project" },
   { id: "worktrees", label: "Worktrees", icon: GitBranch, group: "project" },
   { id: "kanban", label: "Kanban", icon: Columns3, group: "project" },
@@ -61,6 +63,8 @@ export function ConfigPanelContent({ folder, activeTab, onResumeSession }: Confi
         <HooksViewer folder={folder} />
       ) : activeTab === "settings" ? (
         <SettingsViewer folder={folder} />
+      ) : activeTab === "agents" ? (
+        <AgentsViewer folder={folder} />
       ) : activeTab === "github" ? (
         <GitHubViewer folder={folder} />
       ) : activeTab === "worktrees" ? (

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -7,6 +7,7 @@ export type ConfigSubTab =
   | "skills"
   | "hooks"
   | "settings"
+  | "agents"
   | "github"
   | "worktrees"
   | "kanban"

--- a/src/utils/parseAgentFrontmatter.test.ts
+++ b/src/utils/parseAgentFrontmatter.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { parseAgentFrontmatter } from "./parseAgentFrontmatter";
+
+describe("parseAgentFrontmatter", () => {
+  it("parses full frontmatter with all fields", () => {
+    const content = [
+      "---",
+      "model: opus",
+      "max-turns: 20",
+      "allowed-tools: Read, Glob, Grep, Bash(ls *)",
+      "---",
+      "",
+      "# Architect Agent",
+      "",
+      "You are a planning agent.",
+    ].join("\n");
+
+    const result = parseAgentFrontmatter(content, "architect.md");
+
+    expect(result.metadata.name).toBe("architect");
+    expect(result.metadata.model).toBe("opus");
+    expect(result.metadata.maxTurns).toBe(20);
+    expect(result.metadata.allowedTools).toEqual([
+      "Read",
+      "Glob",
+      "Grep",
+      "Bash(ls *)",
+    ]);
+    expect(result.metadata.description).toBe("Architect Agent");
+    expect(result.body).toContain("You are a planning agent.");
+  });
+
+  it("uses filename as name when no name in frontmatter", () => {
+    const content = "---\nmodel: sonnet\n---\n\nSome body.";
+    const result = parseAgentFrontmatter(content, "test-engineer.md");
+
+    expect(result.metadata.name).toBe("test-engineer");
+    expect(result.metadata.model).toBe("sonnet");
+  });
+
+  it("handles content without frontmatter", () => {
+    const content = "# Simple Agent\n\nNo frontmatter here.";
+    const result = parseAgentFrontmatter(content, "simple.md");
+
+    expect(result.metadata.name).toBe("simple");
+    expect(result.metadata.model).toBe("");
+    expect(result.metadata.maxTurns).toBeNull();
+    expect(result.metadata.allowedTools).toEqual([]);
+    expect(result.metadata.description).toBe("Simple Agent");
+    expect(result.body).toBe(content);
+  });
+
+  it("handles empty content gracefully", () => {
+    const result = parseAgentFrontmatter("", "empty.md");
+
+    expect(result.metadata.name).toBe("empty");
+    expect(result.metadata.description).toBe("");
+    expect(result.body).toBe("");
+  });
+
+  it("falls back to 'Unknown' when no filename provided", () => {
+    const result = parseAgentFrontmatter("Some content");
+    expect(result.metadata.name).toBe("Unknown");
+  });
+
+  it("handles malformed frontmatter (no closing delimiter)", () => {
+    const content = "---\nmodel: opus\nThis never closes";
+    const result = parseAgentFrontmatter(content, "broken.md");
+
+    expect(result.metadata.name).toBe("broken");
+    // Falls back to extracting description from content
+    expect(result.body).toBe(content);
+  });
+
+  it("extracts description from first non-heading line if no heading", () => {
+    const content = "---\nmodel: opus\n---\n\nThis is a plain description.";
+    const result = parseAgentFrontmatter(content, "agent.md");
+
+    expect(result.metadata.description).toBe("This is a plain description.");
+  });
+
+  it("respects explicit name and description in frontmatter", () => {
+    const content = [
+      "---",
+      "name: Custom Name",
+      "description: Custom description",
+      "model: haiku",
+      "---",
+      "",
+      "# Heading ignored for description",
+    ].join("\n");
+
+    const result = parseAgentFrontmatter(content, "agent.md");
+
+    expect(result.metadata.name).toBe("Custom Name");
+    expect(result.metadata.description).toBe("Custom description");
+  });
+});

--- a/src/utils/parseAgentFrontmatter.ts
+++ b/src/utils/parseAgentFrontmatter.ts
@@ -1,0 +1,110 @@
+export interface AgentMetadata {
+  name: string;
+  description: string;
+  model: string;
+  maxTurns: number | null;
+  allowedTools: string[];
+}
+
+export interface ParsedAgent {
+  metadata: AgentMetadata;
+  body: string;
+}
+
+/**
+ * Parse a `.claude/agents/*.md` file into structured metadata + body.
+ *
+ * Agent frontmatter uses YAML-like key-value pairs:
+ * ```
+ * ---
+ * model: opus
+ * max-turns: 20
+ * allowed-tools: Read, Glob, Grep, Bash(ls *)
+ * ---
+ * ```
+ */
+export function parseAgentFrontmatter(
+  content: string,
+  fileName?: string,
+): ParsedAgent {
+  const fallbackName = fileName?.replace(/\.md$/i, "") ?? "Unknown";
+
+  const defaultMetadata: AgentMetadata = {
+    name: fallbackName,
+    description: "",
+    model: "",
+    maxTurns: null,
+    allowedTools: [],
+  };
+
+  if (!content.startsWith("---")) {
+    return {
+      metadata: { ...defaultMetadata, description: extractFirstHeadingOrLine(content) },
+      body: content,
+    };
+  }
+
+  const secondDelim = content.indexOf("\n---", 3);
+  if (secondDelim === -1) {
+    return {
+      metadata: { ...defaultMetadata, description: extractFirstHeadingOrLine(content) },
+      body: content,
+    };
+  }
+
+  const frontmatterBlock = content.substring(3, secondDelim).trim();
+  const body = content.substring(secondDelim + 4).trim();
+
+  const metadata: AgentMetadata = { ...defaultMetadata };
+
+  for (const line of frontmatterBlock.split("\n")) {
+    const kvMatch = line.trim().match(/^([\w-]+):\s*(.*)/);
+    if (!kvMatch) continue;
+
+    const key = kvMatch[1];
+    const value = kvMatch[2].trim();
+
+    switch (key) {
+      case "model":
+        metadata.model = value;
+        break;
+      case "max-turns": {
+        const n = parseInt(value, 10);
+        if (!isNaN(n)) metadata.maxTurns = n;
+        break;
+      }
+      case "allowed-tools":
+        metadata.allowedTools = value
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean);
+        break;
+      case "name":
+        metadata.name = value || fallbackName;
+        break;
+      case "description":
+        metadata.description = value;
+        break;
+    }
+  }
+
+  // If no explicit description, derive from first heading or line of body
+  if (!metadata.description && body) {
+    metadata.description = extractFirstHeadingOrLine(body);
+  }
+
+  return { metadata, body };
+}
+
+/** Extract text from the first markdown heading, or the first non-empty line. */
+function extractFirstHeadingOrLine(text: string): string {
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // Strip markdown heading markers
+    const headingMatch = trimmed.match(/^#{1,6}\s+(.+)/);
+    if (headingMatch) return headingMatch[1].trim();
+    return trimmed;
+  }
+  return "";
+}


### PR DESCRIPTION
## Summary
- Add new **Agents** tab to the Config Panel that reads `.claude/agents/*.md` files
- Parse YAML frontmatter (model, max-turns, allowed-tools) and display in list/detail layout
- Follow existing SkillsViewer pattern: left list with search, right detail pane with metadata + content

## Changes
| File | Change |
|------|--------|
| `src/store/uiStore.ts` | Add `"agents"` to `ConfigSubTab` union |
| `src/components/sessions/configPanelShared.tsx` | Register AgentsViewer (lazy import, tab entry, content route) |
| `src/components/sessions/AgentsViewer.tsx` | **New** — Agent list/detail viewer component |
| `src/utils/parseAgentFrontmatter.ts` | **New** — Frontmatter parser for agent .md files |
| `src/utils/parseAgentFrontmatter.test.ts` | **New** — 8 unit tests for parser |
| `src/components/sessions/AgentsViewer.test.tsx` | **New** — 3 component tests (happy path, empty states) |

## Test plan
- [x] 8 unit tests for `parseAgentFrontmatter` (full frontmatter, partial, no frontmatter, empty, malformed)
- [x] 3 component tests for `AgentsViewer` (renders list, empty directory, no .md files)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] All 647 tests pass

Closes #115

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>