### PR TITLE
test(shared): add tests for shared components and utils (#90, #66)

### DIFF
--- a/src/components/shared/ChangelogDialog.test.tsx
+++ b/src/components/shared/ChangelogDialog.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ChangelogDialog } from "./ChangelogDialog";
+
+// Mock the raw changelog import
+vi.mock("../../../CHANGELOG.md?raw", () => ({
+  default: `# Changelog
+
+## [1.5.0] — 2026-04-01
+
+### Added
+- **Feature A**: does something great
+- Simple bullet point
+
+### Fixed
+- **Bug B**: fixed a crash
+
+## [1.4.0] — 2026-03-15
+
+### Changed
+- Updated something
+
+Some paragraph text here.
+`,
+}));
+
+// Mock package.json version
+vi.mock("../../../package.json", () => ({
+  version: "1.5.0",
+}));
+
+// Mock build-time constants
+// @ts-expect-error -- build-time global
+globalThis.__BUILD_DATE__ = "2026-04-01";
+// @ts-expect-error -- build-time global
+globalThis.__GIT_HASH__ = "abc1234";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: () => {
+        return ({ children, ...props }: { children?: React.ReactNode }) => {
+          const filtered: Record<string, unknown> = {};
+          for (const [k, v] of Object.entries(props)) {
+            if (!["layout", "initial", "animate", "exit", "transition", "whileHover", "whileTap"].includes(k)) {
+              filtered[k] = v;
+            }
+          }
+          return <div {...filtered}>{children}</div>;
+        };
+      },
+    },
+  ),
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("ChangelogDialog", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ChangelogDialog open={false} onClose={vi.fn()} />,
+    );
+    // Modal with open=false should not render content
+    expect(container.querySelector("[role='dialog']")).toBeNull();
+  });
+
+  it("renders changelog sections when open", () => {
+    render(<ChangelogDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("CHANGELOG")).toBeTruthy();
+    // v1.5.0 appears both in header and section
+    expect(screen.getAllByText(/v1\.5\.0/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("v1.4.0")).toBeTruthy();
+  });
+
+  it("shows AKTUELL badge for current version", () => {
+    render(<ChangelogDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("AKTUELL")).toBeTruthy();
+  });
+
+  it("renders version, git hash, and build date in header", () => {
+    render(<ChangelogDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getAllByText(/v1\.5\.0/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("abc1234")).toBeTruthy();
+    // 2026-04-01 appears in header and as section date
+    expect(screen.getAllByText("2026-04-01").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders bold items with highlighted text", () => {
+    render(<ChangelogDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("Feature A")).toBeTruthy();
+    expect(screen.getByText(/does something great/)).toBeTruthy();
+  });
+
+  it("renders section headings (### Added, ### Fixed)", () => {
+    render(<ChangelogDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("Added")).toBeTruthy();
+    expect(screen.getByText("Fixed")).toBeTruthy();
+  });
+
+  it("renders plain bullet points", () => {
+    render(<ChangelogDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("Simple bullet point")).toBeTruthy();
+  });
+
+  it("renders paragraph text from changelog", () => {
+    render(<ChangelogDialog open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("Some paragraph text here.")).toBeTruthy();
+  });
+
+  it("dims older versions (not current)", () => {
+    const { container } = render(
+      <ChangelogDialog open={true} onClose={vi.fn()} />,
+    );
+    // The v1.4.0 section should have opacity-60 class
+    const sections = container.querySelectorAll(".opacity-60");
+    expect(sections.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/components/shared/LoadingSpinner.test.tsx
+++ b/src/components/shared/LoadingSpinner.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { LoadingSpinner } from "./LoadingSpinner";
+
+describe("LoadingSpinner", () => {
+  it("renders with default md size and blue color", () => {
+    const { container } = render(<LoadingSpinner />);
+    const spinner = container.querySelector(".w-8");
+    expect(spinner).toBeTruthy();
+    expect(spinner?.className).toContain("border-accent");
+    expect(spinner?.className).toContain("neon-spin-animation");
+  });
+
+  it("renders small spinner", () => {
+    const { container } = render(<LoadingSpinner size="sm" />);
+    const spinner = container.querySelector(".w-5");
+    expect(spinner).toBeTruthy();
+  });
+
+  it("renders large spinner", () => {
+    const { container } = render(<LoadingSpinner size="lg" />);
+    const spinner = container.querySelector(".w-12");
+    expect(spinner).toBeTruthy();
+  });
+
+  it("renders green color variant", () => {
+    const { container } = render(<LoadingSpinner color="green" />);
+    const spinner = container.querySelector(".border-success");
+    expect(spinner).toBeTruthy();
+  });
+
+  it("renders purple color variant", () => {
+    const { container } = render(<LoadingSpinner color="purple" />);
+    const spinner = container.querySelector(".border-info");
+    expect(spinner).toBeTruthy();
+  });
+
+  it("applies box-shadow glow style", () => {
+    const { container } = render(<LoadingSpinner color="blue" />);
+    const spinner = container.querySelector(".neon-spin-animation") as HTMLElement;
+    expect(spinner?.style.boxShadow).toContain("0 0 8px");
+  });
+
+  it("has transparent top border for spinning effect", () => {
+    const { container } = render(<LoadingSpinner />);
+    const spinner = container.querySelector(".border-t-transparent");
+    expect(spinner).toBeTruthy();
+  });
+
+  it("is centered in its container", () => {
+    const { container } = render(<LoadingSpinner />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper?.className).toContain("flex");
+    expect(wrapper?.className).toContain("items-center");
+    expect(wrapper?.className).toContain("justify-center");
+  });
+});

--- a/src/components/shared/NotesPanel.test.tsx
+++ b/src/components/shared/NotesPanel.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { NotesPanel } from "./NotesPanel";
+import { useSettingsStore } from "../../store/settingsStore";
+import { useSessionStore } from "../../store/sessionStore";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: () => {
+        return ({ children, ...props }: { children?: React.ReactNode }) => {
+          const filtered: Record<string, unknown> = {};
+          for (const [k, v] of Object.entries(props)) {
+            if (!["layout", "initial", "animate", "exit", "transition", "whileHover", "whileTap"].includes(k)) {
+              filtered[k] = v;
+            }
+          }
+          return <div {...filtered}>{children}</div>;
+        };
+      },
+    },
+  ),
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("NotesPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSettingsStore.setState({
+      globalNotes: "",
+      projectNotes: {},
+      favorites: [],
+    });
+    useSessionStore.setState({
+      sessions: [],
+      activeSessionId: null,
+    });
+  });
+
+  it("renders the Notizen button", () => {
+    render(<NotesPanel />);
+    expect(screen.getByLabelText("Notizen")).toBeTruthy();
+  });
+
+  it("opens panel on button click", () => {
+    render(<NotesPanel />);
+    fireEvent.click(screen.getByLabelText("Notizen"));
+    // Should show tab buttons
+    expect(screen.getByText("Globale Notizen")).toBeTruthy();
+    expect(screen.getByText("Projekt-Notizen")).toBeTruthy();
+  });
+
+  it("closes panel on second button click", () => {
+    render(<NotesPanel />);
+    fireEvent.click(screen.getByLabelText("Notizen"));
+    expect(screen.getByText("Globale Notizen")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Notizen"));
+    expect(screen.queryByText("Globale Notizen")).toBeNull();
+  });
+
+  it("defaults to global tab when no sessions or favorites", () => {
+    render(<NotesPanel />);
+    fireEvent.click(screen.getByLabelText("Notizen"));
+    // Global tab should be active — textarea with global placeholder visible
+    expect(screen.getByPlaceholderText("Globale Stichsaetze, Ideen, TODOs...")).toBeTruthy();
+  });
+
+  it("shows global notes textarea with stored value", () => {
+    useSettingsStore.setState({ globalNotes: "My global notes" });
+    render(<NotesPanel />);
+    fireEvent.click(screen.getByLabelText("Notizen"));
+
+    // Switch to global tab
+    fireEvent.click(screen.getByText("Globale Notizen"));
+    const textarea = screen.getByPlaceholderText("Globale Stichsaetze, Ideen, TODOs...");
+    expect((textarea as HTMLTextAreaElement).value).toBe("My global notes");
+  });
+
+  it("updates global notes on textarea change", () => {
+    render(<NotesPanel />);
+    fireEvent.click(screen.getByLabelText("Notizen"));
+    fireEvent.click(screen.getByText("Globale Notizen"));
+
+    const textarea = screen.getByPlaceholderText("Globale Stichsaetze, Ideen, TODOs...");
+    fireEvent.change(textarea, { target: { value: "Updated notes" } });
+
+    expect(useSettingsStore.getState().globalNotes).toBe("Updated notes");
+  });
+
+  it("shows project notes when session is active", () => {
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: "s1",
+          title: "Test",
+          folder: "C:\\Projects\\test",
+          shell: "powershell",
+          status: "running",
+          createdAt: Date.now(),
+          finishedAt: null,
+          exitCode: null,
+          lastOutputAt: Date.now(),
+          lastOutputSnippet: "",
+        },
+      ],
+      activeSessionId: "s1",
+    });
+    useSettingsStore.setState({
+      projectNotes: { "c:/projects/test": "Project note content" },
+    });
+
+    render(<NotesPanel />);
+    fireEvent.click(screen.getByLabelText("Notizen"));
+
+    // Should show project tab with project notes textarea
+    const textarea = screen.getByPlaceholderText("Notizen fuer dieses Projekt...");
+    expect((textarea as HTMLTextAreaElement).value).toBe("Project note content");
+  });
+
+  it("shows folder picker when no active session but favorites exist", () => {
+    useSettingsStore.setState({
+      favorites: [{
+        id: "fav-1",
+        path: "C:\\Projects\\fav",
+        label: "Favorite Proj",
+        shell: "powershell",
+        addedAt: Date.now(),
+        lastUsedAt: Date.now(),
+      }],
+    });
+
+    render(<NotesPanel />);
+    fireEvent.click(screen.getByLabelText("Notizen"));
+
+    // Should show project tab with folder picker — button shows folderLabel result
+    fireEvent.click(screen.getByText("Projekt-Notizen"));
+    // The folder picker button shows the auto-selected folder label via folderLabel()
+    expect(screen.getByText("fav")).toBeTruthy();
+
+    // Open the dropdown to see the full label
+    fireEvent.click(screen.getByText("fav"));
+    expect(screen.getByText("Favorite Proj")).toBeTruthy();
+  });
+
+  it("highlights button when notes exist", () => {
+    useSettingsStore.setState({ globalNotes: "Some notes" });
+    const { container } = render(<NotesPanel />);
+    const button = container.querySelector("button");
+    expect(button?.className).toContain("text-accent");
+  });
+
+  it("closes panel on outside click", () => {
+    render(
+      <div>
+        <div data-testid="outside">Outside</div>
+        <NotesPanel />
+      </div>,
+    );
+    fireEvent.click(screen.getByLabelText("Notizen"));
+    expect(screen.getByText("Globale Notizen")).toBeTruthy();
+
+    // Simulate outside click
+    act(() => {
+      fireEvent.mouseDown(screen.getByTestId("outside"));
+    });
+    expect(screen.queryByText("Globale Notizen")).toBeNull();
+  });
+});

