### PR TITLE
test(kanban): add tests for kanban module (#90, #66)

### DIFF
--- a/src/components/kanban/KanbanBoard.test.tsx
+++ b/src/components/kanban/KanbanBoard.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { KanbanBoard } from "./KanbanBoard";
+import { invoke } from "@tauri-apps/api/core";
+import type { KanbanIssue } from "./KanbanCard";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn(),
+}));
+
+vi.mock("../../utils/errorLogger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+// Mock framer-motion to avoid animation issues in tests
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => {
+      // Filter out framer-motion specific props
+      const {
+        initial: _i,
+        animate: _a,
+        exit: _e,
+        transition: _t,
+        ...rest
+      } = props;
+      return <div {...rest}>{children}</div>;
+    },
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const mockInvoke = vi.mocked(invoke);
+
+function makeIssues(): KanbanIssue[] {
+  return [
+    {
+      number: 1,
+      title: "Backlog issue",
+      state: "OPEN",
+      labels: [],
+      assignee: "",
+      url: "https://github.com/org/repo/issues/1",
+    },
+    {
+      number: 2,
+      title: "Todo issue",
+      state: "OPEN",
+      labels: [{ name: "todo", color: "0075ca" }],
+      assignee: "bob",
+      url: "https://github.com/org/repo/issues/2",
+    },
+    {
+      number: 3,
+      title: "In progress issue",
+      state: "OPEN",
+      labels: [{ name: "in-progress", color: "e4e669" }],
+      assignee: "alice",
+      url: "https://github.com/org/repo/issues/3",
+    },
+    {
+      number: 4,
+      title: "Done issue",
+      state: "CLOSED",
+      labels: [],
+      assignee: "",
+      url: "https://github.com/org/repo/issues/4",
+    },
+    {
+      number: 5,
+      title: "Sprint issue",
+      state: "OPEN",
+      labels: [{ name: "sprint", color: "aabbcc" }],
+      assignee: "",
+      url: "https://github.com/org/repo/issues/5",
+    },
+    {
+      number: 6,
+      title: "Done label issue",
+      state: "OPEN",
+      labels: [{ name: "done", color: "00ff00" }],
+      assignee: "",
+      url: "https://github.com/org/repo/issues/6",
+    },
+  ];
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("KanbanBoard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    // Never resolve the invoke
+    mockInvoke.mockReturnValue(new Promise(() => {}));
+    render(<KanbanBoard folder="/test/loading" />);
+
+    expect(screen.getByText("Lade Kanban-Daten...")).toBeTruthy();
+  });
+
+  it("renders columns with classified issues after loading", async () => {
+    mockInvoke.mockResolvedValueOnce(makeIssues());
+
+    render(<KanbanBoard folder="/test/columns" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Kanban (6 Issues)")).toBeTruthy();
+    });
+
+    // Column headers
+    expect(screen.getByText("Backlog")).toBeTruthy();
+    expect(screen.getByText("To Do")).toBeTruthy();
+    expect(screen.getByText("In Arbeit")).toBeTruthy();
+    expect(screen.getByText("Erledigt")).toBeTruthy();
+
+    // Issue titles in correct columns
+    expect(screen.getByText("Backlog issue")).toBeTruthy();
+    expect(screen.getByText("Todo issue")).toBeTruthy();
+    expect(screen.getByText("In progress issue")).toBeTruthy();
+    expect(screen.getByText("Done issue")).toBeTruthy();
+    // sprint label → in-progress column
+    expect(screen.getByText("Sprint issue")).toBeTruthy();
+    // done label → done column
+    expect(screen.getByText("Done label issue")).toBeTruthy();
+  });
+
+  it("shows error state with retry button on fetch failure", async () => {
+    mockInvoke.mockRejectedValueOnce(new Error("Network error"));
+
+    render(<KanbanBoard folder="/test/error" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Fehler beim Laden der Issues"),
+      ).toBeTruthy();
+    });
+
+    expect(screen.getByText("Network error")).toBeTruthy();
+    expect(screen.getByText("Erneut versuchen")).toBeTruthy();
+  });
+
+  it("shows gh CLI hint when error contains 'not found'", async () => {
+    mockInvoke.mockRejectedValueOnce(new Error("gh not found"));
+
+    render(<KanbanBoard folder="/test/notfound" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/gh CLI nicht gefunden/),
+      ).toBeTruthy();
+    });
+  });
+
+  it("shows 'Keine Issues' for empty columns", async () => {
+    // Return a single issue so board renders but most columns are empty
+    mockInvoke.mockResolvedValueOnce([
+      {
+        number: 1,
+        title: "Only issue",
+        state: "OPEN",
+        labels: [{ name: "todo", color: "0075ca" }],
+        assignee: "",
+        url: "",
+      },
+    ]);
+
+    render(<KanbanBoard folder="/test/empty-cols" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Kanban (1 Issues)")).toBeTruthy();
+    });
+
+    // Three columns should show "Keine Issues" (backlog, in-progress, done)
+    const emptyMessages = screen.getAllByText("Keine Issues");
+    expect(emptyMessages.length).toBe(3);
+  });
+
+  it("renders with zero issues (all columns empty)", async () => {
+    mockInvoke.mockResolvedValueOnce([]);
+
+    render(<KanbanBoard folder="/test/zero" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Kanban (0 Issues)")).toBeTruthy();
+    });
+
+    const emptyMessages = screen.getAllByText("Keine Issues");
+    expect(emptyMessages.length).toBe(4);
+  });
+});

