### PR TITLE
feat(ui): Library Detail Modal — M1 Walking Skeleton

### DIFF
--- a/src/components/library/InstancePanel.tsx
+++ b/src/components/library/InstancePanel.tsx
@@ -1,0 +1,17 @@
+import { BookOpen } from "lucide-react";
+
+// ── InstancePanel ────────────────────────────────────────────────────
+// Right column of the Library Detail Modal.
+// M1: static placeholder — Best-Practice content arrives in M4.
+
+export function InstancePanel(): JSX.Element {
+  return (
+    <div className="flex flex-col items-center justify-center h-full min-h-[120px] gap-3 px-4 py-6 text-center">
+      <BookOpen className="w-8 h-8 text-neutral-600 shrink-0" />
+      <p className="text-xs font-medium text-neutral-500">Best Practices</p>
+      <p className="text-[11px] text-neutral-600 max-w-[200px] leading-relaxed">
+        Indikator-Chips, Quotes und vollständige Dokumentation folgen in M4.
+      </p>
+    </div>
+  );
+}

--- a/src/components/library/LibraryDetailContent.test.tsx
+++ b/src/components/library/LibraryDetailContent.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LibraryDetailContent } from "./LibraryDetailContent";
+import type { SelectedDetail } from "../../store/configDiscoveryStore";
+
+const mockSkill = {
+  name: "weather-fetcher",
+  dirName: "weather-fetcher",
+  description: "Fetches weather data",
+  args: [
+    { name: "city", description: "City name", required: true },
+    { name: "unit", description: "Celsius or Fahrenheit", required: false },
+  ],
+  hasReference: true,
+  scope: "global" as const,
+  body: "# Instructions\nCall Open-Meteo API with the given city.",
+};
+
+const skillDetail: SelectedDetail = { category: "skills", item: mockSkill };
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("LibraryDetailContent", () => {
+  it("renders skill name in frontmatter table", () => {
+    render(<LibraryDetailContent detail={skillDetail} />);
+    expect(screen.getByText("weather-fetcher")).toBeTruthy();
+  });
+
+  it("renders skill description in frontmatter table", () => {
+    render(<LibraryDetailContent detail={skillDetail} />);
+    expect(screen.getByText("Fetches weather data")).toBeTruthy();
+  });
+
+  it("renders required arg with asterisk badge", () => {
+    render(<LibraryDetailContent detail={skillDetail} />);
+    expect(screen.getByText("city*")).toBeTruthy();
+  });
+
+  it("renders optional arg without asterisk", () => {
+    render(<LibraryDetailContent detail={skillDetail} />);
+    expect(screen.getByText("unit")).toBeTruthy();
+  });
+
+  it("renders scope badge", () => {
+    render(<LibraryDetailContent detail={skillDetail} />);
+    expect(screen.getByText("global")).toBeTruthy();
+  });
+
+  it("renders markdown body via MarkdownPreview", () => {
+    render(<LibraryDetailContent detail={skillDetail} />);
+    // markdown-it renders "# Instructions" as an h1
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading.textContent).toBe("Instructions");
+  });
+
+  it("renders InstancePanel placeholder in right column", () => {
+    render(<LibraryDetailContent detail={skillDetail} />);
+    expect(screen.getByText("Best Practices")).toBeTruthy();
+  });
+
+  it("renders placeholder for non-skill categories in M1", () => {
+    const agentDetail: SelectedDetail = {
+      category: "agents",
+      item: { name: "test-agent", model: "opus", description: "", scope: "global" },
+    };
+    render(<LibraryDetailContent detail={agentDetail} />);
+    expect(screen.getByText(/kommt in M2/)).toBeTruthy();
+  });
+
+  it("renders empty body placeholder when skill has no body", () => {
+    const emptySkillDetail: SelectedDetail = {
+      category: "skills",
+      item: { ...mockSkill, body: "" },
+    };
+    render(<LibraryDetailContent detail={emptySkillDetail} />);
+    expect(screen.getByText("Kein Inhalt vorhanden")).toBeTruthy();
+  });
+});

