### PR TITLE
test(sessions): add tests for session viewer components (#90, #66)

### DIFF
--- a/src/components/sessions/ClaudeMdViewer.test.tsx
+++ b/src/components/sessions/ClaudeMdViewer.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { ClaudeMdViewer } from "./ClaudeMdViewer";
+
+// Mock @tauri-apps/api/core
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock("../editor/MarkdownPreview", () => ({
+  MarkdownPreview: ({ content }: { content: string }) => (
+    <div data-testid="markdown-preview">{content}</div>
+  ),
+}));
+
+vi.mock("../editor/CodeMirrorEditor", () => ({
+  CodeMirrorEditor: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      data-testid="code-editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+describe("ClaudeMdViewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    mockInvoke.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<ClaudeMdViewer folder="/test/project" />);
+    expect(screen.getByText("Lade CLAUDE.md...")).toBeInTheDocument();
+  });
+
+  it("renders markdown content after loading", async () => {
+    mockInvoke.mockResolvedValue("# My Project\n\nSome content here.");
+    render(<ClaudeMdViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-preview")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("markdown-preview")).toHaveTextContent("# My Project");
+    expect(screen.getByText("CLAUDE.md")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no CLAUDE.md found", async () => {
+    mockInvoke.mockRejectedValue(new Error("file not found"));
+    render(<ClaudeMdViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Keine CLAUDE.md in diesem Projekt gefunden"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("/test/project")).toBeInTheDocument();
+  });
+
+  it("enters edit mode when clicking Bearbeiten button", async () => {
+    mockInvoke.mockResolvedValue("# Content");
+    render(<ClaudeMdViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-preview")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Datei bearbeiten"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("code-editor")).toBeInTheDocument();
+    });
+  });
+
+  it("saves file and exits edit mode", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "read_project_file") return Promise.resolve("original");
+      if (cmd === "write_project_file") return Promise.resolve(undefined);
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<ClaudeMdViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-preview")).toBeInTheDocument();
+    });
+
+    // Enter edit mode
+    fireEvent.click(screen.getByLabelText("Datei bearbeiten"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("code-editor")).toBeInTheDocument();
+    });
+
+    // Modify content
+    fireEvent.change(screen.getByTestId("code-editor"), {
+      target: { value: "modified content" },
+    });
+
+    // Save
+    fireEvent.click(screen.getByLabelText("Datei speichern"));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("write_project_file", {
+        folder: "/test/project",
+        relativePath: "CLAUDE.md",
+        content: "modified content",
+      });
+    });
+  });
+
+  it("shows empty content as null (not found state)", async () => {
+    mockInvoke.mockResolvedValue("");
+    render(<ClaudeMdViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Keine CLAUDE.md in diesem Projekt gefunden"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/sessions/GitHubViewer.test.tsx
+++ b/src/components/sessions/GitHubViewer.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { GitHubViewer } from "./GitHubViewer";
+
+// Mock @tauri-apps/api/core
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+// Mock @tauri-apps/plugin-shell
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GitHubViewer", () => {
+  it("shows loading state initially", () => {
+    mockInvoke.mockReturnValue(new Promise(() => {}));
+    render(<GitHubViewer folder="/test/project" />);
+    expect(screen.getByText("Lade Git/GitHub-Daten...")).toBeInTheDocument();
+  });
+
+  it("renders git info, PRs, and issues", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_git_info") {
+        return Promise.resolve({
+          branch: "feature/test",
+          last_commit: {
+            hash: "abc1234",
+            message: "fix: something",
+            date: "2026-04-01",
+          },
+          remote_url: "https://github.com/user/repo.git",
+        });
+      }
+      if (cmd === "get_github_prs") {
+        return Promise.resolve([
+          {
+            number: 42,
+            title: "Add feature X",
+            author: "dev1",
+            status: "APPROVED",
+            url: "https://github.com/user/repo/pull/42",
+          },
+        ]);
+      }
+      if (cmd === "get_github_issues") {
+        return Promise.resolve([
+          {
+            number: 10,
+            title: "Bug in login",
+            labels: ["bug", "high-priority"],
+            assignee: "dev2",
+            url: "https://github.com/user/repo/issues/10",
+          },
+        ]);
+      }
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<GitHubViewer folder="/test/fresh-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("feature/test")).toBeInTheDocument();
+    });
+
+    // Git info
+    expect(screen.getByText("abc1234")).toBeInTheDocument();
+    expect(screen.getByText("fix: something")).toBeInTheDocument();
+
+    // PR
+    expect(screen.getByText("#42")).toBeInTheDocument();
+    expect(screen.getByText("Add feature X")).toBeInTheDocument();
+    expect(screen.getByText("Approved")).toBeInTheDocument();
+
+    // Issue
+    expect(screen.getByText("#10")).toBeInTheDocument();
+    expect(screen.getByText("Bug in login")).toBeInTheDocument();
+    expect(screen.getByText("bug")).toBeInTheDocument();
+    expect(screen.getByText("high-priority")).toBeInTheDocument();
+  });
+
+  it("shows empty state when git fails", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_git_info") {
+        return Promise.reject(new Error("not a git repository"));
+      }
+      if (cmd === "get_github_prs") return Promise.resolve([]);
+      if (cmd === "get_github_issues") return Promise.resolve([]);
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<GitHubViewer folder="/test/no-git-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Kein Git-Repository")).toBeInTheDocument();
+    });
+  });
+
+  it("shows gh CLI error when github commands fail", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_git_info") {
+        return Promise.resolve({
+          branch: "main",
+          last_commit: null,
+          remote_url: "",
+        });
+      }
+      if (cmd === "get_github_prs" || cmd === "get_github_issues") {
+        return Promise.reject(new Error("gh not found"));
+      }
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<GitHubViewer folder="/test/no-gh-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("main")).toBeInTheDocument();
+    });
+
+    // The error contains "not found" which triggers the special gh CLI message
+    expect(
+      screen.getByText("gh CLI nicht gefunden — installiere von https://cli.github.com"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no PRs/issues when lists are empty", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_git_info") {
+        return Promise.resolve({
+          branch: "main",
+          last_commit: null,
+          remote_url: "",
+        });
+      }
+      if (cmd === "get_github_prs") return Promise.resolve([]);
+      if (cmd === "get_github_issues") return Promise.resolve([]);
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<GitHubViewer folder="/test/empty-gh-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Keine offenen PRs")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Keine offenen Issues")).toBeInTheDocument();
+  });
+
+  it("renders refresh button", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_git_info") {
+        return Promise.resolve({ branch: "main", last_commit: null, remote_url: "" });
+      }
+      if (cmd === "get_github_prs") return Promise.resolve([]);
+      if (cmd === "get_github_issues") return Promise.resolve([]);
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<GitHubViewer folder="/test/refresh-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    const refreshBtn = screen.getByTitle("Neu laden");
+    expect(refreshBtn).toBeInTheDocument();
+
+    // Click refresh triggers reload
+    fireEvent.click(refreshBtn);
+    expect(mockInvoke).toHaveBeenCalledWith("get_git_info", { folder: "/test/refresh-project" });
+  });
+});

