### PR TITLE
test(layout): add tests for layout, app root, and editor (#90, #66)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import App from "./App";
+import { useThemeEffect } from "./hooks/useThemeEffect";
+import { initSessionHistoryListener } from "./store/sessionHistoryStore";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    onCloseRequested: vi.fn(() => Promise.resolve(() => {})),
+  }),
+}));
+
+vi.mock("./components/layout/AppShell", () => ({
+  AppShell: () => <div data-testid="app-shell" />,
+}));
+
+vi.mock("./utils/globalErrorHandler", () => ({
+  installGlobalErrorHandlers: vi.fn(),
+}));
+
+vi.mock("./hooks/useThemeEffect", () => ({
+  useThemeEffect: vi.fn(),
+}));
+
+vi.mock("./store/sessionHistoryStore", () => ({
+  initSessionHistoryListener: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("./store/tauriStorage", () => ({
+  flushPendingSaves: vi.fn(() => Promise.resolve()),
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("App", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders AppShell component", () => {
+    const { getByTestId } = render(<App />);
+    expect(getByTestId("app-shell")).toBeTruthy();
+  });
+
+  it("calls useThemeEffect on mount", () => {
+    render(<App />);
+    expect(useThemeEffect).toHaveBeenCalled();
+  });
+
+  it("initializes session history listener on mount", () => {
+    render(<App />);
+    expect(initSessionHistoryListener).toHaveBeenCalled();
+  });
+});

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Header } from "./Header";
+import { useSessionStore } from "../store/sessionStore";
+import { useSettingsStore } from "../store/settingsStore";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("../../package.json", () => ({
+  version: "1.0.0-test",
+}));
+
+vi.mock("./shared/NotesPanel", () => ({
+  NotesPanel: () => <div data-testid="notes-panel" />,
+}));
+
+vi.mock("./shared/ChangelogDialog", () => ({
+  ChangelogDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="changelog-dialog" /> : null,
+}));
+
+vi.mock("./shared/UpdateNotification", () => ({
+  UpdateNotification: () => <div data-testid="update-notification" />,
+}));
+
+vi.mock("../hooks/useAutoUpdate", () => ({
+  useAutoUpdate: () => ({
+    status: "idle",
+    progress: 0,
+    error: null,
+    newVersion: null,
+    lastChecked: null,
+    checkForUpdate: vi.fn(),
+    downloadAndInstall: vi.fn(),
+    confirmRelaunch: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("Header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionStore.setState({ sessions: [], activeSessionId: null });
+    useSettingsStore.setState({
+      theme: { mode: "dark", accentColor: "#00ff41", reducedMotion: false, animationSpeed: 1 },
+    });
+  });
+
+  it("renders app title and version badge", () => {
+    render(<Header />);
+    expect(screen.getByText("AGENTICEXPLORER")).toBeTruthy();
+    expect(screen.getByText("v1.0.0-test")).toBeTruthy();
+  });
+
+  it("shows 'Keine Session ausgewaehlt' when no active session", () => {
+    render(<Header />);
+    expect(screen.getByText("Keine Session ausgewaehlt")).toBeTruthy();
+  });
+
+  it("toggles theme between dark and light on button click", () => {
+    render(<Header />);
+
+    const themeBtn = screen.getByLabelText("Light Mode aktivieren");
+    fireEvent.click(themeBtn);
+
+    const mode = useSettingsStore.getState().theme.mode;
+    expect(mode).toBe("light");
+  });
+
+  it("renders NotesPanel component", () => {
+    render(<Header />);
+    expect(screen.getByTestId("notes-panel")).toBeTruthy();
+  });
+});

--- a/src/components/editor/CodeMirrorEditor.test.tsx
+++ b/src/components/editor/CodeMirrorEditor.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { CodeMirrorEditor } from "./CodeMirrorEditor";
+
+// Mock @uiw/react-codemirror — CodeMirror does not work in jsdom
+vi.mock("@uiw/react-codemirror", () => ({
+  __esModule: true,
+  default: (props: {
+    value: string;
+    onChange?: (val: string) => void;
+    className?: string;
+  }) => (
+    <div data-testid="codemirror-mock" className={props.className}>
+      <textarea
+        data-testid="codemirror-textarea"
+        value={props.value}
+        onChange={(e) => props.onChange?.(e.target.value)}
+      />
+    </div>
+  ),
+}));
+
+// Mock codemirror extensions that would fail in jsdom
+vi.mock("@codemirror/lang-markdown", () => ({
+  markdown: vi.fn(() => []),
+}));
+
+vi.mock("./languageSupport", () => ({
+  codeLanguages: [],
+}));
+
+vi.mock("@codemirror/view", () => ({
+  keymap: { of: vi.fn(() => []) },
+}));
+
+vi.mock("./editorTheme", () => ({
+  neonEditorTheme: [],
+}));
+
+describe("CodeMirrorEditor", () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders without crashing and displays the mock editor", () => {
+    const { getByTestId } = render(
+      <CodeMirrorEditor value="# Hello" onChange={onChange} />,
+    );
+    expect(getByTestId("codemirror-mock")).toBeTruthy();
+  });
+
+  it("passes value to the underlying editor", () => {
+    const { getByTestId } = render(
+      <CodeMirrorEditor value="test content" onChange={onChange} />,
+    );
+    const textarea = getByTestId("codemirror-textarea") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("test content");
+  });
+
+  it("wraps editor in a full-size container div", () => {
+    const { container } = render(
+      <CodeMirrorEditor value="" onChange={onChange} />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("h-full");
+    expect(wrapper.className).toContain("w-full");
+  });
+});

--- a/src/components/editor/editorTheme.test.ts
+++ b/src/components/editor/editorTheme.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { neonEditorTheme } from "./editorTheme";
+
+describe("editorTheme", () => {
+  it("exports neonEditorTheme as a non-empty array extension", () => {
+    expect(neonEditorTheme).toBeDefined();
+    // Extension is [theme, syntaxHighlighting(highlighting)]
+    const extensions = neonEditorTheme as unknown[];
+    expect(Array.isArray(extensions)).toBe(true);
+    expect(extensions.length).toBeGreaterThan(0);
+  });
+
+  it("contains both theme and syntax highlighting extensions", () => {
+    const extensions = neonEditorTheme as unknown[];
+    expect(extensions).toHaveLength(2);
+  });
+});

--- a/src/components/layout/AppShell.test.tsx
+++ b/src/components/layout/AppShell.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AppShell } from "./AppShell";
+import { useUIStore } from "../../store/uiStore";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("../Header", () => ({
+  Header: () => <div data-testid="header" />,
+}));
+
+vi.mock("./SideNav", () => ({
+  SideNav: () => <nav data-testid="side-nav" />,
+}));
+
+vi.mock("../sessions/SessionManagerView", () => ({
+  SessionManagerView: () => <div data-testid="session-manager" />,
+}));
+
+vi.mock("../pipeline/PipelineView", () => ({
+  PipelineView: () => <div data-testid="pipeline-view" />,
+}));
+
+// Lazy-loaded views — mock as simple components
+vi.mock("./placeholders", () => ({
+  SettingsPlaceholder: () => <div data-testid="settings-placeholder" />,
+}));
+vi.mock("../kanban/KanbanDashboardView", () => ({
+  KanbanDashboardView: () => <div data-testid="kanban-view" />,
+}));
+vi.mock("../logs/LogViewer", () => ({
+  LogViewer: () => <div data-testid="log-viewer" />,
+}));
+vi.mock("../library/LibraryView", () => ({
+  LibraryView: () => <div data-testid="library-view" />,
+}));
+vi.mock("../editor/MarkdownEditorView", () => ({
+  MarkdownEditorView: () => <div data-testid="editor-view" />,
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("AppShell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUIStore.setState({ activeTab: "sessions" });
+  });
+
+  it("renders SideNav, Header, and main content area", () => {
+    render(<AppShell />);
+    expect(screen.getByTestId("side-nav")).toBeTruthy();
+    expect(screen.getByTestId("header")).toBeTruthy();
+    expect(screen.getByTestId("session-manager")).toBeTruthy();
+  });
+
+  it("renders SessionManagerView for default/sessions tab", () => {
+    render(<AppShell />);
+    expect(screen.getByTestId("session-manager")).toBeTruthy();
+  });
+
+  it("renders PipelineView when activeTab is pipeline", () => {
+    useUIStore.setState({ activeTab: "pipeline" });
+    render(<AppShell />);
+    expect(screen.getByTestId("pipeline-view")).toBeTruthy();
+  });
+
+  it("has flex layout with full screen dimensions", () => {
+    const { container } = render(<AppShell />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("flex");
+    expect(root.className).toContain("h-screen");
+    expect(root.className).toContain("w-screen");
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for 5 previously untested components: `App.tsx`, `Header.tsx`, `AppShell.tsx`, `CodeMirrorEditor.tsx`, `editorTheme.ts`
- 16 new tests covering rendering, store integration (theme toggle), tab routing, and editor theme structure
- Part of coverage push from 47% to 75%+ (issues #90, #66)

## Test plan
- [x] All 681 tests pass (`npm run test -- --run`)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Coverage report shows new files covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)