--- a/src/components/kanban/KanbanCard.test.tsx
+++ b/src/components/kanban/KanbanCard.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { KanbanCard, type KanbanIssue } from "./KanbanCard";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+const mockOpen = vi.fn();
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: (...args: unknown[]) => mockOpen(...args),
+}));
+
+vi.mock("../../utils/errorLogger", () => ({
+  logWarn: vi.fn(),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function makeIssue(overrides: Partial<KanbanIssue> = {}): KanbanIssue {
+  return {
+    number: 42,
+    title: "Implement feature X",
+    state: "OPEN",
+    labels: [{ name: "bug", color: "d73a4a" }],
+    assignee: "alice",
+    url: "https://github.com/org/repo/issues/42",
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("KanbanCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOpen.mockResolvedValue(undefined);
+  });
+
+  it("renders issue number, title, labels, and assignee", () => {
+    render(<KanbanCard issue={makeIssue()} />);
+
+    expect(screen.getByText("#42")).toBeTruthy();
+    expect(screen.getByText("Implement feature X")).toBeTruthy();
+    expect(screen.getByText("bug")).toBeTruthy();
+    expect(screen.getByText("alice")).toBeTruthy();
+  });
+
+  it("renders multiple labels with correct styling", () => {
+    const issue = makeIssue({
+      labels: [
+        { name: "bug", color: "d73a4a" },
+        { name: "priority", color: "#ff0000" },
+      ],
+    });
+    render(<KanbanCard issue={issue} />);
+
+    const bugLabel = screen.getByText("bug");
+    expect(bugLabel).toBeTruthy();
+    // jsdom normalizes hex to rgb
+    expect(bugLabel.style.color).toBe("rgb(215, 58, 74)");
+
+    const priorityLabel = screen.getByText("priority");
+    expect(priorityLabel).toBeTruthy();
+    expect(priorityLabel.style.color).toBe("rgb(255, 0, 0)");
+  });
+
+  it("hides assignee when empty", () => {
+    render(<KanbanCard issue={makeIssue({ assignee: "" })} />);
+
+    expect(screen.queryByText("alice")).toBeNull();
+  });
+
+  it("calls onClick when card is clicked", () => {
+    const onClick = vi.fn();
+    render(<KanbanCard issue={makeIssue()} onClick={onClick} />);
+
+    fireEvent.click(screen.getByText("Implement feature X"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDragStart and sets dataTransfer on drag", () => {
+    const onDragStart = vi.fn();
+    const { container } = render(
+      <KanbanCard issue={makeIssue()} onDragStart={onDragStart} />,
+    );
+
+    const card = container.firstElementChild!;
+    const dataTransfer = { setData: vi.fn(), effectAllowed: "" };
+    fireEvent.dragStart(card, { dataTransfer });
+
+    expect(dataTransfer.setData).toHaveBeenCalledWith("text/plain", "42");
+    expect(onDragStart).toHaveBeenCalledOnce();
+  });
+
+  it("opens URL in browser when external link button is clicked", async () => {
+    render(<KanbanCard issue={makeIssue()} />);
+
+    const linkButton = screen.getByTitle("Im Browser oeffnen");
+    fireEvent.click(linkButton);
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      "https://github.com/org/repo/issues/42",
+    );
+  });
+
+  it("does not render external link button when url is empty", () => {
+    render(<KanbanCard issue={makeIssue({ url: "" })} />);
+
+    expect(screen.queryByTitle("Im Browser oeffnen")).toBeNull();
+  });
+
+  it("external link click does not propagate to card onClick", () => {
+    const onClick = vi.fn();
+    render(<KanbanCard issue={makeIssue()} onClick={onClick} />);
+
+    const linkButton = screen.getByTitle("Im Browser oeffnen");
+    fireEvent.click(linkButton);
+
+    // stopPropagation prevents onClick on card
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/kanban/KanbanDashboardView.test.tsx
+++ b/src/components/kanban/KanbanDashboardView.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { KanbanDashboardView } from "./KanbanDashboardView";
+import { useSessionStore } from "../../store/sessionStore";
+import { useSettingsStore } from "../../store/settingsStore";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn(),
+}));
+
+// Mock KanbanBoard to avoid its async data fetching
+vi.mock("./KanbanBoard", () => ({
+  KanbanBoard: ({ folder }: { folder: string }) => (
+    <div data-testid="kanban-board">{folder}</div>
+  ),
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("KanbanDashboardView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset stores to defaults
+    useSessionStore.setState({
+      sessions: [],
+      activeSessionId: null,
+    });
+    useSettingsStore.setState({
+      favorites: [],
+    });
+  });
+
+  it("shows empty state when no folder and no favorites", () => {
+    render(<KanbanDashboardView />);
+
+    expect(screen.getByText("Kein Projekt verfuegbar")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Erstelle eine Session oder fuege einen Favoriten hinzu.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("renders KanbanBoard with active session folder", () => {
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: "s1",
+          title: "My Session",
+          folder: "/projects/my-app",
+          shell: "powershell",
+          status: "running",
+          createdAt: Date.now(),
+          finishedAt: null,
+          exitCode: null,
+          lastOutputAt: Date.now(),
+          lastOutputSnippet: "",
+        },
+      ],
+      activeSessionId: "s1",
+    });
+
+    render(<KanbanDashboardView />);
+
+    const board = screen.getByTestId("kanban-board");
+    expect(board.textContent).toBe("/projects/my-app");
+  });
+
+  it("renders folder picker with favorites", () => {
+    useSettingsStore.setState({
+      favorites: [
+        {
+          id: "fav-1",
+          path: "/projects/fav-project",
+          label: "Fav Project",
+          shell: "powershell",
+          addedAt: Date.now(),
+          lastUsedAt: Date.now(),
+        },
+      ],
+    });
+
+    render(<KanbanDashboardView />);
+
+    // Folder picker should show the favorite
+    expect(screen.getByText("Fav Project")).toBeTruthy();
+  });
+
+  it("switches folder when user selects from picker", () => {
+    useSettingsStore.setState({
+      favorites: [
+        {
+          id: "fav-1",
+          path: "/projects/alpha",
+          label: "Alpha",
+          shell: "powershell",
+          addedAt: Date.now(),
+          lastUsedAt: Date.now(),
+        },
+        {
+          id: "fav-2",
+          path: "/projects/beta",
+          label: "Beta",
+          shell: "powershell",
+          addedAt: Date.now(),
+          lastUsedAt: Date.now(),
+        },
+      ],
+    });
+
+    render(<KanbanDashboardView />);
+
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "/projects/beta" } });
+
+    const board = screen.getByTestId("kanban-board");
+    expect(board.textContent).toBe("/projects/beta");
+  });
+
+  it("shows 'Projekt auswaehlen' when favorites exist but none selected and no session", () => {
+    useSettingsStore.setState({
+      favorites: [
+        {
+          id: "fav-1",
+          path: "/projects/alpha",
+          label: "Alpha",
+          shell: "powershell",
+          addedAt: Date.now(),
+          lastUsedAt: Date.now(),
+        },
+      ],
+    });
+
+    render(<KanbanDashboardView />);
+
+    // Select empty value to deselect
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "" } });
+
+    expect(screen.getByText("Projekt auswaehlen")).toBeTruthy();
+  });
+});