--- a/src/components/shared/Panel.test.tsx
+++ b/src/components/shared/Panel.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Panel } from "./Panel";
+import { AlertCircle } from "lucide-react";
+
+vi.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: () => {
+        return ({ children, ...props }: { children?: React.ReactNode }) => {
+          const filtered: Record<string, unknown> = {};
+          for (const [k, v] of Object.entries(props)) {
+            if (!["layout", "initial", "animate", "exit", "transition", "whileHover", "whileTap"].includes(k)) {
+              filtered[k] = v;
+            }
+          }
+          return <div {...filtered}>{children}</div>;
+        };
+      },
+    },
+  ),
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("Panel", () => {
+  it("renders children in default expanded state", () => {
+    render(<Panel>Hello Panel</Panel>);
+    expect(screen.getByText("Hello Panel")).toBeTruthy();
+  });
+
+  it("renders title in uppercase", () => {
+    render(<Panel title="my title">Content</Panel>);
+    expect(screen.getByText("MY TITLE")).toBeTruthy();
+  });
+
+  it("renders icon when provided", () => {
+    const { container } = render(
+      <Panel title="Status" icon={AlertCircle}>
+        Content
+      </Panel>,
+    );
+    // Lucide icons render as SVGs
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+  });
+
+  it("does not render header when no title and no icon", () => {
+    const { container } = render(<Panel>Only content</Panel>);
+    // No header border-b element
+    const header = container.querySelector(".border-b");
+    expect(header).toBeNull();
+  });
+
+  it("toggles collapsed state when collapsible header clicked", () => {
+    render(
+      <Panel title="Toggle" collapsible>
+        Hidden Content
+      </Panel>,
+    );
+    expect(screen.getByText("Hidden Content")).toBeTruthy();
+
+    // Click header to collapse
+    fireEvent.click(screen.getByText("TOGGLE"));
+    expect(screen.queryByText("Hidden Content")).toBeNull();
+
+    // Click again to expand
+    fireEvent.click(screen.getByText("TOGGLE"));
+    expect(screen.getByText("Hidden Content")).toBeTruthy();
+  });
+
+  it("starts collapsed when defaultCollapsed is true", () => {
+    render(
+      <Panel title="Collapsed" collapsible defaultCollapsed>
+        Secret
+      </Panel>,
+    );
+    expect(screen.queryByText("Secret")).toBeNull();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <Panel className="custom-class">Content</Panel>,
+    );
+    expect(container.querySelector(".custom-class")).toBeTruthy();
+  });
+
+  it("applies neonColor styles", () => {
+    const { container } = render(
+      <Panel title="Error" neonColor="error">
+        Content
+      </Panel>,
+    );
+    expect(container.querySelector(".border-error")).toBeTruthy();
+  });
+
+  it("header is not clickable when not collapsible", () => {
+    render(
+      <Panel title="Static">Content</Panel>,
+    );
+    const header = screen.getByText("STATIC").closest("div");
+    expect(header?.className).not.toContain("cursor-pointer");
+  });
+});

