### PR TITLE
fix(ui): simplify session status colors (#146)

### DIFF
--- a/src/components/sessions/GridCell.tsx
+++ b/src/components/sessions/GridCell.tsx
@@ -25,12 +25,10 @@ export function GridCell({
   const title = session?.title ?? "Session";
   const status = session?.status ?? "starting";
   const lastOutputAt = session?.lastOutputAt ?? Date.now();
-  const lastOutputSnippet = session?.lastOutputSnippet ?? "";
-
   const now = useNowTick();
   const isRunning = status === "running" || status === "starting";
 
-  const activityLevel = isRunning ? getActivityLevel(lastOutputAt, now, lastOutputSnippet) : null;
+  const activityLevel = isRunning ? getActivityLevel(lastOutputAt, now) : null;
 
   return (
     <div

--- a/src/components/sessions/SessionCard.test.tsx
+++ b/src/components/sessions/SessionCard.test.tsx
@@ -117,10 +117,10 @@ describe("SessionCard", () => {
     expect(onClick).toHaveBeenCalledTimes(1); // still 1, not 2
   });
 
-  it("renders starting status with active dot animation class", () => {
+  it("renders starting status with breathe dot animation class", () => {
     const { container } = renderCard(makeSession({ status: "starting" }));
-    // starting + active activity → status-pulse-animation + bg-success
-    const dot = container.querySelector(".status-pulse-animation.bg-success");
+    // starting → status-breathe-animation + bg-success
+    const dot = container.querySelector(".status-breathe-animation.bg-success");
     expect(dot).toBeTruthy();
   });
 });

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -41,11 +41,7 @@ function TimeDisplay({
           </span>
         );
       }
-      return activityLevel === "thinking" ? (
-        <span className="text-info">
-          Denkt... (seit {formatDuration(now - session.lastOutputAt)})
-        </span>
-      ) : (
+      return (
         <span className="text-neutral-500">
           Läuft seit {formatDuration(now - session.createdAt)}
         </span>
@@ -71,7 +67,7 @@ const SessionCardInner = ({ session, isActive, isInGrid, onClick, onClose }: Ses
   const now = useNowTick();
 
   const isRunning = session.status === "running" || session.status === "starting";
-  const activityLevel = isRunning ? getActivityLevel(session.lastOutputAt, now, session.lastOutputSnippet) : null;
+  const activityLevel = isRunning ? getActivityLevel(session.lastOutputAt, now) : null;
 
   return (
     <div

--- a/src/components/sessions/SessionStatusDot.test.tsx
+++ b/src/components/sessions/SessionStatusDot.test.tsx
@@ -13,19 +13,11 @@ describe("SessionStatusDot", () => {
     expect(dot).toBeTruthy();
   });
 
-  it("renders blue breathe dot for running + thinking activity", () => {
-    const { container } = render(
-      <SessionStatusDot status="running" activityLevel="thinking" />,
-    );
-    const dot = container.querySelector(".bg-info.status-breathe-animation");
-    expect(dot).toBeTruthy();
-  });
-
-  it("renders neutral dot for running + idle activity", () => {
+  it("renders dimmed green dot for running + idle activity", () => {
     const { container } = render(
       <SessionStatusDot status="running" activityLevel="idle" />,
     );
-    const dot = container.querySelector(".bg-neutral-500");
+    const dot = container.querySelector(".bg-success.opacity-50");
     expect(dot).toBeTruthy();
     // No pulse or breathe animation for idle
     expect(container.querySelector(".status-pulse-animation")).toBeNull();
@@ -38,10 +30,10 @@ describe("SessionStatusDot", () => {
     expect(dot).toBeTruthy();
   });
 
-  it("renders green pulse dot for starting status (default active)", () => {
+  it("renders green breathe dot for starting status", () => {
     const { container } = render(<SessionStatusDot status="starting" />);
-    // No activityLevel → defaults to null → green pulse
-    const dot = container.querySelector(".bg-success.status-pulse-animation");
+    // starting always gets breathe animation
+    const dot = container.querySelector(".bg-success.status-breathe-animation");
     expect(dot).toBeTruthy();
   });
 

--- a/src/components/sessions/SessionStatusDot.tsx
+++ b/src/components/sessions/SessionStatusDot.tsx
@@ -34,15 +34,14 @@ export function SessionStatusDot({
   const { dot, icon } = SIZE_CLASSES[size];
 
   switch (status) {
-    case "running":
     case "starting":
+      return (
+        <span className={`${dot} rounded-full bg-success status-breathe-animation shrink-0`} />
+      );
+
+    case "running":
       if (activityLevel === "idle") {
-        return <span className={`${dot} rounded-full bg-neutral-500 shrink-0`} />;
-      }
-      if (activityLevel === "thinking") {
-        return (
-          <span className={`${dot} rounded-full bg-info status-breathe-animation shrink-0`} />
-        );
+        return <span className={`${dot} rounded-full bg-success opacity-50 shrink-0`} />;
       }
       // active or no activity level — green pulse
       return (

--- a/src/components/sessions/activityLevel.test.ts
+++ b/src/components/sessions/activityLevel.test.ts
@@ -1,25 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
-  looksLikeThinking,
   looksLikePrompt,
   getActivityLevel,
-  ACTIVE_THRESHOLD_MS,
   IDLE_THRESHOLD_MS,
 } from "./activityLevel";
-
-describe("looksLikeThinking", () => {
-  it("returns true for spinner characters", () => {
-    expect(looksLikeThinking("⠋ Processing...")).toBe(true);
-  });
-
-  it("returns true for 'Thinking' text", () => {
-    expect(looksLikeThinking("Thinking")).toBe(true);
-  });
-
-  it("returns false for plain text", () => {
-    expect(looksLikeThinking("Hello world")).toBe(false);
-  });
-});
 
 describe("looksLikePrompt", () => {
   it("returns true for (y/n) prompt", () => {
@@ -28,10 +12,6 @@ describe("looksLikePrompt", () => {
 
   it("returns true for [y/N] prompt", () => {
     expect(looksLikePrompt("Confirm [y/N]")).toBe(true);
-  });
-
-  it("returns true for (y/n) prompt", () => {
-    expect(looksLikePrompt("Proceed(y/n)")).toBe(true);
   });
 
   it("returns true for [Y/n] prompt", () => {
@@ -44,27 +24,27 @@ describe("looksLikePrompt", () => {
 });
 
 describe("getActivityLevel", () => {
-  it("returns 'active' when elapsed < ACTIVE_THRESHOLD_MS", () => {
-    const now = 10_000;
-    const lastOutputAt = now - ACTIVE_THRESHOLD_MS + 1;
+  it("returns 'active' when elapsed < IDLE_THRESHOLD_MS", () => {
+    const now = 50_000;
+    const lastOutputAt = now - IDLE_THRESHOLD_MS + 1;
     expect(getActivityLevel(lastOutputAt, now)).toBe("active");
   });
 
-  it("returns 'thinking' when elapsed is between thresholds", () => {
-    const now = 50_000;
-    const lastOutputAt = now - ACTIVE_THRESHOLD_MS - 1;
-    expect(getActivityLevel(lastOutputAt, now)).toBe("thinking");
-  });
-
-  it("returns 'idle' when elapsed >= IDLE_THRESHOLD_MS with no snippet", () => {
+  it("returns 'idle' when elapsed >= IDLE_THRESHOLD_MS", () => {
     const now = 100_000;
     const lastOutputAt = now - IDLE_THRESHOLD_MS;
     expect(getActivityLevel(lastOutputAt, now)).toBe("idle");
   });
 
-  it("returns 'idle' when elapsed >= IDLE_THRESHOLD_MS with prompt snippet", () => {
-    const now = 100_000;
-    const lastOutputAt = now - IDLE_THRESHOLD_MS;
-    expect(getActivityLevel(lastOutputAt, now, "Continue? ")).toBe("idle");
+  it("returns 'active' for very recent output", () => {
+    const now = 10_000;
+    const lastOutputAt = now - 1_000;
+    expect(getActivityLevel(lastOutputAt, now)).toBe("active");
+  });
+
+  it("returns 'idle' for long-elapsed output", () => {
+    const now = 200_000;
+    const lastOutputAt = now - 120_000;
+    expect(getActivityLevel(lastOutputAt, now)).toBe("idle");
   });
 });

--- a/src/components/sessions/activityLevel.ts
+++ b/src/components/sessions/activityLevel.ts
@@ -1,19 +1,6 @@
-export const ACTIVE_THRESHOLD_MS = 8_000;
-export const IDLE_THRESHOLD_MS = 60_000;
+export const IDLE_THRESHOLD_MS = 30_000;
 
-export type ActivityLevel = "active" | "thinking" | "idle";
-
-/** Spinner characters used by Claude CLI during thinking */
-const SPINNER_CHARS = /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/;
-
-/**
- * Returns whether the last output snippet looks like Claude is actively thinking
- * (spinner chars, "Thinking" text). This prevents long thinking pauses (ultrathink)
- * from being misclassified as "idle".
- */
-export function looksLikeThinking(lastOutputSnippet: string): boolean {
-  return SPINNER_CHARS.test(lastOutputSnippet) || lastOutputSnippet.includes("Thinking");
-}
+export type ActivityLevel = "active" | "idle";
 
 /**
  * Returns whether the last output snippet looks like an interactive prompt
@@ -34,21 +21,6 @@ export function looksLikePrompt(lastOutputSnippet: string): boolean {
 export function getActivityLevel(
   lastOutputAt: number,
   now: number,
-  lastOutputSnippet?: string,
 ): ActivityLevel {
-  const elapsed = now - lastOutputAt;
-  if (elapsed < ACTIVE_THRESHOLD_MS) return "active";
-  if (elapsed < IDLE_THRESHOLD_MS) return "thinking";
-
-  // Beyond IDLE_THRESHOLD: only classify as "idle" if the last output looks
-  // like a prompt. If it looks like thinking (spinner, "Thinking" text) or is
-  // just normal output, stay in "thinking" — Claude may be in ultrathink mode.
-  if (lastOutputSnippet && looksLikePrompt(lastOutputSnippet)) {
-    return "idle";
-  }
-  if (lastOutputSnippet && looksLikeThinking(lastOutputSnippet)) {
-    return "thinking";
-  }
-
-  return "idle";
+  return now - lastOutputAt < IDLE_THRESHOLD_MS ? "active" : "idle";
 }


### PR DESCRIPTION
## Summary
- Removes the `"thinking"` ActivityLevel state and `looksLikeThinking` function — simplifies to binary `"active"` / `"idle"` with a single 30s threshold
- Makes idle sessions visually distinguishable from done: idle now shows dimmed green (`bg-success opacity-50`) instead of neutral gray (`bg-neutral-500`)
- Starting status gets a breathe animation (instead of pulse) to distinguish it from actively running sessions

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `npm run test` — all 910 tests pass (84 test files)
- [ ] Visual check in `npm run tauri dev` after merge

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)