### PR TITLE
fix(ui): echte Umlaute in allen UI-Strings (#132)

### DIFF
--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -58,9 +58,9 @@ describe("Header", () => {
     expect(screen.getByText("v1.0.0-test")).toBeTruthy();
   });
 
-  it("shows 'Keine Session ausgewaehlt' when no active session", () => {
+  it("shows 'Keine Session ausgewählt' when no active session", () => {
     render(<Header />);
-    expect(screen.getByText("Keine Session ausgewaehlt")).toBeTruthy();
+    expect(screen.getByText("Keine Session ausgewählt")).toBeTruthy();
   });
 
   it("toggles theme between dark and light on button click", () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -92,7 +92,7 @@ export function Header() {
             </span>
           </div>
         ) : (
-          <span className="text-sm text-neutral-500">Keine Session ausgewaehlt</span>
+          <span className="text-sm text-neutral-500">Keine Session ausgewählt</span>
         )}
 
         {/* Divider */}

--- a/src/components/editor/EditorToolbar.test.tsx
+++ b/src/components/editor/EditorToolbar.test.tsx
@@ -52,11 +52,11 @@ describe("EditorToolbar", () => {
     resetStore();
   });
 
-  it("shows 'Keine Datei geoeffnet' when no file is open", () => {
+  it("shows 'Keine Datei geöffnet' when no file is open", () => {
     render(<EditorToolbar />);
-    expect(screen.getByText("Keine Datei geoeffnet")).toBeTruthy();
+    expect(screen.getByText("Keine Datei geöffnet")).toBeTruthy();
     // Close button should not exist without open file
-    expect(screen.queryByLabelText("Datei schliessen")).toBeNull();
+    expect(screen.queryByLabelText("Datei schließen")).toBeNull();
   });
 
   it("renders file path and dirty indicator when file is dirty", () => {
@@ -66,7 +66,7 @@ describe("EditorToolbar", () => {
     render(<EditorToolbar />);
     expect(screen.getByText("docs/readme.md")).toBeTruthy();
     // Dirty dot (role=img, aria-label)
-    expect(screen.getByLabelText("Ungespeicherte Aenderungen")).toBeTruthy();
+    expect(screen.getByLabelText("Ungespeicherte Änderungen")).toBeTruthy();
   });
 
   it("calls saveFile action when Save button clicked (and is dirty)", () => {
@@ -90,7 +90,7 @@ describe("EditorToolbar", () => {
     const saveBtn = screen.getByLabelText("Datei speichern") as HTMLButtonElement;
     expect(saveBtn.disabled).toBe(true);
     // No dirty indicator either
-    expect(screen.queryByLabelText("Ungespeicherte Aenderungen")).toBeNull();
+    expect(screen.queryByLabelText("Ungespeicherte Änderungen")).toBeNull();
   });
 
   it("toggles preview and closes file via corresponding buttons", () => {
@@ -108,7 +108,7 @@ describe("EditorToolbar", () => {
     fireEvent.click(previewBtn);
     expect(togglePreviewSpy).toHaveBeenCalledTimes(1);
 
-    const closeBtn = screen.getByLabelText("Datei schliessen");
+    const closeBtn = screen.getByLabelText("Datei schließen");
     fireEvent.click(closeBtn);
     expect(closeFileSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -42,15 +42,15 @@ export function EditorToolbar() {
             {isDirty && (
               <span
                 className="w-2 h-2 rounded-full bg-warning shrink-0"
-                title="Ungespeicherte Aenderungen"
-                aria-label="Ungespeicherte Aenderungen"
+                title="Ungespeicherte Änderungen"
+                aria-label="Ungespeicherte Änderungen"
                 role="img"
               />
             )}
           </>
         ) : (
           <span className="text-sm text-neutral-500">
-            Keine Datei geoeffnet
+            Keine Datei geöffnet
           </span>
         )}
       </div>
@@ -60,11 +60,11 @@ export function EditorToolbar() {
         <button
           onClick={openFileFromDialog}
           className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-neutral-300 hover:text-neutral-100 hover:bg-hover-overlay rounded transition-colors"
-          title="Datei oeffnen"
-          aria-label="Markdown-Datei oeffnen"
+          title="Datei öffnen"
+          aria-label="Markdown-Datei öffnen"
         >
           <FolderOpen className="w-3.5 h-3.5" aria-hidden="true" />
-          <span className="hidden sm:inline">Oeffnen</span>
+          <span className="hidden sm:inline">Öffnen</span>
         </button>
 
         <button
@@ -101,8 +101,8 @@ export function EditorToolbar() {
           <button
             onClick={closeFile}
             className="flex items-center px-1.5 py-1.5 text-neutral-400 hover:text-neutral-100 hover:bg-hover-overlay rounded transition-colors"
-            title="Datei schliessen"
-            aria-label="Datei schliessen"
+            title="Datei schließen"
+            aria-label="Datei schließen"
           >
             <X className="w-3.5 h-3.5" aria-hidden="true" />
           </button>

--- a/src/components/editor/MarkdownEditorView.test.tsx
+++ b/src/components/editor/MarkdownEditorView.test.tsx
@@ -69,14 +69,14 @@ describe("MarkdownEditorView", () => {
 
   it("shows EmptyState with open-file CTA when no file is open", () => {
     render(<MarkdownEditorView />);
-    // EmptyState renders CTA button with visible text "Markdown-Datei oeffnen"
-    // EmptyState CTA button has visible text "Markdown-Datei oeffnen"; toolbar's "Oeffnen" button also has that aria-label.
+    // EmptyState renders CTA button with visible text "Markdown-Datei öffnen"
+    // EmptyState CTA button has visible text "Markdown-Datei öffnen"; toolbar's "Öffnen" button also has that aria-label.
     // Find EmptyState specifically via the button that has textContent matching exactly.
-    const buttons = screen.getAllByRole("button", { name: "Markdown-Datei oeffnen" });
-    const emptyStateCta = buttons.find((b) => b.textContent?.trim() === "Markdown-Datei oeffnen");
+    const buttons = screen.getAllByRole("button", { name: "Markdown-Datei öffnen" });
+    const emptyStateCta = buttons.find((b) => b.textContent?.trim() === "Markdown-Datei öffnen");
     expect(emptyStateCta).toBeTruthy();
-    // "Keine Datei geoeffnet" appears twice (toolbar + EmptyState) when no file is open
-    expect(screen.getAllByText("Keine Datei geoeffnet").length).toBeGreaterThanOrEqual(1);
+    // "Keine Datei geöffnet" appears twice (toolbar + EmptyState) when no file is open
+    expect(screen.getAllByText("Keine Datei geöffnet").length).toBeGreaterThanOrEqual(1);
     // No editor textarea in empty state
     expect(screen.queryByTestId("cm-mock")).toBeNull();
   });
@@ -119,10 +119,10 @@ describe("MarkdownEditorView", () => {
     rerender(<MarkdownEditorView />);
 
     expect(screen.queryByTestId("cm-mock")).toBeNull();
-    // EmptyState CTA button has visible text "Markdown-Datei oeffnen"; toolbar's "Oeffnen" button also has that aria-label.
+    // EmptyState CTA button has visible text "Markdown-Datei öffnen"; toolbar's "Öffnen" button also has that aria-label.
     // Find EmptyState specifically via the button that has textContent matching exactly.
-    const buttons = screen.getAllByRole("button", { name: "Markdown-Datei oeffnen" });
-    const emptyStateCta = buttons.find((b) => b.textContent?.trim() === "Markdown-Datei oeffnen");
+    const buttons = screen.getAllByRole("button", { name: "Markdown-Datei öffnen" });
+    const emptyStateCta = buttons.find((b) => b.textContent?.trim() === "Markdown-Datei öffnen");
     expect(emptyStateCta).toBeTruthy();
   });
 

--- a/src/components/editor/MarkdownEditorView.tsx
+++ b/src/components/editor/MarkdownEditorView.tsx
@@ -20,13 +20,13 @@ function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center h-full gap-4 text-neutral-400">
       <FileEdit className="w-12 h-12 text-neutral-600" />
-      <p className="text-sm">Keine Datei geoeffnet</p>
+      <p className="text-sm">Keine Datei geöffnet</p>
       <Button
         variant="primary"
         onClick={openFileFromDialog}
-        aria-label="Markdown-Datei oeffnen"
+        aria-label="Markdown-Datei öffnen"
       >
-        Markdown-Datei oeffnen
+        Markdown-Datei öffnen
       </Button>
     </div>
   );

--- a/src/components/kanban/KanbanCard.test.tsx
+++ b/src/components/kanban/KanbanCard.test.tsx
@@ -94,7 +94,7 @@ describe("KanbanCard", () => {
   it("opens URL in browser when external link button is clicked", async () => {
     render(<KanbanCard issue={makeIssue()} />);
 
-    const linkButton = screen.getByTitle("Im Browser oeffnen");
+    const linkButton = screen.getByTitle("Im Browser öffnen");
     fireEvent.click(linkButton);
 
     expect(mockOpen).toHaveBeenCalledWith(
@@ -105,14 +105,14 @@ describe("KanbanCard", () => {
   it("does not render external link button when url is empty", () => {
     render(<KanbanCard issue={makeIssue({ url: "" })} />);
 
-    expect(screen.queryByTitle("Im Browser oeffnen")).toBeNull();
+    expect(screen.queryByTitle("Im Browser öffnen")).toBeNull();
   });
 
   it("external link click does not propagate to card onClick", () => {
     const onClick = vi.fn();
     render(<KanbanCard issue={makeIssue()} onClick={onClick} />);
 
-    const linkButton = screen.getByTitle("Im Browser oeffnen");
+    const linkButton = screen.getByTitle("Im Browser öffnen");
     fireEvent.click(linkButton);
 
     // stopPropagation prevents onClick on card

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -61,7 +61,7 @@ export function KanbanCard({ issue, onClick, onDragStart }: KanbanCardProps) {
               openUrl(issue.url);
             }}
             className="p-0.5 text-neutral-600 hover:text-neutral-300 opacity-0 group-hover:opacity-100 transition-opacity"
-            title="Im Browser oeffnen"
+            title="Im Browser öffnen"
           >
             <ExternalLink className="w-3 h-3" />
           </button>

--- a/src/components/kanban/KanbanDashboardView.test.tsx
+++ b/src/components/kanban/KanbanDashboardView.test.tsx
@@ -39,10 +39,10 @@ describe("KanbanDashboardView", () => {
   it("shows empty state when no folder and no favorites", () => {
     render(<KanbanDashboardView />);
 
-    expect(screen.getByText("Kein Projekt verfuegbar")).toBeTruthy();
+    expect(screen.getByText("Kein Projekt verfügbar")).toBeTruthy();
     expect(
       screen.getByText(
-        "Erstelle eine Session oder fuege einen Favoriten hinzu.",
+        "Erstelle eine Session oder füge einen Favoriten hinzu.",
       ),
     ).toBeTruthy();
   });
@@ -123,7 +123,7 @@ describe("KanbanDashboardView", () => {
     expect(board.textContent).toBe("/projects/beta");
   });
 
-  it("shows 'Projekt auswaehlen' when favorites exist but none selected and no session", () => {
+  it("shows 'Projekt auswählen' when favorites exist but none selected and no session", () => {
     useSettingsStore.setState({
       favorites: [
         {
@@ -143,6 +143,6 @@ describe("KanbanDashboardView", () => {
     const select = screen.getByRole("combobox");
     fireEvent.change(select, { target: { value: "" } });
 
-    expect(screen.getByText("Projekt auswaehlen")).toBeTruthy();
+    expect(screen.getByText("Projekt auswählen")).toBeTruthy();
   });
 });

--- a/src/components/kanban/KanbanDashboardView.tsx
+++ b/src/components/kanban/KanbanDashboardView.tsx
@@ -19,9 +19,9 @@ export function KanbanDashboardView() {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-3 text-neutral-500">
         <Columns3 className="w-10 h-10 text-neutral-600" />
-        <span className="text-sm">Kein Projekt verfuegbar</span>
+        <span className="text-sm">Kein Projekt verfügbar</span>
         <span className="text-xs text-neutral-600">
-          Erstelle eine Session oder fuege einen Favoriten hinzu.
+          Erstelle eine Session oder füge einen Favoriten hinzu.
         </span>
       </div>
     );
@@ -62,7 +62,7 @@ export function KanbanDashboardView() {
       ) : (
         <div className="flex flex-col items-center justify-center h-full gap-3 text-neutral-500">
           <Columns3 className="w-10 h-10 text-neutral-600" />
-          <span className="text-sm">Projekt auswaehlen</span>
+          <span className="text-sm">Projekt auswählen</span>
         </div>
       )}
     </div>

--- a/src/components/kanban/KanbanDetailModal.tsx
+++ b/src/components/kanban/KanbanDetailModal.tsx
@@ -142,7 +142,7 @@ export function KanbanDetailModal({
       {detail?.url && (
         <IconButton
           icon={<ExternalLink className="w-4 h-4" />}
-          label="Im Browser oeffnen"
+          label="Im Browser öffnen"
           onClick={() => open(detail.url)}
         />
       )}

--- a/src/components/pipeline/AgentMetricsPanel.tsx
+++ b/src/components/pipeline/AgentMetricsPanel.tsx
@@ -169,7 +169,7 @@ export function AgentMetricsPanel({ sessionId }: AgentMetricsPanelProps) {
       <div className="border-t border-neutral-700 px-4 py-3">
         <div className="flex items-center gap-2 text-neutral-500 text-xs">
           <Activity className="w-3.5 h-3.5" />
-          <span>Keine Agent-Metriken verfuegbar — noch keine Agenten erkannt.</span>
+          <span>Keine Agent-Metriken verfügbar — noch keine Agenten erkannt.</span>
         </div>
       </div>
     );

--- a/src/components/pipeline/PipelineView.test.tsx
+++ b/src/components/pipeline/PipelineView.test.tsx
@@ -89,14 +89,14 @@ describe("PipelineView", () => {
     useSessionStore.setState({ sessions: [], activeSessionId: null });
     render(<PipelineView />);
     expect(
-      screen.getByText(/Waehle ein Projekt um Workflows zu erkennen/)
+      screen.getByText(/Wähle ein Projekt um Workflows zu erkennen/)
     ).toBeInTheDocument();
   });
 
   it("shows AgentMetricsPanel empty state when no agents exist", () => {
     render(<PipelineView />);
     expect(
-      screen.getByText(/Keine Agent-Metriken verfuegbar/)
+      screen.getByText(/Keine Agent-Metriken verfügbar/)
     ).toBeInTheDocument();
   });
 });
@@ -109,7 +109,7 @@ describe("AgentMetricsPanel", () => {
   it("renders empty state when no agents exist", () => {
     render(<AgentMetricsPanel />);
     expect(
-      screen.getByText(/Keine Agent-Metriken verfuegbar/)
+      screen.getByText(/Keine Agent-Metriken verfügbar/)
     ).toBeInTheDocument();
   });
 

--- a/src/components/pipeline/WorkflowLauncher.tsx
+++ b/src/components/pipeline/WorkflowLauncher.tsx
@@ -207,7 +207,7 @@ export function WorkflowLauncher() {
       <div className="border-b border-neutral-700 px-4 py-4">
         <div className="flex items-center gap-2 text-neutral-500 text-sm">
           <Puzzle className="w-4 h-4" />
-          <span>Waehle ein Projekt um Workflows zu erkennen</span>
+          <span>Wähle ein Projekt um Workflows zu erkennen</span>
         </div>
       </div>
     );

--- a/src/components/sessions/AgentBottomPanel.test.tsx
+++ b/src/components/sessions/AgentBottomPanel.test.tsx
@@ -128,7 +128,7 @@ describe("AgentBottomPanel", () => {
     render(<AgentBottomPanel sessionId="session-1" />);
 
     // Initially collapsed — no "Agenten" header in tree
-    expect(screen.queryByText("Agent auswaehlen fuer Details")).toBeNull();
+    expect(screen.queryByText("Agent auswählen für Details")).toBeNull();
 
     // Click to expand
     fireEvent.click(screen.getByText(/1 Agent/));
@@ -167,6 +167,6 @@ describe("AgentBottomPanel", () => {
 
     render(<AgentBottomPanel sessionId="session-1" />);
 
-    expect(screen.getByText("Agent auswaehlen fuer Details")).toBeTruthy();
+    expect(screen.getByText("Agent auswählen für Details")).toBeTruthy();
   });
 });

--- a/src/components/sessions/AgentBottomPanel.tsx
+++ b/src/components/sessions/AgentBottomPanel.tsx
@@ -121,7 +121,7 @@ export function AgentBottomPanel({ sessionId }: AgentBottomPanelProps) {
               <AgentDetailCard agent={selectedAgent} worktrees={worktrees} />
             ) : (
               <div className="flex items-center justify-center h-full text-xs text-neutral-500">
-                Agent auswaehlen fuer Details
+                Agent auswählen für Details
               </div>
             )}
           </div>

--- a/src/components/sessions/AgentsViewer.tsx
+++ b/src/components/sessions/AgentsViewer.tsx
@@ -180,7 +180,7 @@ export function AgentsViewer({ folder }: AgentsViewerProps) {
           <AgentDetail entry={selectedAgent} />
         ) : (
           <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
-            Agent auswaehlen
+            Agent auswählen
           </div>
         )}
       </div>

--- a/src/components/sessions/ClaudeMdViewer.tsx
+++ b/src/components/sessions/ClaudeMdViewer.tsx
@@ -119,7 +119,7 @@ export function ClaudeMdViewer({ folder }: ClaudeMdViewerProps) {
         <div className="flex items-center gap-2">
           <span className="text-xs text-neutral-400 font-medium">CLAUDE.md</span>
           {isDirty && (
-            <span className="w-2 h-2 rounded-full bg-orange-400" title="Ungespeicherte Aenderungen" />
+            <span className="w-2 h-2 rounded-full bg-orange-400" title="Ungespeicherte Änderungen" />
           )}
         </div>
         <div className="flex items-center gap-1">
@@ -139,7 +139,7 @@ export function ClaudeMdViewer({ folder }: ClaudeMdViewerProps) {
                 onClick={exitEditMode}
                 className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-neutral-400 hover:text-neutral-200 rounded hover:bg-hover-overlay transition-colors"
                 title="Zur Vorschau"
-                aria-label="Zurueck zur Vorschau"
+                aria-label="Zurück zur Vorschau"
               >
                 <Eye className="w-3 h-3" />
                 Vorschau

--- a/src/components/sessions/ConfigPanel.test.tsx
+++ b/src/components/sessions/ConfigPanel.test.tsx
@@ -26,13 +26,13 @@ describe("ConfigPanel", () => {
 
     expect(screen.getByTestId("config-panel-tab-list")).toBeTruthy();
     expect(screen.getByTestId("config-panel-content")).toBeTruthy();
-    expect(screen.getByLabelText("Konfig-Panel schliessen")).toBeTruthy();
+    expect(screen.getByLabelText("Konfig-Panel schließen")).toBeTruthy();
   });
 
   it("calls setConfigPanelOpen(false) when close button is clicked", () => {
     render(<ConfigPanel folder="/test/project" />);
 
-    fireEvent.click(screen.getByLabelText("Konfig-Panel schliessen"));
+    fireEvent.click(screen.getByLabelText("Konfig-Panel schließen"));
     expect(useUIStore.getState().configPanelOpen).toBe(false);
   });
 

--- a/src/components/sessions/ConfigPanel.tsx
+++ b/src/components/sessions/ConfigPanel.tsx
@@ -26,8 +26,8 @@ export function ConfigPanel({ folder, width, onResumeSession }: ConfigPanelProps
         <button
           onClick={() => setConfigPanelOpen(false)}
           className="p-1.5 mr-1 text-neutral-500 hover:text-neutral-300 transition-colors"
-          title="Panel schliessen"
-          aria-label="Konfig-Panel schliessen"
+          title="Panel schließen"
+          aria-label="Konfig-Panel schließen"
         >
           <X className="w-3.5 h-3.5" />
         </button>

--- a/src/components/sessions/ConfigPanelTabList.tsx
+++ b/src/components/sessions/ConfigPanelTabList.tsx
@@ -29,7 +29,7 @@ export function ConfigPanelTabList({ folder, size = "md" }: ConfigPanelTabListPr
   const setConfigSubTab = (newTab: ConfigSubTab) => {
     if (hasDirtyEditor && newTab !== configSubTab) {
       const ok = window.confirm(
-        "Ungespeicherte Aenderungen gehen verloren. Wirklich wechseln?"
+        "Ungespeicherte Änderungen gehen verloren. Wirklich wechseln?"
       );
       if (!ok) return;
     }
@@ -86,7 +86,7 @@ export function ConfigPanelTabList({ folder, size = "md" }: ConfigPanelTabListPr
         filters: [{ name: "Markdown", extensions: ["md", "markdown"] }],
         multiple: false,
         defaultPath: folder,
-        title: "Markdown-Datei zum Anpinnen auswaehlen",
+        title: "Markdown-Datei zum Anpinnen auswählen",
       });
       if (!filePath || typeof filePath !== "string") return;
 
@@ -96,8 +96,8 @@ export function ConfigPanelTabList({ folder, size = "md" }: ConfigPanelTabListPr
       if (!normalizedFile.toLowerCase().startsWith(normalizedFolder.toLowerCase() + "/")) {
         addToast({
           type: "error",
-          title: "Datei ausserhalb des Projekts",
-          message: "Nur Dateien innerhalb des Projektordners koennen angepinnt werden.",
+          title: "Datei außerhalb des Projekts",
+          message: "Nur Dateien innerhalb des Projektordners können angepinnt werden.",
         });
         return;
       }

--- a/src/components/sessions/EmptyState.test.tsx
+++ b/src/components/sessions/EmptyState.test.tsx
@@ -7,7 +7,7 @@ describe("EmptyState", () => {
     render(<EmptyState onNewSession={vi.fn()} />);
 
     expect(screen.getByText("NEUE SESSION STARTEN")).toBeTruthy();
-    expect(screen.getByText(/Waehle einen Ordner/)).toBeTruthy();
+    expect(screen.getByText(/Wähle einen Ordner/)).toBeTruthy();
   });
 
   it("calls onNewSession when button is clicked", () => {

--- a/src/components/sessions/EmptyState.tsx
+++ b/src/components/sessions/EmptyState.tsx
@@ -18,7 +18,7 @@ export function EmptyState({ onNewSession }: EmptyStateProps) {
         NEUE SESSION STARTEN
       </Button>
       <p className="mt-4 text-neutral-500 text-sm text-center max-w-xs">
-        Waehle einen Ordner und starte eine Claude Session.
+        Wähle einen Ordner und starte eine Claude Session.
         <br />
         Der Output erscheint hier in Echtzeit.
       </p>

--- a/src/components/sessions/FavoriteCard.test.tsx
+++ b/src/components/sessions/FavoriteCard.test.tsx
@@ -65,7 +65,7 @@ describe("FavoriteCard", () => {
       <FavoriteCard favorite={fav} onStart={vi.fn()} onRemove={vi.fn()} />,
     );
 
-    fireEvent.click(screen.getByLabelText("Ordner im Explorer oeffnen"));
+    fireEvent.click(screen.getByLabelText("Ordner im Explorer öffnen"));
     expect(mockInvoke).toHaveBeenCalledWith("open_folder_in_explorer", { path: "/test/path" });
   });
 
@@ -75,7 +75,7 @@ describe("FavoriteCard", () => {
       <FavoriteCard favorite={fav} onStart={vi.fn()} onRemove={vi.fn()} />,
     );
 
-    fireEvent.click(screen.getByLabelText("Terminal im Ordner oeffnen"));
+    fireEvent.click(screen.getByLabelText("Terminal im Ordner öffnen"));
     expect(mockInvoke).toHaveBeenCalledWith("open_terminal_in_folder", { path: "/test/path" });
   });
 

--- a/src/components/sessions/FavoriteCard.tsx
+++ b/src/components/sessions/FavoriteCard.tsx
@@ -31,8 +31,8 @@ export function FavoriteCard({ favorite, onStart, onRemove }: FavoriteCardProps)
             invoke("open_folder_in_explorer", { path: favorite.path });
           }}
           className="p-0.5 text-neutral-600 hover:text-neutral-300"
-          aria-label="Ordner im Explorer oeffnen"
-          title="Ordner im Explorer oeffnen"
+          aria-label="Ordner im Explorer öffnen"
+          title="Ordner im Explorer öffnen"
         >
           <FolderOpen className="w-3.5 h-3.5" />
         </button>
@@ -42,8 +42,8 @@ export function FavoriteCard({ favorite, onStart, onRemove }: FavoriteCardProps)
             invoke("open_terminal_in_folder", { path: favorite.path });
           }}
           className="p-0.5 text-neutral-600 hover:text-neutral-300"
-          aria-label="Terminal im Ordner oeffnen"
-          title="Terminal im Ordner oeffnen"
+          aria-label="Terminal im Ordner öffnen"
+          title="Terminal im Ordner öffnen"
         >
           <Terminal className="w-3.5 h-3.5" />
         </button>

--- a/src/components/sessions/FavoritePreview.test.tsx
+++ b/src/components/sessions/FavoritePreview.test.tsx
@@ -42,7 +42,7 @@ describe("FavoritePreview", () => {
       <FavoritePreview folder="/test/project" onClose={onClose} />,
     );
 
-    fireEvent.click(screen.getByLabelText("Preview schliessen"));
+    fireEvent.click(screen.getByLabelText("Preview schließen"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/sessions/FavoritePreview.tsx
+++ b/src/components/sessions/FavoritePreview.tsx
@@ -30,8 +30,8 @@ export function FavoritePreview({ folder, onClose, onResumeSession }: FavoritePr
         <button
           onClick={onClose}
           className="p-1.5 text-neutral-500 hover:text-neutral-300 transition-colors ml-2"
-          title="Preview schliessen"
-          aria-label="Preview schliessen"
+          title="Preview schließen"
+          aria-label="Preview schließen"
         >
           <X className="w-3.5 h-3.5" />
         </button>

--- a/src/components/sessions/FavoritesList.test.tsx
+++ b/src/components/sessions/FavoritesList.test.tsx
@@ -32,7 +32,7 @@ describe("FavoritesList", () => {
 
   it("renders empty state text when no favorites", () => {
     render(<FavoritesList onQuickStart={vi.fn()} />);
-    expect(screen.getByText("Ordner hinzufuegen fuer Schnellstart")).toBeTruthy();
+    expect(screen.getByText("Ordner hinzufügen für Schnellstart")).toBeTruthy();
   });
 
   it("renders section header with FAVORITEN label", () => {
@@ -70,7 +70,7 @@ describe("FavoritesList", () => {
 
   it("renders add favorite button with correct aria-label", () => {
     render(<FavoritesList onQuickStart={vi.fn()} />);
-    expect(screen.getByLabelText("Ordner als Favorit hinzufuegen")).toBeTruthy();
+    expect(screen.getByLabelText("Ordner als Favorit hinzufügen")).toBeTruthy();
   });
 
   it("does not show empty state when favorites exist", () => {
@@ -79,6 +79,6 @@ describe("FavoritesList", () => {
     });
 
     render(<FavoritesList onQuickStart={vi.fn()} />);
-    expect(screen.queryByText("Ordner hinzufuegen fuer Schnellstart")).toBeNull();
+    expect(screen.queryByText("Ordner hinzufügen für Schnellstart")).toBeNull();
   });
 });

--- a/src/components/sessions/FavoritesList.tsx
+++ b/src/components/sessions/FavoritesList.tsx
@@ -26,7 +26,7 @@ export function FavoritesList({ onQuickStart }: FavoritesListProps) {
       const selected = await open({
         directory: true,
         multiple: false,
-        title: "Ordner als Favorit hinzufuegen",
+        title: "Ordner als Favorit hinzufügen",
       });
       if (selected && typeof selected === "string") {
         addFavorite(selected);
@@ -44,7 +44,7 @@ export function FavoritesList({ onQuickStart }: FavoritesListProps) {
         <button
           onClick={handleAddFavorite}
           className="text-neutral-500 hover:text-accent transition-colors"
-          aria-label="Ordner als Favorit hinzufuegen"
+          aria-label="Ordner als Favorit hinzufügen"
         >
           <FolderPlus className="w-3.5 h-3.5" />
         </button>
@@ -65,7 +65,7 @@ export function FavoritesList({ onQuickStart }: FavoritesListProps) {
       {/* Empty state */}
       {favorites.length === 0 && (
         <div className="px-3 py-2 text-xs text-neutral-600">
-          Ordner hinzufuegen fuer Schnellstart
+          Ordner hinzufügen für Schnellstart
         </div>
       )}
     </div>

--- a/src/components/sessions/GitHubViewer.tsx
+++ b/src/components/sessions/GitHubViewer.tsx
@@ -274,7 +274,7 @@ export function GitHubViewer({ folder }: GitHubViewerProps) {
                       <button
                         onClick={() => openUrl(pr.url)}
                         className="p-0.5 text-neutral-600 hover:text-neutral-300 opacity-0 group-hover:opacity-100 transition-opacity"
-                        title="Im Browser oeffnen"
+                        title="Im Browser öffnen"
                       >
                         <ExternalLink className="w-3 h-3" />
                       </button>
@@ -321,7 +321,7 @@ export function GitHubViewer({ folder }: GitHubViewerProps) {
                       <button
                         onClick={() => openUrl(issue.url)}
                         className="p-0.5 text-neutral-600 hover:text-neutral-300 opacity-0 group-hover:opacity-100 transition-opacity"
-                        title="Im Browser oeffnen"
+                        title="Im Browser öffnen"
                       >
                         <ExternalLink className="w-3 h-3" />
                       </button>

--- a/src/components/sessions/LibraryViewer.test.tsx
+++ b/src/components/sessions/LibraryViewer.test.tsx
@@ -151,7 +151,7 @@ describe("LibraryViewer", () => {
       fetchItems: vi.fn(),
     });
     render(<LibraryViewer />);
-    expect(screen.getByText("Item auswaehlen")).toBeInTheDocument();
+    expect(screen.getByText("Item auswählen")).toBeInTheDocument();
   });
 
   it("shows 'Keine Items gefunden' when filters match nothing", () => {

--- a/src/components/sessions/LibraryViewer.tsx
+++ b/src/components/sessions/LibraryViewer.tsx
@@ -266,7 +266,7 @@ export function LibraryViewer({ folder = "" }: LibraryViewerProps) {
           <ItemDetail item={selectedItem} folder={folder} />
         ) : (
           <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
-            Item auswaehlen
+            Item auswählen
           </div>
         )}
       </div>

--- a/src/components/sessions/NewSessionDialog.test.tsx
+++ b/src/components/sessions/NewSessionDialog.test.tsx
@@ -36,7 +36,7 @@ describe("NewSessionDialog", () => {
     render(<NewSessionDialog open={true} onClose={vi.fn()} />);
 
     expect(screen.getByText("NEUE CLAUDE SESSION")).toBeTruthy();
-    expect(screen.getByText("Waehlen")).toBeTruthy();
+    expect(screen.getByText("Wählen")).toBeTruthy();
     expect(screen.getByText("STARTEN")).toBeTruthy();
     expect(screen.getByText("Abbrechen")).toBeTruthy();
   });

--- a/src/components/sessions/NewSessionDialog.tsx
+++ b/src/components/sessions/NewSessionDialog.tsx
@@ -38,7 +38,7 @@ export function NewSessionDialog({ open: isOpen, onClose }: NewSessionDialogProp
       const selected = await open({
         directory: true,
         multiple: false,
-        title: "Arbeitsordner waehlen",
+        title: "Arbeitsordner wählen",
       });
       if (selected && typeof selected === "string") {
         setFolder(selected);
@@ -100,7 +100,7 @@ export function NewSessionDialog({ open: isOpen, onClose }: NewSessionDialogProp
               label="Ordner:"
               value={folder}
               readOnly
-              placeholder="Ordner waehlen..."
+              placeholder="Ordner wählen..."
             />
           </div>
           <Button
@@ -110,7 +110,7 @@ export function NewSessionDialog({ open: isOpen, onClose }: NewSessionDialogProp
             onClick={handlePickFolder}
             className="bg-surface-base hover:text-accent hover:border-accent"
           >
-            Waehlen
+            Wählen
           </Button>
         </div>
 

--- a/src/components/sessions/PinnedDocViewer.tsx
+++ b/src/components/sessions/PinnedDocViewer.tsx
@@ -180,7 +180,7 @@ export function PinnedDocViewer({ folder, pinId }: PinnedDocViewerProps) {
             </span>
           )}
           {isDirty && (
-            <span className="w-2 h-2 rounded-full bg-orange-400 shrink-0" title="Ungespeicherte Aenderungen" />
+            <span className="w-2 h-2 rounded-full bg-orange-400 shrink-0" title="Ungespeicherte Änderungen" />
           )}
         </div>
         <div className="flex items-center gap-1 shrink-0">
@@ -200,7 +200,7 @@ export function PinnedDocViewer({ folder, pinId }: PinnedDocViewerProps) {
                 onClick={exitEditMode}
                 className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-neutral-400 hover:text-neutral-200 rounded hover:bg-hover-overlay transition-colors"
                 title="Zur Vorschau"
-                aria-label="Zurueck zur Vorschau"
+                aria-label="Zurück zur Vorschau"
               >
                 <Eye className="w-3 h-3" />
                 Vorschau

--- a/src/components/sessions/SessionCard.test.tsx
+++ b/src/components/sessions/SessionCard.test.tsx
@@ -68,10 +68,10 @@ describe("SessionCard", () => {
     expect(dot).toBeTruthy();
   });
 
-  it("shows 'Laeuft seit' for running status with recent output", () => {
+  it("shows 'Läuft seit' for running status with recent output", () => {
     renderCard(makeSession({ status: "running" }));
-    // "active" level → "Laeuft seit X:XX"
-    expect(screen.getByText(/Laeuft seit/)).toBeTruthy();
+    // "active" level → "Läuft seit X:XX"
+    expect(screen.getByText(/Läuft seit/)).toBeTruthy();
   });
 
   it("shows check icon and 'Fertig' for done status", () => {
@@ -111,7 +111,7 @@ describe("SessionCard", () => {
 
     // Click close button — should trigger onClose, NOT re-trigger onClick
     // (stopPropagation verified via call count unchanged)
-    const closeBtn = screen.getByLabelText("Session schliessen");
+    const closeBtn = screen.getByLabelText("Session schließen");
     fireEvent.click(closeBtn);
     expect(onClose).toHaveBeenCalledWith("sess-99");
     expect(onClick).toHaveBeenCalledTimes(1); // still 1, not 2

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -47,7 +47,7 @@ function TimeDisplay({
         </span>
       ) : (
         <span className="text-neutral-500">
-          Laeuft seit {formatDuration(now - session.createdAt)}
+          Läuft seit {formatDuration(now - session.createdAt)}
         </span>
       );
     case "waiting":
@@ -93,8 +93,8 @@ const SessionCardInner = ({ session, isActive, isInGrid, onClick, onClose }: Ses
             invoke("open_folder_in_explorer", { path: session.folder });
           }}
           className="p-0.5 text-neutral-600 hover:text-neutral-300"
-          aria-label="Ordner im Explorer oeffnen"
-          title="Ordner im Explorer oeffnen"
+          aria-label="Ordner im Explorer öffnen"
+          title="Ordner im Explorer öffnen"
         >
           <FolderOpen className="w-3.5 h-3.5" />
         </button>
@@ -104,8 +104,8 @@ const SessionCardInner = ({ session, isActive, isInGrid, onClick, onClose }: Ses
             invoke("open_terminal_in_folder", { path: session.folder });
           }}
           className="p-0.5 text-neutral-600 hover:text-neutral-300"
-          aria-label="Terminal im Ordner oeffnen"
-          title="Terminal im Ordner oeffnen"
+          aria-label="Terminal im Ordner öffnen"
+          title="Terminal im Ordner öffnen"
         >
           <Terminal className="w-3.5 h-3.5" />
         </button>
@@ -115,7 +115,7 @@ const SessionCardInner = ({ session, isActive, isInGrid, onClick, onClose }: Ses
             onClose(session.id);
           }}
           className="p-0.5 text-neutral-600 hover:text-neutral-300"
-          aria-label="Session schliessen"
+          aria-label="Session schließen"
         >
           <X className="w-3.5 h-3.5" />
         </button>

--- a/src/components/sessions/SkillsViewer.tsx
+++ b/src/components/sessions/SkillsViewer.tsx
@@ -205,7 +205,7 @@ export function SkillsViewer({ folder }: SkillsViewerProps) {
           <SkillDetail entry={selectedSkill} />
         ) : (
           <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
-            Skill auswaehlen
+            Skill auswählen
           </div>
         )}
       </div>

--- a/src/components/sessions/TerminalToolbar.test.tsx
+++ b/src/components/sessions/TerminalToolbar.test.tsx
@@ -77,7 +77,7 @@ describe("TerminalToolbar", () => {
       />,
     );
 
-    const btn = screen.getByLabelText("Konfig-Panel oeffnen");
+    const btn = screen.getByLabelText("Konfig-Panel öffnen");
     expect(btn).toBeTruthy();
     fireEvent.click(btn);
     expect(onToggle).toHaveBeenCalledTimes(1);
@@ -94,7 +94,7 @@ describe("TerminalToolbar", () => {
       />,
     );
 
-    expect(screen.queryByLabelText("Konfig-Panel oeffnen")).toBeNull();
+    expect(screen.queryByLabelText("Konfig-Panel öffnen")).toBeNull();
   });
 
   it("shows close label when config panel is open", () => {
@@ -108,6 +108,6 @@ describe("TerminalToolbar", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Konfig-Panel schliessen")).toBeTruthy();
+    expect(screen.getByLabelText("Konfig-Panel schließen")).toBeTruthy();
   });
 });

--- a/src/components/sessions/TerminalToolbar.tsx
+++ b/src/components/sessions/TerminalToolbar.tsx
@@ -38,8 +38,8 @@ export function TerminalToolbar({
                 ? "text-accent"
                 : "text-neutral-500 hover:text-neutral-300"
             }`}
-            aria-label={configPanelOpen ? "Konfig-Panel schliessen" : "Konfig-Panel oeffnen"}
-            title={configPanelOpen ? "Konfig-Panel schliessen" : "Konfig-Panel oeffnen"}
+            aria-label={configPanelOpen ? "Konfig-Panel schließen" : "Konfig-Panel öffnen"}
+            title={configPanelOpen ? "Konfig-Panel schließen" : "Konfig-Panel öffnen"}
           >
             {configPanelOpen ? (
               <PanelRightClose className="w-4 h-4" />

--- a/src/components/shared/NotesPanel.test.tsx
+++ b/src/components/shared/NotesPanel.test.tsx
@@ -119,7 +119,7 @@ describe("NotesPanel", () => {
     fireEvent.click(screen.getByLabelText("Notizen"));
 
     // Should show project tab with project notes textarea
-    const textarea = screen.getByPlaceholderText("Notizen fuer dieses Projekt...");
+    const textarea = screen.getByPlaceholderText("Notizen für dieses Projekt...");
     expect((textarea as HTMLTextAreaElement).value).toBe("Project note content");
   });
 

--- a/src/components/shared/NotesPanel.tsx
+++ b/src/components/shared/NotesPanel.tsx
@@ -161,7 +161,7 @@ export function NotesPanel() {
                     <span className="truncate flex-1 text-left">
                       {effectiveFolderKey
                         ? folderLabel(effectiveFolderKey)
-                        : "Projekt waehlen..."}
+                        : "Projekt wählen..."}
                     </span>
                     <ChevronDown className={`w-3.5 h-3.5 text-neutral-500 transition-transform ${folderPickerOpen ? "rotate-180" : ""}`} />
                   </button>
@@ -170,7 +170,7 @@ export function NotesPanel() {
                     <div className="absolute left-0 right-0 top-full z-10 max-h-48 overflow-y-auto bg-surface-overlay border border-neutral-700 rounded-b-sm shadow-lg">
                       {availableFolders.length === 0 ? (
                         <div className="px-3 py-3 text-xs text-neutral-500 text-center">
-                          Keine Projekte vorhanden — starte eine Session oder fuege Favoriten hinzu
+                          Keine Projekte vorhanden — starte eine Session oder füge Favoriten hinzu
                         </div>
                       ) : (
                         availableFolders.map((f) => (
@@ -205,7 +205,7 @@ export function NotesPanel() {
                   <textarea
                     value={currentProjectNotes}
                     onChange={(e) => setProjectNotes(effectiveFolderKey, e.target.value)}
-                    placeholder="Notizen fuer dieses Projekt..."
+                    placeholder="Notizen für dieses Projekt..."
                     className="w-full h-52 p-3 bg-transparent text-sm text-neutral-200 placeholder-neutral-600 outline-none resize-none font-mono"
                     autoFocus
                   />
@@ -217,7 +217,7 @@ export function NotesPanel() {
                 <div className="h-52 flex items-center justify-center text-sm text-neutral-500">
                   {availableFolders.length === 0
                     ? "Keine Projekte vorhanden"
-                    : "Projekt waehlen um Notizen zu sehen"}
+                    : "Projekt wählen um Notizen zu sehen"}
                 </div>
               )}
             </>

--- a/src/store/editorStore.test.ts
+++ b/src/store/editorStore.test.ts
@@ -105,7 +105,7 @@ describe("editorStore", () => {
       const toasts = useUIStore.getState().toasts;
       expect(toasts).toHaveLength(1);
       expect(toasts[0].type).toBe("error");
-      expect(toasts[0].title).toBe("Fehler beim Oeffnen");
+      expect(toasts[0].title).toBe("Fehler beim Öffnen");
     });
   });
 
@@ -361,7 +361,7 @@ describe("editorStore", () => {
       const toasts = useUIStore.getState().toasts;
       expect(toasts).toHaveLength(1);
       expect(toasts[0].type).toBe("error");
-      expect(toasts[0].title).toBe("Fehler beim Oeffnen");
+      expect(toasts[0].title).toBe("Fehler beim Öffnen");
     });
   });
 

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -68,7 +68,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       logError("editorStore.openFileFromProject", err);
       useUIStore.getState().addToast({
         type: "error",
-        title: "Fehler beim Oeffnen",
+        title: "Fehler beim Öffnen",
         message: getErrorMessage(err),
       });
     }
@@ -93,7 +93,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
       logError("editorStore.openFileFromDialog", err);
       useUIStore.getState().addToast({
         type: "error",
-        title: "Fehler beim Oeffnen",
+        title: "Fehler beim Öffnen",
         message: getErrorMessage(err),
       });
     }

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -85,7 +85,7 @@ export function validatePinnedPath(relativePath: string): string | null {
   }
   // Only markdown extensions
   if (!/\.(md|markdown)$/i.test(normalized)) {
-    return "Nur .md- oder .markdown-Dateien koennen angepinnt werden";
+    return "Nur .md- oder .markdown-Dateien können angepinnt werden";
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Replace all ASCII substitutions (ae/oe/ue/ss) with proper German umlauts (ä/ö/ü/ß) in 28 source files across UI strings, aria-labels, titles, tooltips and placeholders
- Update all 17 corresponding test files to match the new umlaut strings
- Excludes `SideNav.tsx` and `placeholders.tsx` (handled by separate PR)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run test -- --run` passes (907/907 tests green)
- [x] `npm run build` succeeds
- [x] Pre-commit hooks (tsc + eslint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)