--- a/src/components/sessions/LibraryViewer.test.tsx
+++ b/src/components/sessions/LibraryViewer.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { LibraryViewer } from "./LibraryViewer";
+import { useLibraryStore } from "../../store/libraryStore";
+
+// Mock @tauri-apps/api/core
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const mockItem1 = {
+  id: "skill-1",
+  name: "UI Rework Guide",
+  item_type: "skill" as const,
+  tags: ["design", "frontend"],
+  description: "A guide for UI rework",
+  created: "2026-04-01",
+  file_name: "skill-1.md",
+};
+
+const mockItem2 = {
+  id: "agent-1",
+  name: "Architect Agent",
+  item_type: "agent-profile" as const,
+  tags: ["planning"],
+  description: "Planning agent profile",
+  created: "2026-04-02",
+  file_name: "agent-1.md",
+};
+
+const mockItem3 = {
+  id: "hook-1",
+  name: "Pre-commit Hook",
+  item_type: "hook" as const,
+  tags: ["ci"],
+  description: "Runs before commit",
+  created: "2026-04-03",
+  file_name: "hook-1.md",
+};
+
+describe("LibraryViewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset store to clean state
+    useLibraryStore.setState({
+      items: [],
+      selectedItemId: null,
+      loadedContent: {},
+      usage: {},
+      loading: false,
+      lastFetched: null,
+    });
+  });
+
+  it("shows loading state when loading with no items", () => {
+    useLibraryStore.setState({ loading: true, items: [], fetchItems: vi.fn() });
+    render(<LibraryViewer />);
+    expect(screen.getByText("Lade Library...")).toBeInTheDocument();
+  });
+
+  it("shows empty state when library is empty", () => {
+    useLibraryStore.setState({ loading: false, items: [], fetchItems: vi.fn() });
+    render(<LibraryViewer />);
+    expect(screen.getByText("Library ist leer")).toBeInTheDocument();
+    expect(screen.getByText("~/.claude/library/items/")).toBeInTheDocument();
+  });
+
+  it("renders item list with correct counts", () => {
+    useLibraryStore.setState({
+      loading: false,
+      items: [mockItem1, mockItem2, mockItem3],
+      fetchItems: vi.fn(),
+    });
+    render(<LibraryViewer />);
+
+    expect(screen.getByText("Library (3)")).toBeInTheDocument();
+    expect(screen.getByText("UI Rework Guide")).toBeInTheDocument();
+    expect(screen.getByText("Architect Agent")).toBeInTheDocument();
+    expect(screen.getByText("Pre-commit Hook")).toBeInTheDocument();
+  });
+
+  it("filters items by type", () => {
+    useLibraryStore.setState({
+      loading: false,
+      items: [mockItem1, mockItem2, mockItem3],
+      fetchItems: vi.fn(),
+    });
+    render(<LibraryViewer />);
+
+    // Click "Skill" filter — there are multiple "Skill" texts (filter button + type badge)
+    // Use getAllByText and click the filter button (first occurrence)
+    const skillButtons = screen.getAllByText("Skill");
+    fireEvent.click(skillButtons[0]); // filter button
+
+    // Only skill item should remain visible in the list
+    expect(screen.getByText("UI Rework Guide")).toBeInTheDocument();
+    expect(screen.queryByText("Architect Agent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pre-commit Hook")).not.toBeInTheDocument();
+  });
+
+  it("filters items by search query", () => {
+    useLibraryStore.setState({
+      loading: false,
+      items: [mockItem1, mockItem2, mockItem3],
+      fetchItems: vi.fn(),
+    });
+    render(<LibraryViewer />);
+
+    const searchInput = screen.getByPlaceholderText("Suchen...");
+    fireEvent.change(searchInput, { target: { value: "architect" } });
+
+    expect(screen.queryByText("UI Rework Guide")).not.toBeInTheDocument();
+    expect(screen.getByText("Architect Agent")).toBeInTheDocument();
+  });
+
+  it("selects item and shows detail view", async () => {
+    const mockSelectItem = vi.fn();
+    const mockLoadItemContent = vi.fn();
+    useLibraryStore.setState({
+      loading: false,
+      items: [mockItem1, mockItem2],
+      selectedItemId: "skill-1",
+      loadedContent: {
+        "skill-1": {
+          meta: mockItem1,
+          content: "raw content",
+          body: "# UI Rework Guide\n\nDetailed content here.",
+        },
+      },
+      usage: {},
+      fetchItems: vi.fn(),
+      selectItem: mockSelectItem,
+      loadItemContent: mockLoadItemContent,
+    });
+
+    render(<LibraryViewer folder="/test/project" />);
+
+    // Detail view should show the selected item — description appears in both list and detail
+    await waitFor(() => {
+      expect(screen.getAllByText("A guide for UI rework").length).toBeGreaterThanOrEqual(1);
+    });
+    // Body content is in a <pre> element
+    expect(screen.getByText(/Detailed content here/)).toBeInTheDocument();
+  });
+
+  it("shows placeholder when no item is selected", () => {
+    useLibraryStore.setState({
+      loading: false,
+      items: [mockItem1],
+      selectedItemId: null,
+      fetchItems: vi.fn(),
+    });
+    render(<LibraryViewer />);
+    expect(screen.getByText("Item auswaehlen")).toBeInTheDocument();
+  });
+
+  it("shows 'Keine Items gefunden' when filters match nothing", () => {
+    useLibraryStore.setState({
+      loading: false,
+      items: [mockItem1],
+      fetchItems: vi.fn(),
+    });
+    render(<LibraryViewer />);
+
+    const searchInput = screen.getByPlaceholderText("Suchen...");
+    fireEvent.change(searchInput, { target: { value: "nonexistent" } });
+
+    expect(screen.getByText("Keine Items gefunden")).toBeInTheDocument();
+  });
+
+  it("shows new item form when clicking Neues Item button", () => {
+    useLibraryStore.setState({
+      loading: false,
+      items: [],
+      fetchItems: vi.fn(),
+    });
+    render(<LibraryViewer />);
+
+    fireEvent.click(screen.getByText("Neues Item"));
+    expect(screen.getByText("Neues Library-Item")).toBeInTheDocument();
+  });
+
+  it("shows usage count for items with usage data", () => {
+    useLibraryStore.setState({
+      loading: false,
+      items: [mockItem1],
+      usage: { "skill-1": ["/project/a", "/project/b"] },
+      fetchItems: vi.fn(),
+    });
+    render(<LibraryViewer />);
+
+    expect(screen.getByText("2x")).toBeInTheDocument();
+  });
+});

