### PR TITLE
feat(logs): Error-Grouping + Virtualisierung + React.memo (#136)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "agenticexplorer",
-  "version": "1.4.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenticexplorer",
-      "version": "1.4.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",
+        "@tanstack/react-virtual": "^3.13.23",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",
         "@tauri-apps/plugin-process": "^2.3.1",
@@ -2192,6 +2193,33 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -2638,7 +2666,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
+    "@tanstack/react-virtual": "^3.13.23",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/src/components/logs/LogEntry.tsx
+++ b/src/components/logs/LogEntry.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import { ChevronRight, ChevronDown } from "lucide-react";
-import type { UnifiedLogEntry } from "../../store/logViewerStore";
+import type { GroupedLogEntry } from "../../store/logViewerStore";
 
 const severityColors: Record<string, string> = {
   error: "text-red-400 bg-red-400/10",
@@ -30,22 +30,28 @@ function formatTime(timestamp: string): string {
   }
 }
 
+/** Fixed row height for virtualization (px) */
+export const LOG_ROW_HEIGHT = 32;
+
 interface LogEntryRowProps {
-  entry: UnifiedLogEntry;
+  entry: GroupedLogEntry;
 }
 
-export function LogEntryRow({ entry }: LogEntryRowProps) {
+export const LogEntryRow = memo(function LogEntryRow({
+  entry,
+}: LogEntryRowProps) {
   const [expanded, setExpanded] = useState(false);
   const hasStack = !!entry.stack;
 
   return (
     <div className="group border-b border-neutral-800 hover:bg-neutral-800/30 font-mono text-xs">
       <div
-        className={`flex items-start gap-2 px-3 py-1 ${hasStack ? "cursor-pointer" : ""}`}
+        className={`flex items-center gap-2 px-3 ${hasStack ? "cursor-pointer" : ""}`}
+        style={{ height: LOG_ROW_HEIGHT }}
         onClick={hasStack ? () => setExpanded(!expanded) : undefined}
       >
         {/* Expand icon for stack traces */}
-        <span className="w-3 shrink-0 pt-0.5">
+        <span className="w-3 shrink-0">
           {hasStack &&
             (expanded ? (
               <ChevronDown className="w-3 h-3 text-neutral-500" />
@@ -73,6 +79,13 @@ export function LogEntryRow({ entry }: LogEntryRowProps) {
           {entry.source}
         </span>
 
+        {/* Group count badge */}
+        {entry.count > 1 && (
+          <span className="shrink-0 px-1.5 rounded text-[10px] font-semibold bg-neutral-600/40 text-neutral-300">
+            &times;{entry.count}
+          </span>
+        )}
+
         {/* Module */}
         {entry.module && (
           <span className="text-neutral-500 shrink-0 truncate max-w-[200px]">
@@ -92,4 +105,4 @@ export function LogEntryRow({ entry }: LogEntryRowProps) {
       )}
     </div>
   );
-}
+});

--- a/src/components/logs/LogViewer.test.tsx
+++ b/src/components/logs/LogViewer.test.tsx
@@ -17,6 +17,26 @@ vi.mock("../../utils/errorLogger", () => ({
   logError: vi.fn(),
 }));
 
+// Mock @tanstack/react-virtual — jsdom has no layout engine, so the virtualizer
+// would render zero rows. This mock renders all items directly.
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: (opts: {
+    count: number;
+    estimateSize: () => number;
+    getScrollElement: () => HTMLElement | null;
+  }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: opts.count }, (_, i) => ({
+        index: i,
+        start: i * opts.estimateSize(),
+        size: opts.estimateSize(),
+        key: i,
+      })),
+    getTotalSize: () => opts.count * opts.estimateSize(),
+    scrollToIndex: vi.fn(),
+  }),
+}));
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -106,7 +126,7 @@ describe("LogViewer", () => {
     ]);
 
     render(<LogViewer />);
