### PR TITLE
fix(store): Session-Rename-Kollision bei leerer zweiter Session (#176)

### DIFF
--- a/src/components/sessions/hooks/useSessionEvents.test.ts
+++ b/src/components/sessions/hooks/useSessionEvents.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
 import { useSessionEvents } from "./useSessionEvents";
 
 // ── Mocks ─────────────────────────────────────────────────────────────
@@ -12,13 +13,37 @@ vi.mock("@tauri-apps/api/core", () => ({
 const mockUpdateLastOutput = vi.fn();
 const mockSetExitCode = vi.fn();
 const mockUpdateStatus = vi.fn();
+const mockSetClaudeSessionId = vi.fn();
+
+// Mutable so individual tests can inject their own sessions array
+let mockSessionsData: Array<{
+  id: string;
+  createdAt: number;
+  claudeSessionId?: string;
+  folder: string;
+  title: string;
+}> = [];
 
 vi.mock("../../../store/sessionStore", () => ({
   useSessionStore: {
     getState: () => ({
+      sessions: mockSessionsData,
       updateLastOutput: mockUpdateLastOutput,
       setExitCode: mockSetExitCode,
       updateStatus: mockUpdateStatus,
+      setClaudeSessionId: mockSetClaudeSessionId,
+    }),
+  },
+}));
+
+const mockSetSessionTitleOverride = vi.fn();
+let mockSessionTitleOverridesData: Record<string, string> = {};
+
+vi.mock("../../../store/settingsStore", () => ({
+  useSettingsStore: {
+    getState: () => ({
+      sessionTitleOverrides: mockSessionTitleOverridesData,
+      setSessionTitleOverride: mockSetSessionTitleOverride,
     }),
   },
 }));
@@ -29,6 +54,7 @@ vi.mock("../../../utils/perfLogger", () => ({
 
 vi.mock("../../../utils/errorLogger", () => ({
   logError: vi.fn(),
+  logWarn: vi.fn(),
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -51,6 +77,12 @@ describe("useSessionEvents", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    mockSessionsData = [];
+    mockSessionTitleOverridesData = {};
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("registers 3 core event listeners on mount", () => {
@@ -132,5 +164,160 @@ describe("useSessionEvents", () => {
 
     cb({ payload: { id: "s1", status: "unknown-status" } });
     expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  // ── Discovery Tests (Issue #176) ────────────────────────────────────
+
+  describe("claudeSessionId discovery", () => {
+    it("happy path: assigns claudeSessionId when timestamp matches session creation time", async () => {
+      const createdAt = 100_000;
+      mockSessionsData = [
+        { id: "tab-1", createdAt, folder: "C:/foo", title: "My Session" },
+      ];
+      (invoke as Mock).mockResolvedValue([
+        { session_id: "SID-NEW", started_at: new Date(createdAt).toISOString() },
+      ]);
+
+      renderHook(() => useSessionEvents());
+      const cb = getListenCallback("session-status");
+
+      cb({ payload: { id: "tab-1", status: "running" } });
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      expect(mockSetClaudeSessionId).toHaveBeenCalledWith("tab-1", "SID-NEW");
+      // Title override written because none existed yet
+      expect(mockSetSessionTitleOverride).toHaveBeenCalledWith("SID-NEW", "My Session");
+    });
+
+    it("old entry: does not assign when only history entries from before session creation exist", async () => {
+      const createdAt = 100_000;
+      mockSessionsData = [
+        { id: "tab-1", createdAt, folder: "C:/foo", title: "New Session" },
+      ];
+      // Only an old entry — started 60s before session was created, far outside 10s tolerance
+      (invoke as Mock).mockResolvedValue([
+        { session_id: "SID-OLD", started_at: new Date(createdAt - 60_000).toISOString() },
+      ]);
+
+      renderHook(() => useSessionEvents());
+      const cb = getListenCallback("session-status");
+
+      cb({ payload: { id: "tab-1", status: "running" } });
+      await vi.advanceTimersByTimeAsync(3_000); // attempt 1 — no match
+
+      expect(mockSetClaudeSessionId).not.toHaveBeenCalled();
+
+      // A retry should be scheduled — advancing timer triggers attempt 2
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(mockSetClaudeSessionId).not.toHaveBeenCalled();
+    });
+
+    it("claim conflict: does not assign an ID already claimed by another tab's discovery", async () => {
+      const now = 100_000;
+      mockSessionsData = [
+        { id: "tab-a", createdAt: now - 5_000, folder: "C:/foo", title: "Old Session" },
+        { id: "tab-b", createdAt: now, folder: "C:/foo", title: "New Session" },
+      ];
+      // Only SID-A exists in history — within tolerance for both tabs
+      (invoke as Mock).mockResolvedValue([
+        { session_id: "SID-A", started_at: new Date(now - 5_000).toISOString() },
+      ]);
+
+      renderHook(() => useSessionEvents());
+      const cb = getListenCallback("session-status");
+
+      // Tab A discovers SID-A first → claimedIds.add("SID-A")
+      cb({ payload: { id: "tab-a", status: "running" } });
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(mockSetClaudeSessionId).toHaveBeenCalledWith("tab-a", "SID-A");
+
+      // Tab B fires — SID-A is the only entry but it's now claimed
+      cb({ payload: { id: "tab-b", status: "running" } });
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      // Only 1 setClaudeSessionId call total — tab-b was blocked by claim check
+      expect(mockSetClaudeSessionId).toHaveBeenCalledTimes(1);
+    });
+
+    it("override existence check: does not overwrite an existing user-set title override", async () => {
+      const createdAt = 100_000;
+      mockSessionsData = [
+        { id: "tab-1", createdAt, folder: "C:/foo", title: "Default Title" },
+      ];
+      // Pre-existing user override for this claudeSessionId
+      mockSessionTitleOverridesData = { "SID-NEW": "Mein Custom Name" };
+      (invoke as Mock).mockResolvedValue([
+        { session_id: "SID-NEW", started_at: new Date(createdAt).toISOString() },
+      ]);
+
+      renderHook(() => useSessionEvents());
+      const cb = getListenCallback("session-status");
+
+      cb({ payload: { id: "tab-1", status: "running" } });
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      // ID is assigned correctly
+      expect(mockSetClaudeSessionId).toHaveBeenCalledWith("tab-1", "SID-NEW");
+      // But override is NOT overwritten — existing user title is preserved
+      expect(mockSetSessionTitleOverride).not.toHaveBeenCalled();
+    });
+
+    it("claim conflict (concurrent): both tabs fire running simultaneously, only one gets the ID", async () => {
+      const now = 100_000;
+      mockSessionsData = [
+        { id: "tab-a", createdAt: now - 5_000, folder: "C:/foo", title: "Old Session" },
+        { id: "tab-b", createdAt: now, folder: "C:/foo", title: "New Session" },
+      ];
+      // SID-A is the only entry — within tolerance for both tabs
+      (invoke as Mock).mockResolvedValue([
+        { session_id: "SID-A", started_at: new Date(now - 5_000).toISOString() },
+      ]);
+
+      renderHook(() => useSessionEvents());
+      const cb = getListenCallback("session-status");
+
+      // Both tabs fire "running" before either discovery completes (concurrent scenario)
+      cb({ payload: { id: "tab-a", status: "running" } });
+      cb({ payload: { id: "tab-b", status: "running" } });
+
+      // Both discovery timers fire at t=3000ms; microtasks execute sequentially
+      // tab-a's continuation runs first: claimedIds.add("SID-A"), setClaudeSessionId("tab-a")
+      // tab-b's continuation runs next: claimedIds.has("SID-A") = true → no match
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      // Only one assignment — whichever tab ran first gets SID-A, the other is blocked
+      expect(mockSetClaudeSessionId).toHaveBeenCalledTimes(1);
+    });
+
+    it("retry: retries discovery on each failed attempt and succeeds on a later attempt", async () => {
+      const createdAt = 100_000;
+      mockSessionsData = [
+        { id: "tab-1", createdAt, folder: "C:/foo", title: "My Session" },
+      ];
+      (invoke as Mock)
+        .mockResolvedValueOnce([]) // attempt 1: session file not yet created
+        .mockResolvedValueOnce([]) // attempt 2: still empty
+        .mockResolvedValue([       // attempt 3+: file exists now
+          { session_id: "SID-NEW", started_at: new Date(createdAt).toISOString() },
+        ]);
+
+      renderHook(() => useSessionEvents());
+      const cb = getListenCallback("session-status");
+
+      cb({ payload: { id: "tab-1", status: "running" } });
+
+      await vi.advanceTimersByTimeAsync(3_000); // attempt 1
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(mockSetClaudeSessionId).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(3_000); // attempt 2
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(mockSetClaudeSessionId).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(3_000); // attempt 3 — success
+      expect(invoke).toHaveBeenCalledTimes(3);
+      expect(mockSetClaudeSessionId).toHaveBeenCalledWith("tab-1", "SID-NEW");
+    });
   });
 });

--- a/src/components/sessions/hooks/useSessionEvents.ts
+++ b/src/components/sessions/hooks/useSessionEvents.ts
@@ -8,6 +8,18 @@ import { logError, logWarn } from "../../../utils/errorLogger";
 
 const trackSessionOutput = createEventTracker("session-output");
 
+// Private type — backend already sends started_at, only the TS type was missing
+interface ClaudeHistoryEntry {
+  session_id: string;
+  started_at: string; // ISO-8601, e.g. "2026-04-13T10:05:00.000Z"
+}
+
+const DISCOVERY_MAX_RETRIES = 5;
+const DISCOVERY_RETRY_DELAY_MS = 3_000;
+// 10s covers the gap between React session creation (Date.now()) and the moment
+// Claude CLI writes started_at to its session file, plus any clock skew
+const DISCOVERY_TIMESTAMP_TOLERANCE_MS = 10_000;
+
 /**
  * Registers Tauri event listeners for core session lifecycle:
  * session-output, session-exit, session-status.
@@ -64,6 +76,74 @@ export function useSessionEvents(): void {
 
     // session-status -> update status + detect Claude session ID
     const scannedSessions = new Set<string>();
+    // Tracks retry attempts and pending timer IDs per session tab-id
+    const retryMap = new Map<string, { count: number; timerId: ReturnType<typeof setTimeout> }>();
+    // Tracks claudeSessionIds already claimed by another tab — prevents collision
+    const claimedIds = new Set<string>();
+
+    async function discoverClaudeSessionId(id: string, attempt: number): Promise<void> {
+      const session = useSessionStore.getState().sessions.find((s) => s.id === id);
+      // Abort if session was removed or already has an ID assigned
+      if (!session || session.claudeSessionId) return;
+
+      try {
+        const history = await invoke<ClaudeHistoryEntry[]>(
+          "scan_claude_sessions",
+          { folder: session.folder },
+        );
+
+        if (history && history.length > 0) {
+          // Find the first history entry that:
+          // 1. Is not already claimed by another tab
+          // 2. Has a valid timestamp at or after this session's creation time (within tolerance)
+          const match = history.find((h) => {
+            if (claimedIds.has(h.session_id)) return false;
+            const historyTs = new Date(h.started_at).getTime();
+            if (isNaN(historyTs)) return false;
+            return historyTs >= session.createdAt - DISCOVERY_TIMESTAMP_TOLERANCE_MS;
+          });
+
+          if (match) {
+            claimedIds.add(match.session_id);
+            retryMap.delete(id);
+            useSessionStore.getState().setClaudeSessionId(id, match.session_id);
+
+            // Only write title override if none exists yet — never overwrite a
+            // user-set override with an auto-discovered default title (bug fix)
+            const overrides = useSettingsStore.getState().sessionTitleOverrides;
+            // Re-fetch session after setClaudeSessionId in case it was updated
+            const refreshedSession = useSessionStore.getState().sessions.find((s) => s.id === id);
+            if (refreshedSession?.title?.trim() && !overrides[match.session_id]) {
+              useSettingsStore.getState().setSessionTitleOverride(match.session_id, refreshedSession.title);
+            }
+            return;
+          }
+        }
+      } catch {
+        logWarn(
+          "useSessionEvents",
+          `Claude-Session-ID für "${session.folder}" nicht ermittelt (Versuch ${attempt})`,
+        );
+      }
+
+      // No match found — retry up to DISCOVERY_MAX_RETRIES times
+      const nextAttempt = attempt + 1;
+      if (nextAttempt <= DISCOVERY_MAX_RETRIES) {
+        const timerId = setTimeout(() => {
+          discoverClaudeSessionId(id, nextAttempt).catch((e) =>
+            logError("useSessionEvents.discovery.retry", e),
+          );
+        }, DISCOVERY_RETRY_DELAY_MS);
+        retryMap.set(id, { count: nextAttempt, timerId });
+      } else {
+        retryMap.delete(id);
+        logWarn(
+          "useSessionEvents",
+          `Discovery für "${session.folder}" nach ${DISCOVERY_MAX_RETRIES} Versuchen aufgegeben`,
+        );
+      }
+    }
+
     unlisteners.push(
       listen<{ id: string; status: string }>("session-status", (event) => {
         try {
@@ -84,27 +164,13 @@ export function useSessionEvents(): void {
             scannedSessions.add(id);
             const session = useSessionStore.getState().sessions.find((s) => s.id === id);
             if (session && !session.claudeSessionId) {
-              // Delay to let Claude CLI create its session file
-              setTimeout(async () => {
-                try {
-                  const history = await invoke<Array<{ session_id: string }>>(
-                    "scan_claude_sessions",
-                    { folder: session.folder },
-                  );
-                  if (history && history.length > 0) {
-                    const discoveredSessionId = history[0].session_id;
-                    useSessionStore.getState().setClaudeSessionId(id, discoveredSessionId);
-                    // Persist current session title under the discovered Claude session ID.
-                    // This preserves user renames even if they happened before ID discovery.
-                    const current = useSessionStore.getState().sessions.find((s) => s.id === id);
-                    if (current?.title?.trim()) {
-                      useSettingsStore.getState().setSessionTitleOverride(discoveredSessionId, current.title);
-                    }
-                  }
-                } catch {
-                  logWarn("useSessionEvents", `Claude-Session-ID für "${session.folder}" nicht ermittelt`);
-                }
-              }, 3000);
+              // Delay to let Claude CLI create its session file, then start discovery
+              const timerId = setTimeout(() => {
+                discoverClaudeSessionId(id, 1).catch((e) =>
+                  logError("useSessionEvents.discovery", e),
+                );
+              }, DISCOVERY_RETRY_DELAY_MS);
+              retryMap.set(id, { count: 1, timerId });
             }
           }
         } catch (err) {
@@ -121,6 +187,9 @@ export function useSessionEvents(): void {
       );
       timers.forEach((t) => clearTimeout(t));
       timers.clear();
+      // Cancel any pending discovery retries to prevent stale callbacks after unmount
+      retryMap.forEach(({ timerId }) => clearTimeout(timerId));
+      retryMap.clear();
     };
   }, []);
 }


### PR DESCRIPTION
## Problem
Session-Rename bei einer leeren zweiten Session im selben Folder schrieb den Namen auf den alten History-Eintrag statt den neuen.

## Root Cause
`useSessionEvents.ts` nahm blind `history[0]` aus `scan_claude_sessions({folder})`. Leere Sessions haben keine eigene `.jsonl`-Datei — `history[0]` war immer die alte Session. Beide Tabs bekamen dieselbe `claudeSessionId` und `sessionTitleOverrides[alteSID]` wurde mit dem neuen Titel überschrieben.

## Fix
- **Zeitstempel-Matching**: Statt `history[0]` wird der erste History-Eintrag mit `started_at >= session.createdAt - 10s` gewählt
- **Claim-Tracking**: `claimedIds: Set<string>` verhindert, dass zwei Tabs dieselbe `claudeSessionId` belegen
- **Retry-Logik**: Bei keinem Treffer (leere Session, Datei noch nicht geschrieben) wird bis zu 5× alle 3s neu gescannt
- **Override-Existenzcheck**: Auto-Discovery überschreibt keinen vorhandenen User-Titel mehr

## Test Coverage
13 Tests in `useSessionEvents.test.ts` (+6 neue Discovery-Szenarien):
- Happy Path
- Leere Session / alter Eintrag
- Claim-Konflikt (sequenziell + concurrent)
- Override-Existenzcheck
- Retry-Verhalten

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)