--- a/src/components/sessions/PinnedDocViewer.test.tsx
+++ b/src/components/sessions/PinnedDocViewer.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { PinnedDocViewer } from "./PinnedDocViewer";
+import { useSettingsStore, normalizeProjectKey } from "../../store/settingsStore";
+
+// Mock @tauri-apps/api/core
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock("../editor/MarkdownPreview", () => ({
+  MarkdownPreview: ({ content }: { content: string }) => (
+    <div data-testid="markdown-preview">{content}</div>
+  ),
+}));
+
+vi.mock("../editor/CodeMirrorEditor", () => ({
+  CodeMirrorEditor: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      data-testid="code-editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+const TEST_FOLDER = "/test/project";
+const TEST_PIN_ID = "pin-123";
+
+function setupPinnedDoc(relativePath: string, label?: string) {
+  const key = normalizeProjectKey(TEST_FOLDER);
+  useSettingsStore.setState({
+    pinnedDocs: {
+      [key]: [
+        {
+          id: TEST_PIN_ID,
+          relativePath,
+          label: label ?? relativePath,
+          addedAt: Date.now(),
+        },
+      ],
+    },
+  });
+}
+
+describe("PinnedDocViewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSettingsStore.setState({ pinnedDocs: {} });
+  });
+
+  it("shows 'Pin nicht gefunden' when pin does not exist", () => {
+    render(<PinnedDocViewer folder={TEST_FOLDER} pinId="nonexistent" />);
+    expect(screen.getByText("Pin nicht gefunden")).toBeInTheDocument();
+  });
+
+  it("shows loading state while fetching", () => {
+    setupPinnedDoc("docs/guide.md", "Guide");
+    mockInvoke.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<PinnedDocViewer folder={TEST_FOLDER} pinId={TEST_PIN_ID} />);
+    expect(screen.getByText(/Lade docs\/guide.md/)).toBeInTheDocument();
+  });
+
+  it("renders document content after loading", async () => {
+    setupPinnedDoc("docs/guide.md", "Guide");
+    mockInvoke.mockResolvedValue("# Guide\n\nHelpful content.");
+    render(<PinnedDocViewer folder={TEST_FOLDER} pinId={TEST_PIN_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-preview")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("markdown-preview")).toHaveTextContent("# Guide");
+  });
+
+  it("shows error state when loading fails", async () => {
+    setupPinnedDoc("docs/missing.md", "Missing Doc");
+    mockInvoke.mockRejectedValue(new Error("file not found"));
+    render(<PinnedDocViewer folder={TEST_FOLDER} pinId={TEST_PIN_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Fehler beim Laden")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Erneut versuchen")).toBeInTheDocument();
+  });
+
+  it("shows empty file state when content is empty", async () => {
+    setupPinnedDoc("docs/empty.md", "Empty Doc");
+    mockInvoke.mockResolvedValue("");
+    render(<PinnedDocViewer folder={TEST_FOLDER} pinId={TEST_PIN_ID} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Datei existiert nicht oder ist leer"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("enters edit mode and can save", async () => {
+    setupPinnedDoc("docs/guide.md", "Guide");
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "read_project_file") return Promise.resolve("original content");
+      if (cmd === "write_project_file") return Promise.resolve(undefined);
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<PinnedDocViewer folder={TEST_FOLDER} pinId={TEST_PIN_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-preview")).toBeInTheDocument();
+    });
+
+    // Enter edit mode
+    fireEvent.click(screen.getByLabelText("Datei bearbeiten"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("code-editor")).toBeInTheDocument();
+    });
+
+    // Modify and save
+    fireEvent.change(screen.getByTestId("code-editor"), {
+      target: { value: "updated content" },
+    });
+
+    fireEvent.click(screen.getByLabelText("Datei speichern"));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("write_project_file", {
+        folder: TEST_FOLDER,
+        relativePath: "docs/guide.md",
+        content: "updated content",
+      });
+    });
+  });
+});