-    expect(screen.getByText(/2 von 2 Einträgen/)).toBeInTheDocument();
+    expect(screen.getByText(/2 Gruppen von 2 Einträgen/)).toBeInTheDocument();
   });
 
   it("filters entries by severity", () => {
@@ -133,6 +153,36 @@ describe("LogViewer", () => {
     render(<LogViewer />);
     expect(screen.getByText("error msg")).toBeInTheDocument();
     expect(screen.queryByText("info msg")).not.toBeInTheDocument();
-    expect(screen.getByText(/1 von 2 Einträgen/)).toBeInTheDocument();
+    expect(screen.getByText(/1 Gruppen von 2 Einträgen/)).toBeInTheDocument();
+  });
+
+  it("groups consecutive identical entries and shows count badge", () => {
+    // Add 3 identical error entries
+    useLogViewerStore.getState().addEntries([
+      {
+        timestamp: "2025-01-15T10:30:00.000Z",
+        severity: "error",
+        source: "frontend",
+        message: "repeated error",
+      },
+      {
+        timestamp: "2025-01-15T10:30:01.000Z",
+        severity: "error",
+        source: "frontend",
+        message: "repeated error",
+      },
+      {
+        timestamp: "2025-01-15T10:30:02.000Z",
+        severity: "error",
+        source: "frontend",
+        message: "repeated error",
+      },
+    ]);
+
+    render(<LogViewer />);
+    // Should show 1 grouped row, not 3
+    expect(screen.getByText(/1 Gruppen von 3 Einträgen/)).toBeInTheDocument();
+    // The group count badge should show ×3
+    expect(screen.getByText("×3")).toBeInTheDocument();
   });
 });

--- a/src/components/logs/LogViewer.tsx
+++ b/src/components/logs/LogViewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useMemo, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   RefreshCw,
   Trash2,
