### PR TITLE
fix(ui): SideNav Labels + Sprachmix + Settings ausblenden (#133, #137, #138)

### DIFF
--- a/src/components/layout/SideNav.test.tsx
+++ b/src/components/layout/SideNav.test.tsx
@@ -13,21 +13,22 @@ describe("SideNav", () => {
     vi.clearAllMocks();
   });
 
-  it("renders all 7 nav items with aria-labels", () => {
+  it("renders all 6 visible nav items with German labels", () => {
     render(<SideNav />);
-    expect(screen.getByLabelText("Sessions")).toBeTruthy();
+    expect(screen.getByLabelText("Sitzungen")).toBeTruthy();
     expect(screen.getByLabelText("Pipeline")).toBeTruthy();
     expect(screen.getByLabelText("Kanban")).toBeTruthy();
-    expect(screen.getByLabelText("Library")).toBeTruthy();
+    expect(screen.getByLabelText("Bibliothek")).toBeTruthy();
     expect(screen.getByLabelText("Editor")).toBeTruthy();
-    expect(screen.getByLabelText("Logs")).toBeTruthy();
-    expect(screen.getByLabelText("Einstellungen")).toBeTruthy();
+    expect(screen.getByLabelText("Protokolle")).toBeTruthy();
+    // Settings tab is hidden (#138)
+    expect(screen.queryByLabelText("Einstellungen")).toBeNull();
   });
 
   it("highlights active tab and calls setActiveTab on click", () => {
     render(<SideNav />);
 
-    const sessionsBtn = screen.getByLabelText("Sessions");
+    const sessionsBtn = screen.getByLabelText("Sitzungen");
     // active tab has "text-accent" class
     expect(sessionsBtn.className).toContain("text-accent");
 
@@ -37,6 +38,14 @@ describe("SideNav", () => {
 
     fireEvent.click(pipelineBtn);
     expect(useUIStore.getState().activeTab).toBe("pipeline");
+  });
+
+  it("shows permanent text labels (not just icon tooltips)", () => {
+    render(<SideNav />);
+    expect(screen.getByText("Sitzungen")).toBeTruthy();
+    expect(screen.getByText("Pipeline")).toBeTruthy();
+    expect(screen.getByText("Bibliothek")).toBeTruthy();
+    expect(screen.getByText("Protokolle")).toBeTruthy();
   });
 
   it("renders badge when count > 0 and hides when 0 or undefined", () => {

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -1,4 +1,4 @@
-import { Monitor, Activity, Columns3, ScrollText, BookOpen, Settings, FileEdit } from "lucide-react";
+import { Monitor, Activity, Columns3, ScrollText, BookOpen, FileEdit } from "lucide-react";
 import { useUIStore, type ActiveTab } from "../../store/uiStore";
 
 interface NavItem {
@@ -16,16 +16,15 @@ export function SideNav({ badges = {} }: SideNavProps) {
   const { activeTab, setActiveTab } = useUIStore();
 
   const topItems: NavItem[] = [
-    { id: "sessions", label: "Sessions", icon: Monitor, badge: badges.sessions },
+    { id: "sessions", label: "Sitzungen", icon: Monitor, badge: badges.sessions },
     { id: "pipeline", label: "Pipeline", icon: Activity, badge: badges.pipeline },
     { id: "kanban", label: "Kanban", icon: Columns3, badge: badges.kanban },
-    { id: "library", label: "Library", icon: BookOpen, badge: badges.library },
+    { id: "library", label: "Bibliothek", icon: BookOpen, badge: badges.library },
     { id: "editor", label: "Editor", icon: FileEdit, badge: badges.editor },
   ];
 
   const bottomItems: NavItem[] = [
-    { id: "logs", label: "Logs", icon: ScrollText, badge: badges.logs },
-    { id: "settings", label: "Einstellungen", icon: Settings, badge: badges.settings },
+    { id: "logs", label: "Protokolle", icon: ScrollText, badge: badges.logs },
   ];
 
   function renderItem(item: NavItem) {
@@ -37,8 +36,8 @@ export function SideNav({ badges = {} }: SideNavProps) {
         key={item.id}
         onClick={() => setActiveTab(item.id)}
         className={`
-          relative group flex items-center justify-center w-10 h-10 rounded-none
-          transition-all duration-150
+          relative flex items-center gap-2 w-full h-9 px-3 rounded-none
+          transition-all duration-150 text-left
           ${isActive
             ? "text-accent bg-accent-a10 border-l-2 border-accent"
             : "text-neutral-400 hover:text-neutral-200 hover:bg-hover-overlay border-l-2 border-transparent"
@@ -46,27 +45,23 @@ export function SideNav({ badges = {} }: SideNavProps) {
         `}
         aria-label={item.label}
       >
-        <Icon className="w-5 h-5" />
+        <Icon className="w-4 h-4 shrink-0" />
+        <span className="text-xs truncate">{item.label}</span>
 
         {/* Badge */}
         {item.badge != null && item.badge > 0 && (
-          <span className="absolute -top-0.5 -right-0.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-error text-white text-[9px] font-bold px-1">
+          <span className="ml-auto min-w-[16px] h-4 flex items-center justify-center rounded-full bg-error text-white text-[9px] font-bold px-1">
             {item.badge > 99 ? "99+" : item.badge}
           </span>
         )}
-
-        {/* Tooltip */}
-        <span className="absolute left-full ml-2 px-2 py-1 text-xs text-neutral-100 bg-surface-raised border border-neutral-700 rounded-none whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-50">
-          {item.label}
-        </span>
       </button>
     );
   }
 
   return (
-    <nav className="flex flex-col items-center w-12 min-w-[48px] bg-surface-base border-r border-neutral-700 py-2 gap-1">
+    <nav className="flex flex-col w-32 min-w-[128px] bg-surface-base border-r border-neutral-700 py-2 gap-0.5">
       {topItems.map(renderItem)}
-      <div className="mt-auto flex flex-col items-center gap-1">
+      <div className="mt-auto flex flex-col gap-0.5">
         {bottomItems.map(renderItem)}
       </div>
     </nav>

--- a/src/components/layout/placeholders.tsx
+++ b/src/components/layout/placeholders.tsx
@@ -1,7 +1,7 @@
 export function SettingsPlaceholder() {
   return (
     <div className="flex items-center justify-center h-full w-full bg-surface-base text-neutral-500 text-sm font-mono">
-      Einstellungen — kommt im naechsten Sprint
+      Einstellungen — kommt im nächsten Sprint
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **#133 Sprachmix bereinigen**: Nav-Labels einheitlich Deutsch (Sitzungen, Bibliothek, Protokolle). Etablierte Dev-Begriffe (Pipeline, Kanban, Editor) beibehalten.
- **#137 Permanente Labels**: Icons + Text-Labels immer sichtbar, Nav-Breite von 48px auf 128px. Tooltips entfernt (redundant).
- **#138 Settings ausblenden**: Settings-Tab aus SideNav entfernt. `ActiveTab`-Typ bleibt fuer spaetere Nutzung erhalten. Umlaut-Fix in placeholders.tsx.

## Test plan
- [x] Bestehende SideNav-Tests aktualisiert (deutsche Labels, Settings hidden, permanente Labels)
- [x] 908/908 Tests gruen
- [x] `npx tsc --noEmit` fehlerfrei
- [x] `npm run build` erfolgreich
- [ ] Visuelle Pruefung im Dev-Modus

Closes #133, closes #137, closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)