--- a/src/components/sessions/SessionHistoryViewer.test.tsx
+++ b/src/components/sessions/SessionHistoryViewer.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import SessionHistoryViewer from "./SessionHistoryViewer";
+
+// Mock @tauri-apps/api/core
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+const mockSession = {
+  session_id: "sess-001",
+  title: "Fix login bug",
+  started_at: "2026-04-05T10:00:00Z",
+  ended_at: "2026-04-05T10:30:00Z",
+  model: "claude-opus-4-20250514",
+  user_turns: 5,
+  total_messages: 20,
+  subagent_count: 2,
+  git_branch: "fix/login",
+  cwd: "/projects/app",
+};
+
+const mockSession2 = {
+  session_id: "sess-002",
+  title: "Add unit tests",
+  started_at: "2026-04-04T14:00:00Z",
+  ended_at: "2026-04-04T15:15:00Z",
+  model: "claude-sonnet-4-20250514",
+  user_turns: 12,
+  total_messages: 40,
+  subagent_count: 0,
+  git_branch: "test/coverage",
+  cwd: "/projects/app",
+};
+
+describe("SessionHistoryViewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    mockInvoke.mockReturnValue(new Promise(() => {}));
+    render(<SessionHistoryViewer folder="/test/project" />);
+    expect(screen.getByText("Sessions werden geladen...")).toBeInTheDocument();
+  });
+
+  it("renders session list", async () => {
+    mockInvoke.mockResolvedValue([mockSession, mockSession2]);
+
+    render(<SessionHistoryViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("2 Sessions")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Fix login bug")).toBeInTheDocument();
+    expect(screen.getByText("Add unit tests")).toBeInTheDocument();
+
+    // Model display
+    expect(screen.getByText("Opus")).toBeInTheDocument();
+    expect(screen.getByText("Sonnet")).toBeInTheDocument();
+
+    // Git branch
+    expect(screen.getByText("fix/login")).toBeInTheDocument();
+    expect(screen.getByText("test/coverage")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no sessions found", async () => {
+    mockInvoke.mockResolvedValue([]);
+
+    render(<SessionHistoryViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Keine Claude-Sessions fuer dieses Projekt gefunden"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows error state when loading fails", async () => {
+    mockInvoke.mockRejectedValue(new Error("scan failed"));
+
+    render(<SessionHistoryViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Fehler beim Laden/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Erneut versuchen")).toBeInTheDocument();
+  });
+
+  it("calls onResumeSession when clicking resume button", async () => {
+    mockInvoke.mockResolvedValue([mockSession]);
+    const handleResume = vi.fn();
+
+    render(
+      <SessionHistoryViewer
+        folder="/test/project"
+        onResumeSession={handleResume}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeInTheDocument();
+    });
+
+    const resumeBtn = screen.getByTitle("Session fortsetzen");
+    fireEvent.click(resumeBtn);
+
+    expect(handleResume).toHaveBeenCalledWith("sess-001", "/projects/app");
+  });
+
+  it("does not show resume button when onResumeSession is not provided", async () => {
+    mockInvoke.mockResolvedValue([mockSession]);
+
+    render(<SessionHistoryViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTitle("Session fortsetzen")).not.toBeInTheDocument();
+  });
+
+  it("shows subagent count only when > 0", async () => {
+    mockInvoke.mockResolvedValue([mockSession, mockSession2]);
+
+    render(<SessionHistoryViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeInTheDocument();
+    });
+
+    // mockSession has 2 subagents, mockSession2 has 0
+    expect(screen.getByText("2")).toBeInTheDocument(); // subagent count for session 1
+    // Session 2 should not have a subagent count displayed
+    // (5 and 12 are user_turns, not subagent counts)
+  });
+
+  it("refreshes on button click", async () => {
+    mockInvoke.mockResolvedValue([mockSession]);
+
+    render(<SessionHistoryViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeInTheDocument();
+    });
+
+    const refreshBtn = screen.getByTitle("Neu laden");
+    fireEvent.click(refreshBtn);
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("shows singular 'Session' for single result", async () => {
+    mockInvoke.mockResolvedValue([mockSession]);
+
+    render(<SessionHistoryViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("1 Session")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/sessions/SkillsViewer.test.tsx
+++ b/src/components/sessions/SkillsViewer.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { SkillsViewer } from "./SkillsViewer";
+
+// Mock @tauri-apps/api/core
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+const skillContent1 = `---
+name: implement
+description: Issue to PR workflow
+user-invokable: true
+args:
+  - name: issue
+    description: GitHub issue number
+    required: true
+---
+
+# Implement Skill
+
+Steps to implement a feature.`;
+
+const skillContent2 = `---
+name: auto-lint
+description: Automatic linting hook
+user-invokable: false
+---
+
+# Auto Lint
+
+Runs lint automatically.`;
+
+describe("SkillsViewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    mockInvoke.mockReturnValue(new Promise(() => {}));
+    render(<SkillsViewer folder="/test/project" />);
+    expect(screen.getByText("Lade Skills...")).toBeInTheDocument();
+  });
+
+  it("renders skill list via list_skill_dirs", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_skill_dirs") {
+        return Promise.resolve([
+          {
+            dir_name: "implement",
+            content: skillContent1,
+            has_reference_dir: true,
+          },
+          {
+            dir_name: "auto-lint",
+            content: skillContent2,
+            has_reference_dir: false,
+          },
+        ]);
+      }
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<SkillsViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Skills (2)")).toBeInTheDocument();
+    });
+
+    // "implement" appears in both list and detail (auto-selected first item)
+    expect(screen.getAllByText("implement").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("auto-lint")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no skills found", async () => {
+    mockInvoke.mockRejectedValue(new Error("not found"));
+
+    render(<SkillsViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Keine Skills in diesem Projekt konfiguriert"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("filters skills by invokable type", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_skill_dirs") {
+        return Promise.resolve([
+          { dir_name: "implement", content: skillContent1, has_reference_dir: false },
+          { dir_name: "auto-lint", content: skillContent2, has_reference_dir: false },
+        ]);
+      }
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<SkillsViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Skills (2)")).toBeInTheDocument();
+    });
+
+    // Filter to "Aufrufbar" (user-invokable) — multiple "Aufrufbar" exist (filter btn + badge)
+    const aufrufbarButtons = screen.getAllByText("Aufrufbar");
+    fireEvent.click(aufrufbarButtons[0]); // filter button
+
+    // Only invokable skill should show
+    expect(screen.getAllByText("implement").length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("auto-lint")).not.toBeInTheDocument();
+
+    // Filter to "Automatisch"
+    const autoButtons = screen.getAllByText("Automatisch");
+    fireEvent.click(autoButtons[0]);
+
+    // "implement" should no longer be in the list, only in the detail (if still selected)
+    expect(screen.getByText("auto-lint")).toBeInTheDocument();
+  });
+
+  it("searches skills by name", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_skill_dirs") {
+        return Promise.resolve([
+          { dir_name: "implement", content: skillContent1, has_reference_dir: false },
+          { dir_name: "auto-lint", content: skillContent2, has_reference_dir: false },
+        ]);
+      }
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<SkillsViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Skills (2)")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText("Suchen...");
+    fireEvent.change(searchInput, { target: { value: "lint" } });
+
+    // auto-lint is shown in the filtered list
+    expect(screen.getAllByText("auto-lint").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("auto-selects first skill and shows detail", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_skill_dirs") {
+        return Promise.resolve([
+          { dir_name: "implement", content: skillContent1, has_reference_dir: true },
+        ]);
+      }
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<SkillsViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      // Detail pane shows the skill description
+      expect(screen.getAllByText("Issue to PR workflow").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Args section should show the parameter
+    expect(screen.getByText("Parameter")).toBeInTheDocument();
+    expect(screen.getByText("issue")).toBeInTheDocument();
+  });
+
+  it("falls back to legacy loading when list_skill_dirs fails", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_skill_dirs") {
+        return Promise.reject(new Error("command not found"));
+      }
+      if (cmd === "list_project_dir") {
+        return Promise.resolve(["implement.md"]);
+      }
+      if (cmd === "read_project_file") {
+        return Promise.resolve(skillContent1);
+      }
+      return Promise.reject(new Error("unknown"));
+    });
+
+    render(<SkillsViewer folder="/test/project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Skills (1)")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/sessions/WorktreeViewer.test.tsx
+++ b/src/components/sessions/WorktreeViewer.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { WorktreeViewer } from "./WorktreeViewer";
+
+// Mock @tauri-apps/api/core
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+describe("WorktreeViewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    mockInvoke.mockReturnValue(new Promise(() => {}));
+    render(<WorktreeViewer folder="/test/project" />);
+    expect(screen.getByText("Laden...")).toBeInTheDocument();
+  });
+
+  it("renders worktree list", async () => {
+    mockInvoke.mockResolvedValue([
+      { path: "/projects/main", branch: "master", is_main: true },
+      { path: "/projects/.claude/worktrees/feature-x", branch: "feature-x", is_main: false },
+    ]);
+
+    render(<WorktreeViewer folder="/test/wt-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Worktrees (2)")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("master")).toBeInTheDocument();
+    expect(screen.getByText("feature-x")).toBeInTheDocument();
+    expect(screen.getByText("Haupt")).toBeInTheDocument(); // main badge
+    expect(screen.getByText("/projects/main")).toBeInTheDocument();
+  });
+
+  it("shows error state when scan fails", async () => {
+    mockInvoke.mockRejectedValue(new Error("git error: not a repository"));
+
+    render(<WorktreeViewer folder="/test/error-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("git error: not a repository")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty worktree message", async () => {
+    mockInvoke.mockResolvedValue([]);
+
+    render(<WorktreeViewer folder="/test/empty-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Keine Worktrees gefunden")).toBeInTheDocument();
+    });
+  });
+
+  it("handles detached HEAD worktrees", async () => {
+    mockInvoke.mockResolvedValue([
+      { path: "/projects/detached", branch: null, is_main: false },
+    ]);
+
+    render(<WorktreeViewer folder="/test/detached-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("detached")).toBeInTheDocument();
+    });
+  });
+
+  it("refreshes on button click", async () => {
+    mockInvoke.mockResolvedValue([
+      { path: "/projects/main", branch: "master", is_main: true },
+    ]);
+
+    render(<WorktreeViewer folder="/test/refresh-project" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Worktrees (1)")).toBeInTheDocument();
+    });
+
+    const refreshBtn = screen.getByTitle("Neu laden");
+    fireEvent.click(refreshBtn);
+
+    // Should invoke again with force
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 50 tests across 7 previously uncovered session viewer components (ClaudeMdViewer, GitHubViewer, LibraryViewer, SkillsViewer, PinnedDocViewer, WorktreeViewer, SessionHistoryViewer)
- Covers loading states, data rendering, empty/error states, user interactions (edit, save, filter, search, refresh), and edge cases (detached HEAD, legacy fallback)
- Statement coverage improved from ~47% to ~61%

## Test plan
- [x] All 715 tests pass (`npm run test -- --run`)
- [x] TypeScript types check (`npx tsc --noEmit`)
- [x] Coverage verified via `npm run test:coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)