@@ -10,11 +11,12 @@ import {
 import {
   useLogViewerStore,
   parseBackendLogLine,
+  groupConsecutiveEntries,
   type LogSeverity,
   type LogSource,
 } from "../../store/logViewerStore";
 import { getRecentLogs, subscribeToLogs, logError } from "../../utils/errorLogger";
-import { LogEntryRow } from "./LogEntry";
+import { LogEntryRow, LOG_ROW_HEIGHT } from "./LogEntry";
 
 const SEVERITY_OPTIONS: { key: LogSeverity; label: string; color: string }[] = [
   { key: "error", label: "Error", color: "bg-red-400/20 text-red-400 border-red-400/40" },
@@ -114,23 +116,32 @@ export function LogViewer() {
     return unsub;
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-scroll when liveTail is on
-  useEffect(() => {
-    if (liveTail && scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [entries.length, liveTail]);
-
-  // Filter entries
-  const filtered = useMemo(() => {
+  // Filter entries, then group consecutive identical ones
+  const grouped = useMemo(() => {
     const lowerSearch = searchText.toLowerCase();
-    return entries.filter((e) => {
+    const filtered = entries.filter((e) => {
       if (!severityFilter.has(e.severity)) return false;
       if (!sourceFilter.has(e.source)) return false;
       if (lowerSearch && !e.message.toLowerCase().includes(lowerSearch)) return false;
       return true;
     });
+    return groupConsecutiveEntries(filtered);
   }, [entries, severityFilter, sourceFilter, searchText]);
+
+  // Virtualizer for performant rendering
+  const virtualizer = useVirtualizer({
+    count: grouped.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => LOG_ROW_HEIGHT,
+    overscan: 20,
+  });
+
+  // Auto-scroll when liveTail is on
+  useEffect(() => {
+    if (liveTail && grouped.length > 0) {
+      virtualizer.scrollToIndex(grouped.length - 1, { align: "end" });
+    }
+  }, [grouped.length, liveTail, virtualizer]);
 
   const toggleSeverity = (key: LogSeverity) => {
     const next = new Set(severityFilter);
@@ -246,18 +257,39 @@ export function LogViewer() {
       {/* Entry count */}
       <div className="flex items-center justify-between px-4 py-1 text-[10px] text-neutral-500 border-b border-neutral-800">
         <span>
-          {filtered.length} von {entries.length} Einträgen
+          {grouped.length} Gruppen von {entries.length} Einträgen
         </span>
       </div>
 
-      {/* Log list */}
+      {/* Virtualized log list */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto">
-        {filtered.length === 0 ? (
+        {grouped.length === 0 ? (
           <div className="flex items-center justify-center h-32 text-neutral-500 text-sm">
             Keine Logs vorhanden
           </div>
         ) : (
-          filtered.map((entry) => <LogEntryRow key={entry.id} entry={entry} />)
+          <div
+            style={{
+              height: virtualizer.getTotalSize(),
+              width: "100%",
+              position: "relative",
+            }}
+          >
+            {virtualizer.getVirtualItems().map((virtualRow) => (
+              <div
+                key={grouped[virtualRow.index].id}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <LogEntryRow entry={grouped[virtualRow.index]} />
+              </div>
+            ))}
+          </div>
         )}
       </div>
     </div>

--- a/src/store/logViewerStore.test.ts
+++ b/src/store/logViewerStore.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   useLogViewerStore,
   parseBackendLogLine,
+  groupConsecutiveEntries,
   type UnifiedLogEntry,
 } from "./logViewerStore";
 
@@ -230,6 +231,66 @@ describe("noise filtering", () => {
 
     const stored = useLogViewerStore.getState().entries;
     expect(stored[0].severity).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupConsecutiveEntries
+// ---------------------------------------------------------------------------
+
+describe("groupConsecutiveEntries", () => {
+  it("returns empty array for empty input", () => {
+    expect(groupConsecutiveEntries([])).toEqual([]);
+  });
+
+  it("groups consecutive identical entries", () => {
+    const entries: UnifiedLogEntry[] = [
+      { id: 1, timestamp: "t1", severity: "error", source: "frontend", message: "fail" },
+      { id: 2, timestamp: "t2", severity: "error", source: "frontend", message: "fail" },
+      { id: 3, timestamp: "t3", severity: "error", source: "frontend", message: "fail" },
+    ];
+    const grouped = groupConsecutiveEntries(entries);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].count).toBe(3);
+    expect(grouped[0].id).toBe(1); // keeps first entry's id
+  });
+
+  it("does not group non-consecutive identical entries", () => {
+    const entries: UnifiedLogEntry[] = [
+      { id: 1, timestamp: "t1", severity: "error", source: "frontend", message: "fail" },
+      { id: 2, timestamp: "t2", severity: "info", source: "frontend", message: "ok" },
+      { id: 3, timestamp: "t3", severity: "error", source: "frontend", message: "fail" },
+    ];
+    const grouped = groupConsecutiveEntries(entries);
+    expect(grouped).toHaveLength(3);
+    expect(grouped.every((g) => g.count === 1)).toBe(true);
+  });
+
+  it("does not group entries with different severity", () => {
+    const entries: UnifiedLogEntry[] = [
+      { id: 1, timestamp: "t1", severity: "error", source: "frontend", message: "fail" },
+      { id: 2, timestamp: "t2", severity: "warn", source: "frontend", message: "fail" },
+    ];
+    const grouped = groupConsecutiveEntries(entries);
+    expect(grouped).toHaveLength(2);
+  });
+
+  it("does not group entries with different source", () => {
+    const entries: UnifiedLogEntry[] = [
+      { id: 1, timestamp: "t1", severity: "error", source: "frontend", message: "fail" },
+      { id: 2, timestamp: "t2", severity: "error", source: "backend", message: "fail" },
+    ];
+    const grouped = groupConsecutiveEntries(entries);
+    expect(grouped).toHaveLength(2);
+  });
+
+  it("handles single entry", () => {
+    const entries: UnifiedLogEntry[] = [
+      { id: 1, timestamp: "t1", severity: "info", source: "frontend", message: "hello" },
+    ];
+    const grouped = groupConsecutiveEntries(entries);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].count).toBe(1);
   });
 });
 

--- a/src/store/logViewerStore.ts
+++ b/src/store/logViewerStore.ts
@@ -13,6 +13,12 @@ export interface UnifiedLogEntry {
   stack?: string;
 }
 
+/** A log entry with a group count for consecutive identical entries */
+export interface GroupedLogEntry extends UnifiedLogEntry {
+  /** Number of consecutive identical entries (same message + source + severity) */
+  count: number;
+}
+
 const MAX_ENTRIES = 1000;
 let entryCounter = 0;
 
@@ -63,8 +69,17 @@ export const useLogViewerStore = create<LogViewerState>((set) => ({
         };
       });
       const merged = [...state.entries, ...processed];
-      // Sort by timestamp to ensure chronological order
-      merged.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+      // Skip sort when a single entry appends chronologically (live-tail).
+      // Sort for batches or when timestamps are out of order.
+      const needsSort =
+        processed.length > 1 ||
+        (state.entries.length > 0 &&
+          processed.length === 1 &&
+          processed[0].timestamp <
+            state.entries[state.entries.length - 1].timestamp);
+      if (needsSort) {
+        merged.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+      }
       return { entries: merged.slice(-MAX_ENTRIES) };
     }),
 
@@ -75,6 +90,35 @@ export const useLogViewerStore = create<LogViewerState>((set) => ({
   setSearchText: (text) => set({ searchText: text }),
   toggleLiveTail: () => set((state) => ({ liveTail: !state.liveTail })),
 }));
+
+/**
+ * Group consecutive entries with the same message, source, and severity.
+ * Reduces e.g. 33 identical errors to 1 entry with count=33.
+ */
+export function groupConsecutiveEntries(
+  entries: UnifiedLogEntry[],
+): GroupedLogEntry[] {
+  if (entries.length === 0) return [];
+
+  const result: GroupedLogEntry[] = [];
+  let current: GroupedLogEntry = { ...entries[0], count: 1 };
+
+  for (let i = 1; i < entries.length; i++) {
+    const e = entries[i];
+    if (
+      e.message === current.message &&
+      e.source === current.source &&
+      e.severity === current.severity
+    ) {
+      current.count++;
+    } else {
+      result.push(current);
+      current = { ...e, count: 1 };
+    }
+  }
+  result.push(current);
+  return result;
+}
 
 /** Parse a Rust backend log line into a UnifiedLogEntry (without id) */
 export function parseBackendLogLine(


### PR DESCRIPTION
## Summary
- **Error Grouping**: Consecutive identical log entries (same message, source, severity) are collapsed into a single row with a count badge (e.g. "x42"), reducing visual noise from repeated errors
- **List Virtualization**: Replaced `.map()` rendering with `@tanstack/react-virtual`, rendering only visible rows instead of all 1000 MAX_ENTRIES (reduces DOM nodes from 10,000+ to ~50)
- **React.memo**: `LogEntryRow` wrapped with `React.memo` to prevent re-renders of the entire list when new entries arrive
- **Sort Optimization**: `addEntries` skips O(n log n) sort for single chronological appends (live-tail); only sorts for batches or out-of-order timestamps
- **Fixed Row Height**: 32px per row for consistent virtualization and improved readability

Closes #136

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] All 914 tests pass (`npm run test -- --run`)
- [x] New tests for `groupConsecutiveEntries` (5 cases: empty, grouped, non-consecutive, different severity, different source, single)
- [x] Updated `LogViewer.test.tsx` with virtualizer mock and grouping assertion
- [ ] Visual check: open Logs tab, verify grouped entries show count badge and scroll is smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)