--- a/src/components/kanban/KanbanDetailModal.test.tsx
+++ b/src/components/kanban/KanbanDetailModal.test.tsx
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { KanbanDetailModal } from "./KanbanDetailModal";
+import { invoke } from "@tauri-apps/api/core";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn(),
+}));
+
+// Mock framer-motion to render synchronously
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => {
+      const {
+        initial: _i,
+        animate: _a,
+        exit: _e,
+        transition: _t,
+        ...rest
+      } = props;
+      return <div {...rest}>{children}</div>;
+    },
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const mockInvoke = vi.mocked(invoke);
+
+function makeIssueDetail() {
+  return {
+    number: 42,
+    title: "Fix login bug",
+    body: "The login form does not validate email.",
+    state: "OPEN",
+    author: "alice",
+    created_at: "2026-03-15T10:00:00Z",
+    closed_at: "",
+    labels: [
+      { name: "bug", color: "d73a4a" },
+      { name: "priority", color: "ff0000" },
+    ],
+    assignee: "bob",
+    url: "https://github.com/org/repo/issues/42",
+    comments: [
+      {
+        author: "charlie",
+        body: "I can reproduce this.",
+        created_at: "2026-03-16T08:00:00Z",
+      },
+    ],
+  };
+}
+
+function makeLinkedPRs() {
+  return [
+    {
+      number: 50,
+      title: "Fix login validation",
+      state: "MERGED",
+      url: "https://github.com/org/repo/pull/50",
+      checks: [
+        { name: "CI", status: "COMPLETED", conclusion: "SUCCESS" },
+        { name: "Lint", status: "COMPLETED", conclusion: "FAILURE" },
+        { name: "Build", status: "IN_PROGRESS", conclusion: "" },
+      ],
+    },
+  ];
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("KanbanDetailModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state while fetching", () => {
+    mockInvoke.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Laden...")).toBeTruthy();
+    expect(screen.getByText("#42")).toBeTruthy();
+  });
+
+  it("renders issue details after loading", async () => {
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(makeIssueDetail());
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeTruthy();
+    });
+
+    // State badge
+    expect(screen.getByText("Offen")).toBeTruthy();
+    // Author
+    expect(screen.getByText("alice")).toBeTruthy();
+    // Assignee
+    expect(screen.getByText(/Zugewiesen: bob/)).toBeTruthy();
+    // Labels
+    expect(screen.getByText("bug")).toBeTruthy();
+    expect(screen.getByText("priority")).toBeTruthy();
+    // Body
+    expect(
+      screen.getByText("The login form does not validate email."),
+    ).toBeTruthy();
+    // Comments
+    expect(screen.getByText("1 Kommentar")).toBeTruthy();
+    expect(screen.getByText("charlie")).toBeTruthy();
+    expect(screen.getByText("I can reproduce this.")).toBeTruthy();
+  });
+
+  it("renders closed state badge and closed_at date", async () => {
+    const detail = makeIssueDetail();
+    detail.state = "CLOSED";
+    detail.closed_at = "2026-03-20T14:00:00Z";
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(detail);
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Geschlossen")).toBeTruthy();
+    });
+
+    expect(screen.getByText(/Geschlossen am/)).toBeTruthy();
+  });
+
+  it("renders linked PRs with CI checks", async () => {
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(makeIssueDetail());
+      if (cmd === "get_issue_checks") return Promise.resolve(makeLinkedPRs());
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Verknuepfte Pull Requests"),
+      ).toBeTruthy();
+    });
+
+    // PR title
+    expect(screen.getByText(/#50 Fix login validation/)).toBeTruthy();
+    // PR state badge
+    expect(screen.getByText("Merged")).toBeTruthy();
+    // Check names
+    expect(screen.getByText("CI")).toBeTruthy();
+    expect(screen.getByText("Lint")).toBeTruthy();
+    expect(screen.getByText("Build")).toBeTruthy();
+  });
+
+  it("shows error state on fetch failure", async () => {
+    mockInvoke.mockRejectedValue(new Error("API error"));
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("API error")).toBeTruthy();
+    });
+  });
+
+  it("does not render content when open is false", () => {
+    const { container } = render(
+      <KanbanDetailModal
+        open={false}
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    // Modal is not rendered when closed
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("renders plural 'Kommentare' for multiple comments", async () => {
+    const detail = makeIssueDetail();
+    detail.comments = [
+      { author: "a", body: "First", created_at: "2026-03-16T08:00:00Z" },
+      { author: "b", body: "Second", created_at: "2026-03-17T08:00:00Z" },
+    ];
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(detail);
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("2 Kommentare")).toBeTruthy();
+    });
+  });
+
+  it("hides comments section when no comments", async () => {
+    const detail = makeIssueDetail();
+    detail.comments = [];
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(detail);
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeTruthy();
+    });
+
+    expect(screen.queryByText(/Kommentar/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for the entire kanban module (4 files, 27 tests)
- Kanban module coverage raised from 0% to ~90% statement coverage
- Covers KanbanCard, KanbanDashboardView, KanbanBoard, and KanbanDetailModal

## Test plan
- [x] All 692 tests pass (`npm run test -- --run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Coverage verified via `npm run test:coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)