### PR TITLE
fix(ui): Filled CTA-Buttons für primäre Aktionen (#139)

### DIFF
--- a/src/components/editor/MarkdownEditorView.tsx
+++ b/src/components/editor/MarkdownEditorView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FileEdit } from "lucide-react";
+import { Button } from "../ui/Button";
 import {
   useEditorStore,
   selectIsDirty,
@@ -20,13 +21,13 @@ function EmptyState() {
     <div className="flex flex-col items-center justify-center h-full gap-4 text-neutral-400">
       <FileEdit className="w-12 h-12 text-neutral-600" />
       <p className="text-sm">Keine Datei geoeffnet</p>
-      <button
+      <Button
+        variant="primary"
         onClick={openFileFromDialog}
-        className="px-4 py-2 text-sm text-accent border border-accent rounded hover:bg-accent-a10 transition-colors"
         aria-label="Markdown-Datei oeffnen"
       >
         Markdown-Datei oeffnen
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/sessions/EmptyState.tsx
+++ b/src/components/sessions/EmptyState.tsx
@@ -1,4 +1,5 @@
 import { Plus } from "lucide-react";
+import { Button } from "../ui/Button";
 
 interface EmptyStateProps {
   onNewSession: () => void;
@@ -7,13 +8,15 @@ interface EmptyStateProps {
 export function EmptyState({ onNewSession }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center h-full w-full bg-surface-base">
-      <button
+      <Button
+        variant="primary"
+        size="lg"
+        icon={<Plus className="w-5 h-5" />}
         onClick={onNewSession}
-        className="flex items-center gap-2 px-6 py-3 bg-neon-green/10 border-2 border-neon-green text-neon-green font-bold text-sm tracking-widest hover:bg-neon-green/20 transition-colors"
+        className="tracking-widest"
       >
-        <Plus className="w-5 h-5" />
         NEUE SESSION STARTEN
-      </button>
+      </Button>
       <p className="mt-4 text-neutral-500 text-sm text-center max-w-xs">
         Waehle einen Ordner und starte eine Claude Session.
         <br />

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -24,7 +24,7 @@ const baseClasses =
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    "bg-neon-green/10 border border-neon-green text-neon-green hover:bg-neon-green/20 tracking-wider font-bold",
+    "bg-neon-green text-neutral-900 font-bold tracking-wider hover:bg-neon-green/90 border border-transparent",
   secondary:
     "border border-neutral-700 text-neutral-400 hover:text-neutral-200 hover:border-neutral-500",
   ghost:


### PR DESCRIPTION
## Summary
- Primary button variant changed from outline style (`bg-neon-green/10 border border-neon-green`) to filled style (`bg-neon-green text-neutral-900 font-bold`)
- EmptyState buttons in `SessionManagerView` and `MarkdownEditorView` now use the shared `Button` component instead of duplicating inline styles
- Secondary, ghost, and danger variants remain unchanged

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run test -- --run` all tests green
- [x] `npm run build` succeeds
- [ ] Visual check: primary CTAs appear as filled green buttons with dark text
- [ ] Visual check: secondary/ghost buttons remain outline-style

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)