--- a/src/components/library/LibraryDetailContent.tsx
+++ b/src/components/library/LibraryDetailContent.tsx
@@ -1,0 +1,107 @@
+import { MarkdownPreview } from "../editor/MarkdownPreview";
+import { InstancePanel } from "./InstancePanel";
+import { SkillArgBadge } from "./SkillArgBadge";
+import type { SelectedDetail, DiscoveredSkill } from "../../store/configDiscoveryStore";
+
+// ── Frontmatter Table ────────────────────────────────────────────────
+
+function FrontmatterRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <tr className="border-b border-neutral-800 last:border-b-0">
+      <td className="py-1.5 pr-4 text-[11px] font-medium text-neutral-500 whitespace-nowrap align-top w-[120px]">
+        {label}
+      </td>
+      <td className="py-1.5 text-xs text-neutral-200 align-top break-words max-w-0 w-full">
+        {children}
+      </td>
+    </tr>
+  );
+}
+
+function SkillFrontmatterTable({ skill }: { skill: DiscoveredSkill }) {
+  return (
+    <div className="shrink-0 px-4 pt-4 pb-3">
+      <table className="w-full table-fixed">
+        <tbody>
+          <FrontmatterRow label="name">{skill.name}</FrontmatterRow>
+          {skill.description && (
+            <FrontmatterRow label="description">{skill.description}</FrontmatterRow>
+          )}
+          <FrontmatterRow label="scope">
+            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-neutral-700 text-neutral-300">
+              {skill.scope}
+            </span>
+          </FrontmatterRow>
+          {skill.hasReference && (
+            <FrontmatterRow label="reference">
+              <span className="text-[10px] px-1 rounded bg-blue-500/15 text-blue-400">ref/</span>
+            </FrontmatterRow>
+          )}
+          {skill.args.length > 0 && (
+            <FrontmatterRow label="args">
+              <div className="flex flex-wrap gap-1">
+                {skill.args.map((a) => (
+                  <SkillArgBadge key={a.name} arg={a} />
+                ))}
+              </div>
+            </FrontmatterRow>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Instance Left Column ─────────────────────────────────────────────
+
+function SkillInstanceLeft({ skill }: { skill: DiscoveredSkill }) {
+  return (
+    <>
+      <SkillFrontmatterTable skill={skill} />
+      <div className="shrink-0 mx-4 border-t border-neutral-700" />
+      <div className="flex-1 min-h-0">
+        {skill.body ? (
+          <MarkdownPreview content={skill.body} />
+        ) : (
+          <div className="flex items-center justify-center h-full text-xs text-neutral-600 p-4">
+            Kein Inhalt vorhanden
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function PlaceholderLeft({ category }: { category: string }) {
+  return (
+    <div className="flex items-center justify-center h-full p-4 text-xs text-neutral-600">
+      Detail-Ansicht für „{category}" kommt in M2.
+    </div>
+  );
+}
+
+// ── LibraryDetailContent ─────────────────────────────────────────────
+
+interface LibraryDetailContentProps {
+  detail: SelectedDetail;
+}
+
+export function LibraryDetailContent({ detail }: LibraryDetailContentProps): JSX.Element {
+  return (
+    <div className="flex flex-col md:flex-row flex-1 min-h-0">
+      {/* Left column — 60% */}
+      <div className="flex flex-col min-h-0 md:overflow-y-auto md:flex-[3] border-b md:border-b-0 md:border-r border-neutral-700">
+        {detail.category === "skills" ? (
+          <SkillInstanceLeft skill={detail.item} />
+        ) : (
+          <PlaceholderLeft category={detail.category} />
+        )}
+      </div>
+
+      {/* Right column — 40% */}
+      <div className="md:flex-[2] flex flex-col min-h-0 md:overflow-y-auto bg-surface-base/30">
+        <InstancePanel />
+      </div>
+    </div>
+  );
+}

--- a/src/components/library/LibraryDetailModal.tsx
+++ b/src/components/library/LibraryDetailModal.tsx
@@ -1,0 +1,68 @@
+import { type LucideIcon, Zap, Bot, Webhook, Brain } from "lucide-react";
+import { Modal } from "../ui/Modal";
+import { LibraryDetailContent } from "./LibraryDetailContent";
+import {
+  useConfigDiscoveryStore,
+  selectSelectedDetail,
+  selectCloseDetail,
+  type SelectedDetail,
+} from "../../store/configDiscoveryStore";
+
+// ── Header meta derivation ───────────────────────────────────────────
+
+interface DetailMeta {
+  Icon: LucideIcon;
+  iconClass: string;
+  title: string;
+  scope?: string;
+}
+
+function getDetailMeta(detail: SelectedDetail): DetailMeta {
+  switch (detail.category) {
+    case "skills":
+      return { Icon: Zap, iconClass: "text-accent", title: detail.item.name, scope: detail.item.scope };
+    case "agents":
+      return { Icon: Bot, iconClass: "text-purple-400", title: detail.item.name, scope: detail.item.scope };
+    case "hooks":
+      return { Icon: Webhook, iconClass: "text-amber-400", title: detail.item.event, scope: detail.item.scope };
+    case "memory":
+      return { Icon: Brain, iconClass: "text-green-400", title: detail.item.name };
+  }
+}
+
+function DetailHeader({ detail }: { detail: SelectedDetail }): JSX.Element {
+  const { Icon, iconClass, title, scope } = getDetailMeta(detail);
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <Icon className={`w-4 h-4 shrink-0 ${iconClass}`} />
+      <span className="text-sm font-semibold text-neutral-200 truncate">{title}</span>
+      {scope && (
+        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-neutral-700 text-neutral-400 shrink-0">
+          {scope}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ── LibraryDetailModal ───────────────────────────────────────────────
+
+export function LibraryDetailModal(): JSX.Element {
+  const selectedDetail = useConfigDiscoveryStore(selectSelectedDetail);
+  const closeDetail = useConfigDiscoveryStore(selectCloseDetail);
+
+  return (
+    <Modal
+      open={selectedDetail !== null}
+      onClose={closeDetail}
+      title={selectedDetail ? <DetailHeader detail={selectedDetail} /> : undefined}
+      className="w-[min(1100px,90vw)] max-h-[85vh] rounded-md shadow-2xl flex flex-col"
+    >
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        {selectedDetail && (
+          <LibraryDetailContent detail={selectedDetail} />
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/library/LibraryView.test.tsx
+++ b/src/components/library/LibraryView.test.tsx
@@ -1,11 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { LibraryView } from "./LibraryView";
+
+// Mock framer-motion to render synchronously (no exit-animation delays)
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => {
+      const { initial: _i, animate: _a, exit: _e, transition: _t, ...rest } = props;
+      return <div {...rest}>{children}</div>;
+    },
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
 import { useConfigDiscoveryStore } from "../../store/configDiscoveryStore";
 import type { ScopeConfig } from "../../store/configDiscoveryStore";
 import { useSettingsStore } from "../../store/settingsStore";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- vitest mock requires runtime cast; vi.MockedFunction<> would need extra setup
 const mockUseSettingsStore = useSettingsStore as any;
 
 // ── Mocks ─────────────────────────────────────────────────────────────
@@ -37,6 +51,16 @@ const makeConfig = (overrides?: Partial<ScopeConfig>): ScopeConfig => ({
   ...overrides,
 });
 
+const mockSkill = {
+  name: "implement",
+  dirName: "implement",
+  description: "Issue to PR",
+  args: [],
+  hasReference: false,
+  scope: "global" as const,
+  body: "# Implement Skill\nFull body content here.",
+};
+
 beforeEach(() => {
   useConfigDiscoveryStore.setState({
     globalConfig: null,
@@ -48,6 +72,7 @@ beforeEach(() => {
     error: null,
     contentCache: {},
     contentLoading: {},
+    selectedDetail: null,
   });
 });
 
@@ -85,19 +110,7 @@ describe("LibraryView", () => {
 
   it("renders global scope panel with skills", () => {
     useConfigDiscoveryStore.setState({
-      globalConfig: makeConfig({
-        skills: [
-          {
-            name: "implement",
-            dirName: "implement",
-            description: "Issue to PR",
-            args: [],
-            hasReference: false,
-            scope: "global",
-            body: "# Implement Skill\nFull body content here.",
-          },
-        ],
-      }),
+      globalConfig: makeConfig({ skills: [mockSkill] }),
     });
 
     render(<LibraryView />);
@@ -217,5 +230,55 @@ describe("LibraryView", () => {
     render(<LibraryView />);
     // "Other App" should not appear since config is not loaded
     expect(screen.queryByText(/Other App/)).toBeNull();
+  });
+
+  // ── Modal Integration Tests ──────────────────────────────────────────
+
+  it("opens detail modal when skill card is clicked", () => {
+    useConfigDiscoveryStore.setState({
+      globalConfig: makeConfig({ skills: [mockSkill] }),
+    });
+
+    render(<LibraryView />);
+    // skill name appears in the card button
+    const skillButton = screen.getByRole("button", { name: /implement/i });
+    fireEvent.click(skillButton);
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("detail modal closes when close button is clicked", async () => {
+    // Open modal via store action directly
+    useConfigDiscoveryStore.getState().openDetail({ category: "skills", item: mockSkill });
+
+    render(<LibraryView />);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    const closeBtn = screen.getByLabelText("Schliessen");
+    fireEvent.click(closeBtn);
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("detail modal shows skill name in header", () => {
+    useConfigDiscoveryStore.getState().openDetail({ category: "skills", item: mockSkill });
+
+    render(<LibraryView />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeTruthy();
+    // skill name appears in the modal header (in addition to card in background)
+    const allImplementTexts = screen.getAllByText("implement");
+    expect(allImplementTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("closes detail modal on Escape key", async () => {
+    useConfigDiscoveryStore.getState().openDetail({ category: "skills", item: mockSkill });
+
+    render(<LibraryView />);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
   });
 });

--- a/src/components/library/LibraryView.tsx
+++ b/src/components/library/LibraryView.tsx
@@ -18,6 +18,7 @@ import { useSessionStore, selectActiveSession } from "../../store/sessionStore";
 import { useSettingsStore } from "../../store/settingsStore";
 import {
   useConfigDiscoveryStore,
+  selectOpenDetail,
   type ScopeConfig,
   type ConfigScope,
   type DiscoveredSkill,
@@ -25,6 +26,8 @@ import {
   type DiscoveredHook,
   type DiscoveredMemoryFile,
 } from "../../store/configDiscoveryStore";
+import { LibraryDetailModal } from "./LibraryDetailModal";
+import { SkillArgBadge } from "./SkillArgBadge";
 
 // ── Content Preview Panel ────────────────────────────────────────────
 
@@ -126,16 +129,12 @@ function Section({
 // ── Skill Card ───────────────────────────────────────────────────────
 
 function SkillCard({ skill }: { skill: DiscoveredSkill }) {
-  const [expanded, setExpanded] = useState(false);
-
-  const contentKey = `${skill.scope}:skill:${skill.dirName}`;
-  // Body is pre-loaded during discovery for both commands/ and skills/ dirs
-  const loader = useCallback(async () => skill.body, [skill.body]);
+  const openDetail = useConfigDiscoveryStore(selectOpenDetail);
 
   return (
     <div className="rounded border border-neutral-700 bg-surface-raised mb-1.5">
       <button
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => openDetail({ category: "skills", item: skill })}
         className="w-full text-left px-3 py-2 hover:bg-hover-overlay transition-colors"
       >
         <div className="flex items-center gap-2">
@@ -157,30 +156,11 @@ function SkillCard({ skill }: { skill: DiscoveredSkill }) {
         {skill.args.length > 0 && (
           <div className="flex gap-1 mt-1 ml-5 flex-wrap">
             {skill.args.map((a) => (
-              <span
-                key={a.name}
-                className={`text-[10px] px-1 rounded ${
-                  a.required
-                    ? "bg-amber-500/15 text-amber-400"
-                    : "bg-neutral-800 text-neutral-500"
-                }`}
-              >
-                {a.name}
-                {a.required ? "*" : ""}
-              </span>
+              <SkillArgBadge key={a.name} arg={a} />
             ))}
           </div>
         )}
       </button>
-      {expanded && (
-        <div className="px-3 pb-2">
-          <ContentPreview
-            title="SKILL.md"
-            contentKey={contentKey}
-            loader={loader}
-          />
-        </div>
-      )}
     </div>
   );
 }
@@ -470,6 +450,9 @@ export function LibraryView() {
           </button>
         </div>
       </div>
+
+      {/* Detail modal — mounts here, reads state from store */}
+      <LibraryDetailModal />
 
       {/* Scrollable content */}
       <div className="flex-1 min-h-0 overflow-auto p-4 space-y-4">

--- a/src/components/library/SkillArgBadge.tsx
+++ b/src/components/library/SkillArgBadge.tsx
@@ -1,0 +1,24 @@
+import type { DiscoveredSkill } from "../../store/configDiscoveryStore";
+
+// ── SkillArgBadge ────────────────────────────────────────────────────
+// Shared badge renderer for skill arguments.
+// Used in both SkillCard (list view) and SkillFrontmatterTable (detail view).
+
+interface SkillArgBadgeProps {
+  arg: DiscoveredSkill["args"][number];
+}
+
+export function SkillArgBadge({ arg }: SkillArgBadgeProps): JSX.Element {
+  return (
+    <span
+      className={`text-[10px] px-1.5 py-0.5 rounded ${
+        arg.required
+          ? "bg-amber-500/15 text-amber-400"
+          : "bg-neutral-800 text-neutral-500"
+      }`}
+      title={arg.description || undefined}
+    >
+      {arg.name}{arg.required ? "*" : ""}
+    </span>
+  );
+}

--- a/src/store/configDiscoveryStore.ts
+++ b/src/store/configDiscoveryStore.ts
@@ -7,6 +7,16 @@ import { parseSkillFrontmatter, type ParsedSkill } from "../utils/parseSkillFron
 
 export type ConfigScope = "global" | "project";
 
+export type LibraryCategory =
+  | "skills"
+  | "agents"
+  | "hooks"
+  | "settings"
+  | "claudeMd"
+  | "memory"
+  | "commands"
+  | "mcp";
+
 export interface DiscoveredSkill {
   name: string;
   dirName: string;
@@ -37,6 +47,12 @@ export interface DiscoveredMemoryFile {
   relativePath: string;
 }
 
+export type SelectedDetail =
+  | { category: "skills"; item: DiscoveredSkill }
+  | { category: "agents"; item: DiscoveredAgent }
+  | { category: "hooks"; item: DiscoveredHook }
+  | { category: "memory"; item: DiscoveredMemoryFile };
+
 export interface ScopeConfig {
   skills: DiscoveredSkill[];
   agents: DiscoveredAgent[];
@@ -63,11 +79,16 @@ interface ConfigDiscoveryState {
   contentCache: Record<string, string>;
   contentLoading: Record<string, boolean>;
 
+  /** Detail modal state */
+  selectedDetail: SelectedDetail | null;
+
   discoverGlobal: () => Promise<void>;
   discoverProject: (folder: string) => Promise<void>;
   discoverFavorites: (folders: string[]) => Promise<void>;
   loadContent: (key: string, loader: () => Promise<string>) => Promise<string>;
   clearProject: () => void;
+  openDetail: (detail: SelectedDetail) => void;
+  closeDetail: () => void;
 }
 
 const EMPTY_SCOPE: ScopeConfig = {
@@ -200,6 +221,7 @@ export const useConfigDiscoveryStore = create<ConfigDiscoveryState>((set, get) =
   error: null,
   contentCache: {},
   contentLoading: {},
+  selectedDetail: null,
 
   discoverGlobal: async () => {
     set({ loading: true, error: null });
@@ -453,6 +475,9 @@ export const useConfigDiscoveryStore = create<ConfigDiscoveryState>((set, get) =
   clearProject: () => {
     set({ projectConfig: null, projectPath: null, contentCache: {}, contentLoading: {} });
   },
+
+  openDetail: (detail: SelectedDetail) => set({ selectedDetail: detail }),
+  closeDetail: () => set({ selectedDetail: null }),
 }));
 
 // ── Selectors ──────────────────────────────────────────────────────────
@@ -463,3 +488,6 @@ export const selectFavoriteConfigs = (s: ConfigDiscoveryState) => s.favoriteConf
 export const selectDiscoveryLoading = (s: ConfigDiscoveryState) => s.loading;
 export const selectContentCache = (s: ConfigDiscoveryState) => s.contentCache;
 export const selectContentLoading = (s: ConfigDiscoveryState) => s.contentLoading;
+export const selectSelectedDetail = (s: ConfigDiscoveryState) => s.selectedDetail;
+export const selectOpenDetail = (s: ConfigDiscoveryState) => s.openDetail;
+export const selectCloseDetail = (s: ConfigDiscoveryState) => s.closeDetail;


### PR DESCRIPTION
## Summary
- Klick auf SkillCard öffnet zweispaltiges Detail-Modal (60/40) mit Frontmatter-Tabelle und gerendertem Markdown-Body
- Store um `selectedDetail`-State + `openDetail`/`closeDetail`-Actions + 3 Selektoren erweitert
- `SkillArgBadge` als shared Komponente extrahiert; rechte Spalte (InstancePanel) ist M4-Placeholder

## Changes
- `src/store/configDiscoveryStore.ts` — `LibraryCategory` + `SelectedDetail` Typen, State + Actions + Selektoren
- `src/components/library/LibraryDetailModal.tsx` — Modal-Wrapper liest `selectedDetail` aus Store
- `src/components/library/LibraryDetailContent.tsx` — 60/40-Layout, Frontmatter-Tabelle + MarkdownPreview
- `src/components/library/InstancePanel.tsx` — rechte Spalte, M4-Placeholder
- `src/components/library/SkillArgBadge.tsx` — extrahierter Arg-Badge (vorher inline in SkillCard)
- `src/components/library/LibraryView.tsx` — Inline-Expand entfernt, `openDetail` verdrahtet, Modal gemountet
- `src/components/library/LibraryView.test.tsx` — `selectedDetail: null` in beforeEach, framer-motion Mock, 4 neue Modal-Integrationstests
- `src/components/library/LibraryDetailContent.test.tsx` — NEU: 9 Render-Tests (Frontmatter, Markdown, Badges, Placeholder)

## Test Plan
- [ ] `npm run test` — alle Tests grün (inkl. 4 Modal-Integration + 9 LibraryDetailContent-Tests)
- [ ] `npx tsc --noEmit` — kein Typefehler
- [ ] `npm run build` — Build erfolgreich
- [ ] Manuell: SkillCard anklicken → Modal öffnet, Frontmatter-Tabelle sichtbar, Markdown gerendert
- [ ] Manuell: Modal schließen (X-Button / Backdrop-Klick) → Store-State zurückgesetzt

🤖 Generated with [Claude Code](https://claude.com/claude-code)