--- a/src/components/shared/StatusBadge.test.tsx
+++ b/src/components/shared/StatusBadge.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatusBadge } from "./StatusBadge";
+
+describe("StatusBadge", () => {
+  it("renders with status as aria-label when no label provided", () => {
+    render(<StatusBadge status="idle" />);
+    expect(screen.getByLabelText("idle")).toBeTruthy();
+  });
+
+  it("renders custom label text and uses it for aria-label", () => {
+    render(<StatusBadge status="active" label="Aktiv" />);
+    expect(screen.getByText("Aktiv")).toBeTruthy();
+    expect(screen.getByLabelText("Aktiv")).toBeTruthy();
+  });
+
+  it("does not render label span when label is undefined", () => {
+    const { container } = render(<StatusBadge status="done" />);
+    // Only the dot span, no text span
+    const spans = container.querySelectorAll("span > span");
+    expect(spans.length).toBe(1); // just the dot
+  });
+
+  it("applies pulse animation for active status by default", () => {
+    const { container } = render(<StatusBadge status="active" label="Running" />);
+    const dot = container.querySelector(".status-pulse-animation");
+    expect(dot).toBeTruthy();
+  });
+
+  it("applies pulse animation for running status by default", () => {
+    const { container } = render(<StatusBadge status="running" />);
+    const dot = container.querySelector(".status-pulse-animation");
+    expect(dot).toBeTruthy();
+  });
+
+  it("does not pulse for idle status by default", () => {
+    const { container } = render(<StatusBadge status="idle" />);
+    const dot = container.querySelector(".status-pulse-animation");
+    expect(dot).toBeNull();
+  });
+
+  it("overrides pulse with explicit pulse=true", () => {
+    const { container } = render(<StatusBadge status="idle" pulse={true} />);
+    const dot = container.querySelector(".status-pulse-animation");
+    expect(dot).toBeTruthy();
+  });
+
+  it("overrides pulse with explicit pulse=false", () => {
+    const { container } = render(<StatusBadge status="active" pulse={false} />);
+    const dot = container.querySelector(".status-pulse-animation");
+    expect(dot).toBeNull();
+  });
+
+  it("renders small size with correct classes", () => {
+    const { container } = render(<StatusBadge status="done" size="sm" label="OK" />);
+    const dot = container.querySelector(".w-1\\.5");
+    expect(dot).toBeTruthy();
+  });
+
+  it("renders large size with correct classes", () => {
+    const { container } = render(<StatusBadge status="error" size="lg" label="Fehler" />);
+    const dot = container.querySelector(".w-2\\.5");
+    expect(dot).toBeTruthy();
+  });
+
+  it("applies error dot color for error status", () => {
+    const { container } = render(<StatusBadge status="error" />);
+    const dot = container.querySelector(".bg-error");
+    expect(dot).toBeTruthy();
+  });
+
+  it("applies success dot color for done status", () => {
+    const { container } = render(<StatusBadge status="done" />);
+    const dot = container.querySelector(".bg-success");
+    expect(dot).toBeTruthy();
+  });
+});

