### PR TITLE
fix(a11y): Toast aria-live + aria-hidden auf dekorativen Icons (#134)

### DIFF
--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -30,7 +30,7 @@ export function EditorToolbar() {
 
   return (
     <div className="flex items-center gap-2 px-4 py-2 bg-surface-raised border-b border-neutral-700 min-h-[44px]">
-      <FileEdit className="w-4 h-4 text-accent shrink-0" />
+      <FileEdit className="w-4 h-4 text-accent shrink-0" aria-hidden="true" />
 
       {/* File name */}
       <div className="flex items-center gap-1.5 min-w-0 flex-1">
@@ -63,7 +63,7 @@ export function EditorToolbar() {
           title="Datei oeffnen"
           aria-label="Markdown-Datei oeffnen"
         >
-          <FolderOpen className="w-3.5 h-3.5" />
+          <FolderOpen className="w-3.5 h-3.5" aria-hidden="true" />
           <span className="hidden sm:inline">Oeffnen</span>
         </button>
 
@@ -78,7 +78,7 @@ export function EditorToolbar() {
           title="Speichern (Ctrl+S)"
           aria-label="Datei speichern"
         >
-          <Save className="w-3.5 h-3.5" />
+          <Save className="w-3.5 h-3.5" aria-hidden="true" />
           <span className="hidden sm:inline">
             {isSaving ? "Speichert..." : "Speichern"}
           </span>
@@ -91,9 +91,9 @@ export function EditorToolbar() {
           aria-label={isPreviewVisible ? "Vorschau ausblenden" : "Vorschau einblenden"}
         >
           {isPreviewVisible ? (
-            <EyeOff className="w-3.5 h-3.5" />
+            <EyeOff className="w-3.5 h-3.5" aria-hidden="true" />
           ) : (
-            <Eye className="w-3.5 h-3.5" />
+            <Eye className="w-3.5 h-3.5" aria-hidden="true" />
           )}
         </button>
 
@@ -104,7 +104,7 @@ export function EditorToolbar() {
             title="Datei schliessen"
             aria-label="Datei schliessen"
           >
-            <X className="w-3.5 h-3.5" />
+            <X className="w-3.5 h-3.5" aria-hidden="true" />
           </button>
         )}
       </div>

--- a/src/components/sessions/SessionStatusBar.tsx
+++ b/src/components/sessions/SessionStatusBar.tsx
@@ -11,25 +11,25 @@ export function SessionStatusBar() {
   const activeSession = useSessionStore(selectActiveSession);
 
   return (
-    <div className="flex items-center justify-between px-4 py-1.5 bg-surface-raised border-t border-neutral-700 text-xs font-mono">
+    <div className="flex items-center justify-between px-4 py-1.5 bg-surface-raised border-t border-neutral-700 text-xs font-mono" role="status">
       <div className="flex items-center gap-4">
         <span className="flex items-center gap-1.5">
-          <span className={`w-2 h-2 rounded-full bg-success ${counts.active > 0 ? "status-pulse-animation" : ""}`} />
+          <span className={`w-2 h-2 rounded-full bg-success ${counts.active > 0 ? "status-pulse-animation" : ""}`} aria-hidden="true" />
           <span className="text-neutral-400">{counts.active} aktiv</span>
         </span>
-        <span className="text-neutral-600">·</span>
+        <span className="text-neutral-600" aria-hidden="true">·</span>
         <span className="flex items-center gap-1.5">
-          <span className={`w-2 h-2 rounded-full bg-warning ${counts.waiting > 0 ? "status-pulse-animation" : ""}`} />
+          <span className={`w-2 h-2 rounded-full bg-warning ${counts.waiting > 0 ? "status-pulse-animation" : ""}`} aria-hidden="true" />
           <span className="text-neutral-400">{counts.waiting} wartend</span>
         </span>
-        <span className="text-neutral-600">·</span>
+        <span className="text-neutral-600" aria-hidden="true">·</span>
         <span className="flex items-center gap-1.5">
-          <span className="w-2 h-2 rounded-full bg-neutral-500" />
+          <span className="w-2 h-2 rounded-full bg-neutral-500" aria-hidden="true" />
           <span className="text-neutral-400">{counts.done} fertig</span>
         </span>
-        <span className="text-neutral-600">·</span>
+        <span className="text-neutral-600" aria-hidden="true">·</span>
         <span className="flex items-center gap-1.5">
-          <span className="w-2 h-2 rounded-full bg-error" />
+          <span className="w-2 h-2 rounded-full bg-error" aria-hidden="true" />
           <span className="text-neutral-400">{counts.error} Fehler</span>
         </span>
       </div>

--- a/src/components/shared/Toast.tsx
+++ b/src/components/shared/Toast.tsx
@@ -68,9 +68,10 @@ export function Toast({ toast, onDismiss }: ToastProps) {
       transition={{ type: "spring", stiffness: 400, damping: 30 }}
       className={`w-80 rounded-none border-2 ${config.border} bg-surface-raised pointer-events-auto`}
       style={{ boxShadow: config.glow }}
+      role="alert"
     >
       <div className="flex items-start gap-3 px-4 py-3">
-        <Icon className={`w-5 h-5 ${config.text} shrink-0 mt-0.5`} />
+        <Icon className={`w-5 h-5 ${config.text} shrink-0 mt-0.5`} aria-hidden="true" />
         <div className="flex-1 min-w-0">
           <p className={`text-sm font-bold tracking-wide ${config.text}`}>
             {toast.title}
@@ -84,8 +85,9 @@ export function Toast({ toast, onDismiss }: ToastProps) {
         <button
           onClick={() => onDismiss(toast.id)}
           className="text-neutral-500 hover:text-neutral-300 transition-colors shrink-0"
+          aria-label="Benachrichtigung schließen"
         >
-          <X className="w-4 h-4" />
+          <X className="w-4 h-4" aria-hidden="true" />
         </button>
       </div>
     </motion.div>

--- a/src/components/shared/ToastContainer.tsx
+++ b/src/components/shared/ToastContainer.tsx
@@ -19,7 +19,7 @@ export function ToastContainer() {
   const visibleToasts = toasts.slice(-MAX_VISIBLE_TOASTS);
 
   return (
-    <div className="fixed top-4 right-4 z-50 flex flex-col gap-3 pointer-events-none">
+    <div className="fixed top-4 right-4 z-50 flex flex-col gap-3 pointer-events-none" aria-live="polite">
       <AnimatePresence mode="popLayout">
         {visibleToasts.map((t) => (
           <Toast


### PR DESCRIPTION
## Summary
- ToastContainer: `aria-live="polite"` auf dem Container, `role="alert"` auf jedem Toast
- Toast: `aria-label="Benachrichtigung schließen"` auf dem Dismiss-Button, `aria-hidden="true"` auf dekorativen Icons
- SessionStatusBar: `role="status"` auf dem Container, `aria-hidden="true"` auf Farbpunkten und Trenner-Dots
- EditorToolbar: `aria-hidden="true"` auf allen dekorativen Icons in Buttons (die bereits `aria-label` haben)

Closes #134

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run test -- --run` passes (907 tests)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)