--- a/src/components/shared/UpdateNotification.test.tsx
+++ b/src/components/shared/UpdateNotification.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { UpdateNotification } from "./UpdateNotification";
+import type { UpdateState } from "../../hooks/useAutoUpdate";
+
+function makeProps(overrides: Partial<UpdateState & {
+  onUpdate?: () => void;
+  onRelaunch?: () => void;
+  onRetry?: () => void;
+  onDismiss?: () => void;
+}> = {}) {
+  return {
+    status: "idle" as UpdateState["status"],
+    progress: 0,
+    error: null as string | null,
+    newVersion: null as string | null,
+    lastChecked: null as Date | null,
+    onUpdate: vi.fn(),
+    onRelaunch: vi.fn(),
+    onRetry: vi.fn(),
+    onDismiss: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("UpdateNotification", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null for idle status", () => {
+    const { container } = render(<UpdateNotification {...makeProps({ status: "idle" })} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null for checking status", () => {
+    const { container } = render(<UpdateNotification {...makeProps({ status: "checking" })} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders upToDate with Aktuell text", () => {
+    render(<UpdateNotification {...makeProps({ status: "upToDate" })} />);
+    expect(screen.getByText("Aktuell")).toBeTruthy();
+  });
+
+  it("auto-dismisses upToDate after 4 seconds", () => {
+    const onDismiss = vi.fn();
+    render(<UpdateNotification {...makeProps({ status: "upToDate", onDismiss })} />);
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it("renders available status with version and update button", () => {
+    const onUpdate = vi.fn();
+    render(
+      <UpdateNotification
+        {...makeProps({ status: "available", newVersion: "2.0.0", onUpdate })}
+      />,
+    );
+    expect(screen.getByText(/v2\.0\.0 verf/)).toBeTruthy();
+    expect(screen.getByText("Jetzt updaten")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Jetzt updaten"));
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it("renders dismiss button for available status", () => {
+    const onDismiss = vi.fn();
+    render(
+      <UpdateNotification
+        {...makeProps({ status: "available", newVersion: "2.0.0", onDismiss })}
+      />,
+    );
+    // X button for dismiss
+    const buttons = screen.getAllByRole("button");
+    // Last button should be the dismiss (X) button
+    fireEvent.click(buttons[buttons.length - 1]);
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it("renders downloading status with progress bar", () => {
+    render(
+      <UpdateNotification {...makeProps({ status: "downloading", progress: 45 })} />,
+    );
+    expect(screen.getByText(/Lade Update.*45%/)).toBeTruthy();
+  });
+
+  it("renders ready status with relaunch button", () => {
+    const onRelaunch = vi.fn();
+    render(
+      <UpdateNotification {...makeProps({ status: "ready", onRelaunch })} />,
+    );
+    expect(screen.getByText("Update bereit")).toBeTruthy();
+    expect(screen.getByText("Jetzt neu starten")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Jetzt neu starten"));
+    expect(onRelaunch).toHaveBeenCalled();
+  });
+
+  it("renders error status with error message and retry button", () => {
+    const onRetry = vi.fn();
+    render(
+      <UpdateNotification
+        {...makeProps({ status: "error", error: "Network failure", onRetry })}
+      />,
+    );
+    expect(screen.getByText(/Update-Fehler.*Network failure/)).toBeTruthy();
+
+    fireEvent.click(screen.getByText(/Erneut/));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("renders dismiss button for error status", () => {
+    const onDismiss = vi.fn();
+    render(
+      <UpdateNotification
+        {...makeProps({ status: "error", error: "fail", onDismiss })}
+      />,
+    );
+    // Find the X dismiss button (last button)
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[buttons.length - 1]);
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it("has correct border color for each status", () => {
+    const { rerender } = render(
+      <UpdateNotification {...makeProps({ status: "upToDate" })} />,
+    );
+    expect(screen.getByRole("status").className).toContain("border-emerald");
+
+    rerender(<UpdateNotification {...makeProps({ status: "error", error: "x" })} />);
+    expect(screen.getByRole("status").className).toContain("border-red");
+
+    rerender(<UpdateNotification {...makeProps({ status: "available", newVersion: "2.0" })} />);
+    expect(screen.getByRole("status").className).toContain("border-accent");
+  });
+});

--- a/src/utils/globalErrorHandler.test.ts
+++ b/src/utils/globalErrorHandler.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useUIStore } from "../store/uiStore";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("./errorLogger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+// We need to import after mocks are set up
+const { logError } = await import("./errorLogger");
+
+describe("globalErrorHandler", () => {
+  let errorListeners: ((event: ErrorEvent) => void)[];
+  let rejectionListeners: ((event: unknown) => void)[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUIStore.setState({ toasts: [] });
+    errorListeners = [];
+    rejectionListeners = [];
+
+    // Capture event listeners added by installGlobalErrorHandlers
+    vi.spyOn(window, "addEventListener").mockImplementation(
+      (type: string, handler: EventListenerOrEventListenerObject) => {
+        if (type === "error") {
+          errorListeners.push(handler as (event: ErrorEvent) => void);
+        } else if (type === "unhandledrejection") {
+          rejectionListeners.push(handler as (event: unknown) => void);
+        }
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function install() {
+    const mod = await import("./globalErrorHandler");
+    mod.installGlobalErrorHandlers();
+  }
+
+  // jsdom does not have PromiseRejectionEvent — create a fake event shape
+  function fakeRejectionEvent(reason: unknown) {
+    return { reason } as unknown;
+  }
+
+  it("installs error and unhandledrejection listeners", async () => {
+    await install();
+    expect(errorListeners.length).toBe(1);
+    expect(rejectionListeners.length).toBe(1);
+  });
+
+  it("handles window error event with Error object", async () => {
+    await install();
+    const error = new Error("Test error message");
+    const event = new ErrorEvent("error", {
+      error,
+      message: "Test error message",
+    });
+
+    errorListeners[0](event);
+
+    expect(logError).toHaveBeenCalledWith("window", error);
+    const toasts = useUIStore.getState().toasts;
+    expect(toasts.length).toBe(1);
+    expect(toasts[0].type).toBe("error");
+    expect(toasts[0].message).toContain("Test error message");
+  });
+
+  it("handles window error event without Error object (fallback message)", async () => {
+    await install();
+    const event = new ErrorEvent("error", {
+      message: "Script error",
+    });
+
+    errorListeners[0](event);
+
+    expect(logError).toHaveBeenCalled();
+    const toasts = useUIStore.getState().toasts;
+    expect(toasts.length).toBe(1);
+    expect(toasts[0].message).toContain("Script error");
+  });
+
+  it("handles unhandled rejection with Error reason", async () => {
+    await install();
+    const reason = new Error("Promise failed");
+
+    rejectionListeners[0](fakeRejectionEvent(reason));
+
+    expect(logError).toHaveBeenCalledWith("promise", reason);
+    const toasts = useUIStore.getState().toasts;
+    expect(toasts.length).toBe(1);
+    expect(toasts[0].message).toContain("Promise failed");
+  });
+
+  it("handles unhandled rejection with string reason", async () => {
+    await install();
+
+    rejectionListeners[0](fakeRejectionEvent("string error reason"));
+
+    const toasts = useUIStore.getState().toasts;
+    expect(toasts.length).toBe(1);
+    expect(toasts[0].message).toContain("string error reason");
+  });
+
+  it("handles unhandled rejection with non-Error/non-string reason", async () => {
+    await install();
+
+    rejectionListeners[0](fakeRejectionEvent({ code: 42 }));
+
+    const toasts = useUIStore.getState().toasts;
+    expect(toasts.length).toBe(1);
+    expect(toasts[0].message).toBe("Unbehandelte Promise-Rejection");
+  });
+
+  it("truncates long error messages to 120 chars", async () => {
+    await install();
+    const longMsg = "A".repeat(200);
+    const event = new ErrorEvent("error", {
+      error: new Error(longMsg),
+      message: longMsg,
+    });
+
+    errorListeners[0](event);
+
+    const toasts = useUIStore.getState().toasts;
+    // 120 chars + ellipsis character
+    expect(toasts[0].message?.length).toBeLessThanOrEqual(121);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 66 unit tests across 7 new test files for previously uncovered shared components and utilities
- Covers Panel, StatusBadge, LoadingSpinner, NotesPanel, ChangelogDialog, UpdateNotification, and globalErrorHandler
- Each file has happy-path + edge-case tests (collapse toggling, pulse override, auto-dismiss timers, error truncation, outside-click closing, etc.)

## Test plan
- [x] All 731 tests pass (`npm run test -- --run`)
- [x] Build succeeds (`npm run build`)
- [x] TypeScript checks pass (`npx tsc --noEmit` via build)
- [x] globalErrorHandler.ts reaches 100% coverage
- [x] New shared component files move from 0% to high coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)