### PR TITLE
feat(kanban): Issue-Modal 2-Spalten + Kommentar-Post + D&D-Fixes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agenticexplorer"
-version = "1.6.23"
+version = "1.6.24"
 dependencies = [
  "chrono",
  "dirs",

--- a/src-tauri/src/github/commands.rs
+++ b/src-tauri/src/github/commands.rs
@@ -65,9 +65,11 @@ pub struct IssueDetail {
     pub state: String,
     pub author: String,
     pub created_at: String,
+    pub updated_at: String,
     pub closed_at: String,
     pub labels: Vec<KanbanLabel>,
-    pub assignee: String,
+    pub assignees: Vec<String>,
+    pub milestone: Option<String>,
     pub url: String,
     pub comments: Vec<IssueComment>,
 }
@@ -136,7 +138,19 @@ fn parse_labels(value: &serde_json::Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Extract the first assignee login from a GitHub JSON value containing an "assignees" array.
+/// Extract all assignee logins from a GitHub JSON value containing an "assignees" array.
+fn parse_assignees(value: &serde_json::Value) -> Vec<String> {
+    value["assignees"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| a["login"].as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Extract the first assignee login (for KanbanIssue / GithubIssue which show only one).
 fn parse_assignee(value: &serde_json::Value) -> String {
     value["assignees"]
         .as_array()
@@ -144,6 +158,14 @@ fn parse_assignee(value: &serde_json::Value) -> String {
         .and_then(|a| a["login"].as_str())
         .unwrap_or("")
         .to_string()
+}
+
+/// Extract the milestone title from a GitHub JSON value, if present.
+fn parse_milestone(value: &serde_json::Value) -> Option<String> {
+    value["milestone"]["title"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(String::from)
 }
 
 // Commands im mod-Block wegen rustc 1.94 E0255 Workaround (siehe CLAUDE.md)
@@ -364,7 +386,7 @@ pub mod commands {
                 "view",
                 &number.to_string(),
                 "--json",
-                "number,title,body,state,author,createdAt,closedAt,labels,assignees,url,comments",
+                "number,title,body,state,author,createdAt,updatedAt,closedAt,labels,assignees,milestone,url,comments",
             ],
         )?;
 
@@ -387,13 +409,6 @@ pub mod commands {
             })
             .unwrap_or_default();
 
-        let assignee = val["assignees"]
-            .as_array()
-            .and_then(|arr| arr.first())
-            .and_then(|a| a["login"].as_str())
-            .unwrap_or("")
-            .to_string();
-
         let comments = val["comments"]
             .as_array()
             .map(|arr| {
@@ -414,9 +429,11 @@ pub mod commands {
             state: val["state"].as_str().unwrap_or("OPEN").to_string(),
             author: val["author"]["login"].as_str().unwrap_or("").to_string(),
             created_at: val["createdAt"].as_str().unwrap_or("").to_string(),
+            updated_at: val["updatedAt"].as_str().unwrap_or("").to_string(),
             closed_at: val["closedAt"].as_str().unwrap_or("").to_string(),
             labels,
-            assignee,
+            assignees: parse_assignees(&val),
+            milestone: parse_milestone(&val),
             url: val["url"].as_str().unwrap_or("").to_string(),
             comments,
         })
@@ -501,6 +518,34 @@ pub mod commands {
             .collect();
 
         Ok(prs)
+    }
+
+    /// Post a new comment on a GitHub issue via gh CLI.
+    ///
+    /// Security: body is passed as a CLI argument (not shell-interpolated), so injection is not
+    /// possible. Input is validated for emptiness before invoking gh.
+    #[tauri::command]
+    pub async fn post_issue_comment(
+        folder: String,
+        number: u64,
+        body: String,
+    ) -> Result<(), ADPError> {
+        if !is_command_available("gh") {
+            return Err(ADPError::new(
+                ADPErrorCode::ServiceRequestFailed,
+                "gh CLI not found",
+            ));
+        }
+        if body.trim().is_empty() {
+            return Err(ADPError::validation("Comment body cannot be empty"));
+        }
+        let num_str = number.to_string();
+        run_command(
+            &folder,
+            "gh",
+            &["issue", "comment", &num_str, "--body", &body],
+        )?;
+        Ok(())
     }
 
     #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,6 +210,7 @@ pub fn run() {
             github::commands::commands::get_kanban_issues,
             github::commands::commands::get_issue_detail,
             github::commands::commands::get_issue_checks,
+            github::commands::commands::post_issue_comment,
             github::commands::commands::move_issue_lane,
             // Library
             library::commands::commands::list_library_items,

--- a/src/components/editor/MarkdownPreview.test.tsx
+++ b/src/components/editor/MarkdownPreview.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MarkdownPreview } from "./MarkdownPreview";
+import { MarkdownPreview, MarkdownBody } from "./MarkdownPreview";
 
 describe("MarkdownPreview", () => {
   it("renders basic markdown", () => {
@@ -114,5 +114,61 @@ describe("MarkdownPreview", () => {
     expect(strong?.textContent).toBe("bold");
     expect(em).toBeTruthy();
     expect(em?.textContent).toBe("italic");
+  });
+});
+
+// ── MarkdownBody Tests ─────────────────────────────────────────────────
+
+describe("MarkdownBody", () => {
+  it("renders markdown content without outer wrapper styles", () => {
+    const { container } = render(<MarkdownBody content="**hello**" />);
+    const div = container.querySelector(".md-preview");
+    expect(div).toBeTruthy();
+    // No h-full, no bg-surface-raised (those belong to MarkdownPreview wrapper)
+    expect(div?.className).not.toContain("h-full");
+    expect(div?.className).not.toContain("bg-surface-raised");
+  });
+
+  it("accepts optional className prop", () => {
+    const { container } = render(
+      <MarkdownBody content="text" className="text-sm text-red-400" />,
+    );
+    const div = container.querySelector(".md-preview");
+    expect(div?.className).toContain("text-sm");
+    expect(div?.className).toContain("text-red-400");
+  });
+
+  it("renders bold text as <strong>", () => {
+    const { container } = render(<MarkdownBody content="**bold**" />);
+    const strong = container.querySelector("strong");
+    expect(strong).toBeTruthy();
+    expect(strong?.textContent).toBe("bold");
+  });
+
+  it("renders empty content without errors", () => {
+    const { container } = render(<MarkdownBody content="" />);
+    expect(container.querySelector(".md-preview")).toBeTruthy();
+  });
+
+  it("preserves task-list checkbox attributes after DOMPurify", () => {
+    // GitHub-flavored task lists use input[type="checkbox"] with checked/disabled
+    // DOMPurify must keep type, checked, and disabled attributes
+    const { container } = render(
+      <MarkdownBody content={"- [x] Done item\n- [ ] Open item"} />,
+    );
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    // markdown-it-task-lists would render these; if not installed,
+    // verify DOMPurify doesn't strip type attr from manually injected HTML
+    // by checking no type attributes were stripped from any input elements
+    const allInputs = container.querySelectorAll("input");
+    for (const input of Array.from(allInputs)) {
+      // type attribute must be preserved (not stripped by DOMPurify)
+      expect(input.hasAttribute("type")).toBe(true);
+    }
+    // Whether or not checkboxes render depends on markdown-it config,
+    // but if they do, they must have type="checkbox"
+    for (const cb of Array.from(checkboxes)) {
+      expect(cb.getAttribute("type")).toBe("checkbox");
+    }
   });
 });

--- a/src/components/editor/MarkdownPreview.tsx
+++ b/src/components/editor/MarkdownPreview.tsx
@@ -8,29 +8,60 @@ const md = new MarkdownIt({
   typographer: true,
 });
 
-// Block event handler attrs, data attributes, and dangerous URI schemes (XSS prevention)
-const PURIFY_ALLOWED_ATTR = ["href", "title", "alt", "src", "class", "id"];
+// Block event handler attrs, data attributes, and dangerous URI schemes (XSS prevention).
+// type/checked/disabled are allowed to preserve GitHub-style task-list checkboxes rendered
+// by markdown-it as <input type="checkbox" checked disabled>.
+const PURIFY_ALLOWED_ATTR = [
+  "href", "title", "alt", "src", "class", "id",
+  "type", "checked", "disabled",
+];
 const PURIFY_FORBID_ATTR = [
   "onerror", "onload", "onclick", "onmouseover", "onmouseout",
   "onfocus", "onblur", "onsubmit", "onchange", "oninput",
 ];
 const PURIFY_ALLOWED_URI = /^(?:https?|mailto|tel|#):/i;
 
+function renderMarkdown(content: string): string {
+  const raw = md.render(content);
+  return DOMPurify.sanitize(raw, {
+    ALLOWED_ATTR: PURIFY_ALLOWED_ATTR,
+    FORBID_ATTR: PURIFY_FORBID_ATTR,
+    ALLOW_DATA_ATTR: false,
+    ALLOWED_URI_REGEXP: PURIFY_ALLOWED_URI,
+  });
+}
+
+// ============================================================================
+// MarkdownBody — slim inline renderer (no wrapper padding/background).
+// Use inside modals, sidebars, or any context that provides its own layout.
+// ============================================================================
+
+interface MarkdownBodyProps {
+  content: string;
+  className?: string;
+}
+
+export function MarkdownBody({ content, className }: MarkdownBodyProps) {
+  const html = useMemo(() => renderMarkdown(content), [content]);
+  return (
+    <div
+      className={`md-preview${className ? ` ${className}` : ""}`}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+// ============================================================================
+// MarkdownPreview — full-page editor preview with scroll and background.
+// Used by MarkdownEditorView, LibraryDetailContent, ClaudeMdViewer, PinnedDocViewer.
+// ============================================================================
+
 interface MarkdownPreviewProps {
   content: string;
 }
 
 export function MarkdownPreview({ content }: MarkdownPreviewProps) {
-  const html = useMemo(() => {
-    const raw = md.render(content);
-    return DOMPurify.sanitize(raw, {
-      ALLOWED_ATTR: PURIFY_ALLOWED_ATTR,
-      FORBID_ATTR: PURIFY_FORBID_ATTR,
-      ALLOW_DATA_ATTR: false,
-      ALLOWED_URI_REGEXP: PURIFY_ALLOWED_URI,
-    });
-  }, [content]);
-
+  const html = useMemo(() => renderMarkdown(content), [content]);
   return (
     <div className="h-full overflow-auto p-6 bg-surface-raised">
       <div

--- a/src/components/kanban/IssueBody.tsx
+++ b/src/components/kanban/IssueBody.tsx
@@ -1,0 +1,20 @@
+import { MarkdownBody } from "../editor/MarkdownPreview";
+
+interface IssueBodyProps {
+  body: string;
+}
+
+export function IssueBody({ body }: IssueBodyProps) {
+  if (!body) {
+    return (
+      <div className="border-t border-neutral-700/50 pt-3 text-xs text-neutral-600 italic">
+        Keine Beschreibung
+      </div>
+    );
+  }
+  return (
+    <div className="border-t border-neutral-700/50 pt-3">
+      <MarkdownBody content={body} className="text-sm text-neutral-300" />
+    </div>
+  );
+}

--- a/src/components/kanban/IssueCommentForm.test.tsx
+++ b/src/components/kanban/IssueCommentForm.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { IssueCommentForm } from "./IssueCommentForm";
+import { invoke } from "@tauri-apps/api/core";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("../../utils/adpError", () => ({
+  getErrorMessage: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const mockInvoke = vi.mocked(invoke);
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("IssueCommentForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders textarea and disabled submit button when empty", () => {
+    render(
+      <IssueCommentForm folder="/test" issueNumber={42} onCommentPosted={vi.fn()} />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Kommentar verfassen/);
+    expect(textarea).toBeTruthy();
+
+    const button = screen.getByText("Kommentar posten");
+    expect(button).toHaveProperty("disabled", true);
+  });
+
+  it("enables submit button when body has text", () => {
+    render(
+      <IssueCommentForm folder="/test" issueNumber={42} onCommentPosted={vi.fn()} />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Kommentar verfassen/);
+    fireEvent.change(textarea, { target: { value: "A comment" } });
+
+    const button = screen.getByText("Kommentar posten");
+    expect(button).toHaveProperty("disabled", false);
+  });
+
+  it("keeps submit disabled when body is only whitespace", () => {
+    render(
+      <IssueCommentForm folder="/test" issueNumber={42} onCommentPosted={vi.fn()} />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Kommentar verfassen/);
+    fireEvent.change(textarea, { target: { value: "   " } });
+
+    const button = screen.getByText("Kommentar posten");
+    expect(button).toHaveProperty("disabled", true);
+  });
+
+  it("calls post_issue_comment and onCommentPosted on successful submit", async () => {
+    const onCommentPosted = vi.fn();
+    mockInvoke.mockResolvedValueOnce(undefined);
+
+    render(
+      <IssueCommentForm
+        folder="/test"
+        issueNumber={42}
+        onCommentPosted={onCommentPosted}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Kommentar verfassen/);
+    fireEvent.change(textarea, { target: { value: "Great fix!" } });
+    fireEvent.click(screen.getByText("Kommentar posten"));
+
+    await waitFor(() => {
+      expect(onCommentPosted).toHaveBeenCalledOnce();
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith("post_issue_comment", {
+      folder: "/test",
+      number: 42,
+      body: "Great fix!",
+    });
+  });
+
+  it("clears textarea after successful submit", async () => {
+    mockInvoke.mockResolvedValueOnce(undefined);
+
+    render(
+      <IssueCommentForm folder="/test" issueNumber={42} onCommentPosted={vi.fn()} />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Kommentar verfassen/);
+    fireEvent.change(textarea, { target: { value: "My comment" } });
+    fireEvent.click(screen.getByText("Kommentar posten"));
+
+    await waitFor(() => {
+      expect((textarea as HTMLTextAreaElement).value).toBe("");
+    });
+  });
+
+  it("shows error message on failed submit", async () => {
+    mockInvoke.mockRejectedValueOnce(new Error("Network timeout"));
+
+    render(
+      <IssueCommentForm folder="/test" issueNumber={42} onCommentPosted={vi.fn()} />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Kommentar verfassen/);
+    fireEvent.change(textarea, { target: { value: "A comment" } });
+    fireEvent.click(screen.getByText("Kommentar posten"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Network timeout")).toBeTruthy();
+    });
+  });
+
+  it("does not call onCommentPosted on failed submit", async () => {
+    const onCommentPosted = vi.fn();
+    mockInvoke.mockRejectedValueOnce(new Error("fail"));
+
+    render(
+      <IssueCommentForm
+        folder="/test"
+        issueNumber={42}
+        onCommentPosted={onCommentPosted}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Kommentar verfassen/);
+    fireEvent.change(textarea, { target: { value: "A comment" } });
+    fireEvent.click(screen.getByText("Kommentar posten"));
+
+    await waitFor(() => {
+      expect(screen.getByText("fail")).toBeTruthy();
+    });
+
+    expect(onCommentPosted).not.toHaveBeenCalled();
+  });
+
+  it("shows submitting state while posting", async () => {
+    let resolve!: (v: undefined) => void;
+    mockInvoke.mockReturnValueOnce(new Promise((r) => (resolve = r)));
+
+    render(
+      <IssueCommentForm folder="/test" issueNumber={42} onCommentPosted={vi.fn()} />,
+    );
+
+    const textarea = screen.getByPlaceholderText(/Kommentar verfassen/);
+    fireEvent.change(textarea, { target: { value: "A comment" } });
+    fireEvent.click(screen.getByText("Kommentar posten"));
+
+    expect(screen.getByText("Wird gesendet…")).toBeTruthy();
+
+    resolve(undefined);
+  });
+});

--- a/src/components/kanban/IssueCommentForm.tsx
+++ b/src/components/kanban/IssueCommentForm.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { getErrorMessage } from "../../utils/adpError";
+import { MessageSquare } from "lucide-react";
+
+interface IssueCommentFormProps {
+  folder: string;
+  issueNumber: number;
+  onCommentPosted: () => void;
+}
+
+export function IssueCommentForm({
+  folder,
+  issueNumber,
+  onCommentPosted,
+}: IssueCommentFormProps) {
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function submitComment() {
+    if (!body.trim()) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      await invoke("post_issue_comment", {
+        folder,
+        number: issueNumber,
+        body,
+      });
+      setBody("");
+      onCommentPosted();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    void submitComment();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      void submitComment();
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="border-t border-neutral-700/50 pt-4 space-y-2"
+    >
+      <div className="flex items-center gap-1.5 text-xs text-neutral-400 font-medium mb-1">
+        <MessageSquare className="w-3.5 h-3.5" />
+        Kommentar hinzufügen
+      </div>
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={submitting}
+        placeholder="Kommentar verfassen (Markdown, ⌘/Ctrl+Enter zum Senden)"
+        rows={4}
+        className="w-full bg-surface-base border border-neutral-700 rounded-sm p-2 text-sm text-neutral-200 placeholder:text-neutral-600 resize-y disabled:opacity-50 focus:outline-none focus:border-neutral-500 transition-colors"
+      />
+      {error && (
+        <p className="text-xs text-red-400">{error}</p>
+      )}
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={!body.trim() || submitting}
+          className="px-3 py-1.5 text-xs font-medium bg-accent text-white rounded-sm disabled:opacity-40 hover:bg-accent/90 transition-colors"
+        >
+          {submitting ? "Wird gesendet…" : "Kommentar posten"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/kanban/IssueComments.tsx
+++ b/src/components/kanban/IssueComments.tsx
@@ -1,0 +1,42 @@
+import { MessageSquare } from "lucide-react";
+import { MarkdownBody } from "../editor/MarkdownPreview";
+
+export interface IssueComment {
+  author: string;
+  body: string;
+  created_at: string;
+}
+
+interface IssueCommentsProps {
+  comments: IssueComment[];
+  formatDate: (iso: string) => string;
+}
+
+export function IssueComments({ comments, formatDate }: IssueCommentsProps) {
+  if (comments.length === 0) return null;
+
+  return (
+    <div className="border-t border-neutral-700/50 pt-3 space-y-3">
+      <div className="flex items-center gap-1.5 text-xs text-neutral-400 font-medium">
+        <MessageSquare className="w-3.5 h-3.5" />
+        {comments.length} {comments.length === 1 ? "Kommentar" : "Kommentare"}
+      </div>
+      {comments.map((comment) => (
+        <div
+          key={`${comment.author}-${comment.created_at}`}
+          className="bg-surface-raised border border-neutral-700/50 rounded-sm p-3"
+        >
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-neutral-300">
+              {comment.author}
+            </span>
+            <span className="text-[10px] text-neutral-600">
+              {formatDate(comment.created_at)}
+            </span>
+          </div>
+          <MarkdownBody content={comment.body} className="text-xs text-neutral-400" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/kanban/IssueLinkedPRs.tsx
+++ b/src/components/kanban/IssueLinkedPRs.tsx
@@ -1,0 +1,123 @@
+import { open } from "@tauri-apps/plugin-shell";
+import { GitPullRequest, CheckCircle2, XCircle, Clock, Loader2 } from "lucide-react";
+
+interface CheckRun {
+  name: string;
+  status: string;
+  conclusion: string;
+}
+
+export interface LinkedPR {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  checks: CheckRun[];
+}
+
+interface IssueLinkedPRsProps {
+  linkedPRs: LinkedPR[];
+}
+
+function checkStyle(check: CheckRun): {
+  className: string;
+  icon: React.ReactNode;
+} {
+  const isSuccess =
+    check.conclusion === "SUCCESS" || check.conclusion === "success";
+  const isFailed =
+    check.conclusion === "FAILURE" ||
+    check.conclusion === "failure" ||
+    check.conclusion === "ERROR" ||
+    check.conclusion === "error";
+  const isPending =
+    check.status === "IN_PROGRESS" ||
+    check.status === "QUEUED" ||
+    check.status === "PENDING" ||
+    check.status === "pending";
+
+  if (isSuccess) {
+    return {
+      className:
+        "bg-green-500/10 text-green-400 border-green-500/20",
+      icon: <CheckCircle2 className="w-2.5 h-2.5" />,
+    };
+  }
+  if (isFailed) {
+    return {
+      className: "bg-red-500/10 text-red-400 border-red-500/20",
+      icon: <XCircle className="w-2.5 h-2.5" />,
+    };
+  }
+  if (isPending) {
+    return {
+      className:
+        "bg-yellow-500/10 text-yellow-400 border-yellow-500/20",
+      icon: <Loader2 className="w-2.5 h-2.5 animate-spin" />,
+    };
+  }
+  return {
+    className:
+      "bg-neutral-500/10 text-neutral-400 border-neutral-700/50",
+    icon: <Clock className="w-2.5 h-2.5" />,
+  };
+}
+
+export function IssueLinkedPRs({ linkedPRs }: IssueLinkedPRsProps) {
+  if (linkedPRs.length === 0) return null;
+
+  return (
+    <div className="border-t border-neutral-700/50 pt-3 space-y-2">
+      <div className="flex items-center gap-1.5 text-xs text-neutral-400 font-medium">
+        <GitPullRequest className="w-3.5 h-3.5" />
+        Verknüpfte Pull Requests
+      </div>
+      {linkedPRs.map((pr) => (
+        <div
+          key={pr.number}
+          className="bg-surface-raised border border-neutral-700/50 rounded-sm p-3"
+        >
+          <div className="flex items-center justify-between mb-1">
+            <button
+              onClick={() => open(pr.url)}
+              className="text-xs font-medium text-neutral-200 hover:text-accent transition-colors text-left"
+            >
+              #{pr.number} {pr.title}
+            </button>
+            <span
+              className={`text-[10px] px-1.5 py-0.5 rounded-sm font-medium ${
+                pr.state === "MERGED"
+                  ? "bg-purple-500/20 text-purple-300"
+                  : pr.state === "CLOSED"
+                    ? "bg-red-500/20 text-red-300"
+                    : "bg-green-500/20 text-green-300"
+              }`}
+            >
+              {pr.state === "MERGED"
+                ? "Merged"
+                : pr.state === "CLOSED"
+                  ? "Closed"
+                  : "Open"}
+            </span>
+          </div>
+          {pr.checks.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {pr.checks.map((check) => {
+                const { className, icon } = checkStyle(check);
+                return (
+                  <span
+                    key={check.name}
+                    className={`inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-sm border font-medium ${className}`}
+                  >
+                    {icon}
+                    {check.name}
+                  </span>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/kanban/IssueSidebar.test.tsx
+++ b/src/components/kanban/IssueSidebar.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { IssueSidebar } from "./IssueSidebar";
+import type { KanbanLabel } from "./KanbanCard";
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const formatDate = (iso: string) =>
+  iso ? new Date(iso).toLocaleDateString("de-DE") : "";
+
+const defaultLabels: KanbanLabel[] = [
+  { name: "bug", color: "d73a4a" },
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("IssueSidebar", () => {
+  it("renders author", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={[]}
+        labels={[]}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.getByText("alice")).toBeTruthy();
+  });
+
+  it("shows 'Niemand zugewiesen' when assignees is empty", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={[]}
+        labels={[]}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.getByText("Niemand zugewiesen")).toBeTruthy();
+  });
+
+  it("renders a single assignee", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={["bob"]}
+        labels={[]}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.getByText("bob")).toBeTruthy();
+    expect(screen.queryByText("Niemand zugewiesen")).toBeNull();
+  });
+
+  it("renders all assignees when multiple are present", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={["bob", "carol", "dave"]}
+        labels={[]}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.getByText("bob")).toBeTruthy();
+    expect(screen.getByText("carol")).toBeTruthy();
+    expect(screen.getByText("dave")).toBeTruthy();
+  });
+
+  it("renders labels with names", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={[]}
+        labels={defaultLabels}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.getByText("bug")).toBeTruthy();
+  });
+
+  it("hides labels section when labels is empty", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={[]}
+        labels={[]}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.queryByText("Labels")).toBeNull();
+  });
+
+  it("renders milestone when present", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={[]}
+        labels={[]}
+        milestone="v2.0"
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.getByText("v2.0")).toBeTruthy();
+  });
+
+  it("hides milestone section when milestone is null", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={[]}
+        labels={[]}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.queryByText("Milestone")).toBeNull();
+  });
+
+  it("renders created date via formatDate", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={[]}
+        labels={[]}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    // formatDate renders as "15.03.2026" with de-DE locale
+    expect(screen.getByText(/Erstellt:/)).toBeTruthy();
+  });
+
+  it("renders closed date when closedAt is set", () => {
+    render(
+      <IssueSidebar
+        state="CLOSED"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-20T14:00:00Z"
+        closedAt="2026-03-20T14:00:00Z"
+        assignees={[]}
+        labels={[]}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.getByText(/Geschlossen:/)).toBeTruthy();
+  });
+
+  it("hides closed date when closedAt is empty", () => {
+    render(
+      <IssueSidebar
+        state="OPEN"
+        author="alice"
+        createdAt="2026-03-15T10:00:00Z"
+        updatedAt="2026-03-15T10:00:00Z"
+        closedAt=""
+        assignees={[]}
+        labels={[]}
+        milestone={null}
+        formatDate={formatDate}
+      />,
+    );
+
+    expect(screen.queryByText(/Geschlossen:/)).toBeNull();
+  });
+});

--- a/src/components/kanban/IssueSidebar.tsx
+++ b/src/components/kanban/IssueSidebar.tsx
@@ -1,0 +1,112 @@
+import { User, Calendar, Tag, Milestone } from "lucide-react";
+import { labelStyle } from "./kanbanUtils";
+import type { KanbanLabel } from "./KanbanCard";
+
+interface IssueSidebarProps {
+  state: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string;
+  assignees: string[];
+  labels: KanbanLabel[];
+  milestone: string | null;
+  formatDate: (iso: string) => string;
+}
+
+export function IssueSidebar({
+  author,
+  createdAt,
+  updatedAt,
+  closedAt,
+  assignees,
+  labels,
+  milestone,
+  formatDate,
+}: IssueSidebarProps) {
+  return (
+    <div className="space-y-4 text-xs">
+
+      {/* Author */}
+      {author && (
+        <div className="space-y-1">
+          <p className="text-[10px] font-medium text-neutral-500 uppercase tracking-wide">Autor</p>
+          <div className="flex items-center gap-1.5 text-neutral-300">
+            <User className="w-3 h-3 text-neutral-500 shrink-0" />
+            <span>{author}</span>
+          </div>
+        </div>
+      )}
+
+      {/* Dates */}
+      <div className="space-y-1">
+        <p className="text-[10px] font-medium text-neutral-500 uppercase tracking-wide">Datum</p>
+        {createdAt && (
+          <div className="flex items-center gap-1.5 text-neutral-400">
+            <Calendar className="w-3 h-3 text-neutral-500 shrink-0" />
+            <span>Erstellt: {formatDate(createdAt)}</span>
+          </div>
+        )}
+        {updatedAt && updatedAt !== createdAt && (
+          <div className="flex items-center gap-1.5 text-neutral-400">
+            <Calendar className="w-3 h-3 text-neutral-500 shrink-0" />
+            <span>Geändert: {formatDate(updatedAt)}</span>
+          </div>
+        )}
+        {closedAt && (
+          <div className="flex items-center gap-1.5 text-neutral-400">
+            <Calendar className="w-3 h-3 text-neutral-500 shrink-0" />
+            <span>Geschlossen: {formatDate(closedAt)}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Assignees */}
+      <div className="space-y-1">
+        <p className="text-[10px] font-medium text-neutral-500 uppercase tracking-wide">Zugewiesen</p>
+        {assignees.length === 0 ? (
+          <p className="text-neutral-600 italic">Niemand zugewiesen</p>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {assignees.map((a) => (
+              <div key={a} className="flex items-center gap-1.5 text-neutral-300">
+                <User className="w-3 h-3 text-neutral-500 shrink-0" />
+                <span>{a}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Labels */}
+      {labels.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-[10px] font-medium text-neutral-500 uppercase tracking-wide">Labels</p>
+          <div className="flex flex-col gap-1">
+            {labels.map((label) => (
+              <span
+                key={label.name}
+                className="self-start text-[10px] px-1.5 py-0.5 rounded-sm border font-medium"
+                style={labelStyle(label.color)}
+              >
+                <Tag className="w-2.5 h-2.5 inline mr-1 opacity-70" />
+                {label.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Milestone */}
+      {milestone && (
+        <div className="space-y-1">
+          <p className="text-[10px] font-medium text-neutral-500 uppercase tracking-wide">Milestone</p>
+          <div className="flex items-center gap-1.5 text-neutral-300">
+            <Milestone className="w-3 h-3 text-neutral-500 shrink-0" />
+            <span>{milestone}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/kanban/KanbanBoard.test.tsx
+++ b/src/components/kanban/KanbanBoard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, createEvent, act } from "@testing-library/react";
 import { KanbanBoard } from "./KanbanBoard";
 import { invoke } from "@tauri-apps/api/core";
 import type { KanbanIssue } from "./KanbanCard";
@@ -200,5 +200,63 @@ describe("KanbanBoard", () => {
 
     const emptyMessages = screen.getAllByText("Keine Issues");
     expect(emptyMessages.length).toBe(4);
+  });
+
+  /** Helper: fire dragOver with a mock dataTransfer to avoid jsdom TypeError */
+  function fireDragOver(element: Element) {
+    const ev = createEvent.dragOver(element);
+    Object.defineProperty(ev, "dataTransfer", {
+      value: { dropEffect: "" },
+      configurable: true,
+    });
+    act(() => {
+      element.dispatchEvent(ev);
+    });
+  }
+
+  it("onDragOver sets column highlight", async () => {
+    mockInvoke.mockResolvedValueOnce(makeIssues());
+
+    const { container } = render(<KanbanBoard folder="/test/dragover" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Kanban (6 Issues)")).toBeTruthy();
+    });
+
+    const columns = container.querySelectorAll(".flex.flex-col.w-\\[260px\\]");
+    const backlogColumn = columns[0] as HTMLElement;
+
+    // dragOver should set highlight (dragOverColumn = "backlog")
+    fireDragOver(backlogColumn);
+
+    await waitFor(() => {
+      expect(backlogColumn.className).toContain("border-accent");
+    });
+  });
+
+  it("onDragLeave clears highlight when leaving to an element outside the column", async () => {
+    mockInvoke.mockResolvedValueOnce(makeIssues());
+
+    const { container } = render(<KanbanBoard folder="/test/dragleave-out" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Kanban (6 Issues)")).toBeTruthy();
+    });
+
+    const columns = container.querySelectorAll(".flex.flex-col.w-\\[260px\\]");
+    const backlogColumn = columns[0] as HTMLElement;
+    const todoColumn = columns[1] as HTMLElement;
+
+    // Drag over backlog to set highlight
+    fireDragOver(backlogColumn);
+
+    await waitFor(() => {
+      expect(backlogColumn.className).toContain("border-accent");
+    });
+
+    // DragLeave to a sibling column (outside) → contains() returns false → highlight clears
+    fireEvent.dragLeave(backlogColumn, { relatedTarget: todoColumn });
+
+    expect(backlogColumn.className).not.toContain("border-accent");
   });
 });

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -217,7 +217,11 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
                 e.dataTransfer.dropEffect = "move";
                 setDragOverColumn(col.id);
               }}
-              onDragLeave={() => setDragOverColumn(null)}
+              onDragLeave={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+                  setDragOverColumn(null);
+                }
+              }}
               onDrop={(e) => handleDrop(col.id, e)}
             >
               {/* Column header */}
@@ -250,6 +254,10 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
                         onDragStart={() => {
                           draggedIssueNumberRef.current = issue.number;
                         }}
+                        onDragEnd={() => {
+                          draggedIssueNumberRef.current = null;
+                          setDragOverColumn(null);
+                        }}
                       />
                     </div>
                   ))
@@ -267,6 +275,10 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
           folder={folder}
           issueNumber={selectedIssue}
           onClose={() => setSelectedIssue(null)}
+          onIssueChanged={() => {
+            cache.delete(folder);
+            void load(true);
+          }}
         />
       )}
     </div>

--- a/src/components/kanban/KanbanCard.test.tsx
+++ b/src/components/kanban/KanbanCard.test.tsx
@@ -118,4 +118,59 @@ describe("KanbanCard", () => {
     // stopPropagation prevents onClick on card
     expect(onClick).not.toHaveBeenCalled();
   });
+
+  it("card has cursor-grab class for drag affordance", () => {
+    const { container } = render(<KanbanCard issue={makeIssue()} />);
+    const card = container.firstElementChild!;
+    expect(card.className).toContain("cursor-grab");
+  });
+
+  it("suppresses onClick when dragging (isDraggingRef guard)", () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <KanbanCard issue={makeIssue()} onClick={onClick} />,
+    );
+
+    const card = container.firstElementChild!;
+    const dataTransfer = { setData: vi.fn(), effectAllowed: "" };
+
+    // Start drag then immediately click — click should be suppressed
+    fireEvent.dragStart(card, { dataTransfer });
+    fireEvent.click(card);
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("calls onDragEnd when drag finishes", () => {
+    const onDragEnd = vi.fn();
+    const { container } = render(
+      <KanbanCard issue={makeIssue()} onDragEnd={onDragEnd} />,
+    );
+
+    const card = container.firstElementChild!;
+    const dataTransfer = { setData: vi.fn(), effectAllowed: "" };
+
+    fireEvent.dragStart(card, { dataTransfer });
+    fireEvent.dragEnd(card);
+
+    expect(onDragEnd).toHaveBeenCalledOnce();
+  });
+
+  it("allows onClick again after drag ends", () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <KanbanCard issue={makeIssue()} onClick={onClick} />,
+    );
+
+    const card = container.firstElementChild!;
+    const dataTransfer = { setData: vi.fn(), effectAllowed: "" };
+
+    // Drag cycle: start → end
+    fireEvent.dragStart(card, { dataTransfer });
+    fireEvent.dragEnd(card);
+
+    // After drag ends, click should work again
+    fireEvent.click(card);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
 });

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -1,6 +1,8 @@
+import { useState, useRef } from "react";
 import { ExternalLink } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
 import { logWarn } from "../../utils/errorLogger";
+import { labelStyle } from "./kanbanUtils";
 
 export interface KanbanLabel {
   name: string;
@@ -20,15 +22,7 @@ interface KanbanCardProps {
   issue: KanbanIssue;
   onClick?: () => void;
   onDragStart?: () => void;
-}
-
-function labelStyle(color: string): React.CSSProperties {
-  const hex = color.startsWith("#") ? color : `#${color}`;
-  return {
-    backgroundColor: `${hex}20`,
-    color: hex,
-    borderColor: `${hex}40`,
-  };
+  onDragEnd?: () => void;
 }
 
 async function openUrl(url: string) {
@@ -39,16 +33,32 @@ async function openUrl(url: string) {
   }
 }
 
-export function KanbanCard({ issue, onClick, onDragStart }: KanbanCardProps) {
+export function KanbanCard({ issue, onClick, onDragStart, onDragEnd }: KanbanCardProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  // Guard: suppress onClick if the pointer moved (drag rather than click)
+  const isDraggingRef = useRef(false);
+
   return (
     <div
-      className="group bg-surface-base border border-neutral-700 rounded-sm p-3 hover:border-neutral-500 transition-colors cursor-pointer"
+      className={`group bg-surface-base border border-neutral-700 rounded-sm p-3 hover:border-neutral-500 transition-colors cursor-grab active:cursor-grabbing select-none ${
+        isDragging ? "opacity-60" : ""
+      }`}
       draggable
-      onClick={onClick}
+      onClick={() => {
+        if (isDraggingRef.current) return;
+        onClick?.();
+      }}
       onDragStart={(e) => {
         e.dataTransfer.setData("text/plain", String(issue.number));
         e.dataTransfer.effectAllowed = "move";
+        isDraggingRef.current = true;
+        setIsDragging(true);
         onDragStart?.();
+      }}
+      onDragEnd={() => {
+        isDraggingRef.current = false;
+        setIsDragging(false);
+        onDragEnd?.();
       }}
     >
       {/* Header: number + external link */}
@@ -58,7 +68,7 @@ export function KanbanCard({ issue, onClick, onDragStart }: KanbanCardProps) {
           <button
             onClick={(e) => {
               e.stopPropagation();
-              openUrl(issue.url);
+              void openUrl(issue.url);
             }}
             className="p-0.5 text-neutral-600 hover:text-neutral-300 opacity-0 group-hover:opacity-100 transition-opacity"
             title="Im Browser öffnen"

--- a/src/components/kanban/KanbanDetailModal.test.tsx
+++ b/src/components/kanban/KanbanDetailModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { KanbanDetailModal } from "./KanbanDetailModal";
 import { invoke } from "@tauri-apps/api/core";
 
@@ -45,12 +45,14 @@ function makeIssueDetail() {
     state: "OPEN",
     author: "alice",
     created_at: "2026-03-15T10:00:00Z",
+    updated_at: "2026-03-16T09:00:00Z",
     closed_at: "",
     labels: [
       { name: "bug", color: "d73a4a" },
       { name: "priority", color: "ff0000" },
     ],
-    assignee: "bob",
+    assignees: ["bob"],
+    milestone: null as string | null,
     url: "https://github.com/org/repo/issues/42",
     comments: [
       {
@@ -97,7 +99,7 @@ describe("KanbanDetailModal", () => {
       />,
     );
 
-    expect(screen.getByText("Laden...")).toBeTruthy();
+    expect(screen.getByText(/Laden/)).toBeTruthy();
     expect(screen.getByText("#42")).toBeTruthy();
   });
 
@@ -123,14 +125,14 @@ describe("KanbanDetailModal", () => {
 
     // State badge
     expect(screen.getByText("Offen")).toBeTruthy();
-    // Author
+    // Author in sidebar
     expect(screen.getByText("alice")).toBeTruthy();
-    // Assignee
-    expect(screen.getByText(/Zugewiesen: bob/)).toBeTruthy();
+    // Assignee in sidebar (rendered as plain username)
+    expect(screen.getByText("bob")).toBeTruthy();
     // Labels
     expect(screen.getByText("bug")).toBeTruthy();
     expect(screen.getByText("priority")).toBeTruthy();
-    // Body
+    // Body (rendered via MarkdownBody → DOM text is findable)
     expect(
       screen.getByText("The login form does not validate email."),
     ).toBeTruthy();
@@ -140,7 +142,7 @@ describe("KanbanDetailModal", () => {
     expect(screen.getByText("I can reproduce this.")).toBeTruthy();
   });
 
-  it("renders closed state badge and closed_at date", async () => {
+  it("renders closed state badge and closed_at date in sidebar", async () => {
     const detail = makeIssueDetail();
     detail.state = "CLOSED";
     detail.closed_at = "2026-03-20T14:00:00Z";
@@ -164,7 +166,8 @@ describe("KanbanDetailModal", () => {
       expect(screen.getByText("Geschlossen")).toBeTruthy();
     });
 
-    expect(screen.getByText(/Geschlossen am/)).toBeTruthy();
+    // Sidebar shows "Geschlossen: {date}"
+    expect(screen.getByText(/Geschlossen:/)).toBeTruthy();
   });
 
   it("renders linked PRs with CI checks", async () => {
@@ -185,7 +188,7 @@ describe("KanbanDetailModal", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Verknuepfte Pull Requests"),
+        screen.getByText("Verknüpfte Pull Requests"),
       ).toBeTruthy();
     });
 
@@ -199,7 +202,7 @@ describe("KanbanDetailModal", () => {
     expect(screen.getByText("Build")).toBeTruthy();
   });
 
-  it("shows error state on fetch failure", async () => {
+  it("shows error state with retry button on fetch failure", async () => {
     mockInvoke.mockRejectedValue(new Error("API error"));
 
     render(
@@ -213,6 +216,39 @@ describe("KanbanDetailModal", () => {
 
     await waitFor(() => {
       expect(screen.getByText("API error")).toBeTruthy();
+    });
+
+    // Retry button should be present
+    expect(screen.getByText("Erneut versuchen")).toBeTruthy();
+  });
+
+  it("retry button triggers a fresh load", async () => {
+    mockInvoke.mockRejectedValueOnce(new Error("API error"));
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Erneut versuchen")).toBeTruthy();
+    });
+
+    // On retry, second call succeeds
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(makeIssueDetail());
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    fireEvent.click(screen.getByText("Erneut versuchen"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeTruthy();
     });
   });
 
@@ -280,6 +316,221 @@ describe("KanbanDetailModal", () => {
       expect(screen.getByText("Fix login bug")).toBeTruthy();
     });
 
-    expect(screen.queryByText(/Kommentar/)).toBeNull();
+    // IssueComments is hidden when empty; but IssueCommentForm still renders.
+    // Verify the comment count badge from IssueComments is absent.
+    expect(screen.queryByText(/\d+ Kommentar/)).toBeNull();
+  });
+
+  it("renders all assignees when multiple are present", async () => {
+    const detail = makeIssueDetail();
+    detail.assignees = ["bob", "carol", "dave"];
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(detail);
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("bob")).toBeTruthy();
+    });
+
+    expect(screen.getByText("carol")).toBeTruthy();
+    expect(screen.getByText("dave")).toBeTruthy();
+  });
+
+  it("shows 'Niemand zugewiesen' when assignees is empty", async () => {
+    const detail = makeIssueDetail();
+    detail.assignees = [];
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(detail);
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Niemand zugewiesen")).toBeTruthy();
+    });
+  });
+
+  it("renders milestone when present", async () => {
+    const detail = makeIssueDetail();
+    detail.milestone = "v2.0";
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(detail);
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("v2.0")).toBeTruthy();
+    });
+  });
+
+  it("hides milestone section when milestone is null", async () => {
+    const detail = makeIssueDetail();
+    detail.milestone = null;
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(detail);
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("Milestone")).toBeNull();
+  });
+
+  it("renders body markdown (bold text)", async () => {
+    const detail = makeIssueDetail();
+    detail.body = "This is **important** info.";
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(detail);
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    const { container } = render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeTruthy();
+    });
+
+    // MarkdownBody should render **important** as <strong>
+    const strong = container.querySelector("strong");
+    expect(strong).toBeTruthy();
+    expect(strong?.textContent).toBe("important");
+  });
+
+  it("shows empty body placeholder when body is empty", async () => {
+    const detail = makeIssueDetail();
+    detail.body = "";
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(detail);
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Keine Beschreibung")).toBeTruthy();
+    });
+  });
+
+  it("calls onIssueChanged and reloads after comment is posted", async () => {
+    const onIssueChanged = vi.fn();
+
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(makeIssueDetail());
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      if (cmd === "post_issue_comment") return Promise.resolve(undefined);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+        onIssueChanged={onIssueChanged}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeTruthy();
+    });
+
+    const textarea = screen.getByPlaceholderText(/Kommentar verfassen/);
+    fireEvent.change(textarea, { target: { value: "Hello world" } });
+
+    const submitButton = screen.getByText("Kommentar posten");
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onIssueChanged).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("disables submit when comment body is empty", async () => {
+    mockInvoke.mockImplementation(((cmd: string) => {
+      if (cmd === "get_issue_detail") return Promise.resolve(makeIssueDetail());
+      if (cmd === "get_issue_checks") return Promise.resolve([]);
+      return Promise.resolve(null);
+    }) as typeof invoke);
+
+    render(
+      <KanbanDetailModal
+        open
+        folder="/test"
+        issueNumber={42}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Kommentar posten")).toBeTruthy();
+    });
+
+    const submitButton = screen.getByText("Kommentar posten");
+    expect(submitButton).toHaveProperty("disabled", true);
   });
 });

--- a/src/components/kanban/KanbanDetailModal.tsx
+++ b/src/components/kanban/KanbanDetailModal.tsx
@@ -1,46 +1,19 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-shell";
 import { getErrorMessage } from "../../utils/adpError";
-import {
-  ExternalLink,
-  MessageSquare,
-  User,
-  Calendar,
-  Tag,
-  RefreshCw,
-  GitPullRequest,
-  CheckCircle2,
-  XCircle,
-  Clock,
-  Loader2,
-} from "lucide-react";
+import { ExternalLink, RefreshCw, AlertCircle } from "lucide-react";
 import { Modal, IconButton } from "../ui";
 import type { KanbanLabel } from "./KanbanCard";
+import { IssueBody } from "./IssueBody";
+import { IssueComments, type IssueComment } from "./IssueComments";
+import { IssueCommentForm } from "./IssueCommentForm";
+import { IssueLinkedPRs, type LinkedPR } from "./IssueLinkedPRs";
+import { IssueSidebar } from "./IssueSidebar";
 
 // ============================================================================
 // Types (matches Rust IssueDetail)
 // ============================================================================
-
-interface IssueComment {
-  author: string;
-  body: string;
-  created_at: string;
-}
-
-interface CheckRun {
-  name: string;
-  status: string;
-  conclusion: string;
-}
-
-interface LinkedPR {
-  number: number;
-  title: string;
-  state: string;
-  url: string;
-  checks: CheckRun[];
-}
 
 interface IssueDetail {
   number: number;
@@ -49,9 +22,11 @@ interface IssueDetail {
   state: string;
   author: string;
   created_at: string;
+  updated_at: string;
   closed_at: string;
   labels: KanbanLabel[];
-  assignee: string;
+  assignees: string[];
+  milestone: string | null;
   url: string;
   comments: IssueComment[];
 }
@@ -65,6 +40,7 @@ interface KanbanDetailModalProps {
   folder: string;
   issueNumber: number;
   onClose: () => void;
+  onIssueChanged?: () => void;
 }
 
 // ============================================================================
@@ -82,15 +58,6 @@ function formatDate(iso: string): string {
   });
 }
 
-function labelStyle(color: string): React.CSSProperties {
-  const hex = color.startsWith("#") ? color : `#${color}`;
-  return {
-    backgroundColor: `${hex}20`,
-    color: hex,
-    borderColor: `${hex}40`,
-  };
-}
-
 // ============================================================================
 // Component
 // ============================================================================
@@ -100,52 +67,84 @@ export function KanbanDetailModal({
   folder,
   issueNumber,
   onClose,
+  onIssueChanged,
 }: KanbanDetailModalProps) {
   const [detail, setDetail] = useState<IssueDetail | null>(null);
   const [linkedPRs, setLinkedPRs] = useState<LinkedPR[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const mountedRef = useRef(true);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    async function load() {
-      setLoading(true);
-      setError("");
-      try {
-        const [issueResult, checksResult] = await Promise.all([
-          invoke<IssueDetail>("get_issue_detail", { folder, number: issueNumber }),
-          invoke<LinkedPR[]>("get_issue_checks", { folder, number: issueNumber }).catch(() => [] as LinkedPR[]),
-        ]);
-        if (!cancelled) {
-          setDetail(issueResult);
-          setLinkedPRs(checksResult);
-        }
-      } catch (err) {
-        if (!cancelled) setError(getErrorMessage(err));
-      } finally {
-        if (!cancelled) setLoading(false);
+  const loadDetail = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [issueResult, checksResult] = await Promise.all([
+        invoke<IssueDetail>("get_issue_detail", { folder, number: issueNumber }),
+        invoke<LinkedPR[]>("get_issue_checks", { folder, number: issueNumber }).catch(
+          () => [] as LinkedPR[]
+        ),
+      ]);
+      if (mountedRef.current) {
+        setDetail(issueResult);
+        setLinkedPRs(checksResult);
       }
+    } catch (err) {
+      if (mountedRef.current) setError(getErrorMessage(err));
+    } finally {
+      if (mountedRef.current) setLoading(false);
     }
-
-    load();
-    return () => {
-      cancelled = true;
-    };
   }, [folder, issueNumber]);
 
+  useEffect(() => {
+    mountedRef.current = true;
+    void loadDetail();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [loadDetail]);
+
+  function handleCommentPosted() {
+    void loadDetail();
+    onIssueChanged?.();
+  }
+
   const headerTitle = (
-    <div className="flex items-center gap-2">
-      <span className="text-sm font-medium text-neutral-200">
+    <div className="flex items-center gap-2 min-w-0 flex-1">
+      <span className="text-sm font-mono text-neutral-500 shrink-0">
         #{issueNumber}
       </span>
-      {detail?.url && (
-        <IconButton
-          icon={<ExternalLink className="w-4 h-4" />}
-          label="Im Browser öffnen"
-          onClick={() => open(detail.url)}
-        />
+      {detail?.title && (
+        <h2 className="text-sm font-semibold text-neutral-100 truncate">
+          {detail.title}
+        </h2>
       )}
+      {detail?.state && (
+        <span
+          className={`shrink-0 text-[10px] px-1.5 py-0.5 rounded-sm font-medium ${
+            detail.state === "CLOSED"
+              ? "bg-purple-500/20 text-purple-300"
+              : "bg-green-500/20 text-green-300"
+          }`}
+        >
+          {detail.state === "CLOSED" ? "Geschlossen" : "Offen"}
+        </span>
+      )}
+      <div className="ml-auto flex items-center gap-1 shrink-0">
+        <IconButton
+          icon={<RefreshCw className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />}
+          label="Neu laden"
+          onClick={() => void loadDetail()}
+          disabled={loading}
+        />
+        {detail?.url && (
+          <IconButton
+            icon={<ExternalLink className="w-4 h-4" />}
+            label="Im Browser öffnen"
+            onClick={() => open(detail.url)}
+          />
+        )}
+      </div>
     </div>
   );
 
@@ -154,197 +153,54 @@ export function KanbanDetailModal({
       open={isOpen}
       onClose={onClose}
       title={headerTitle}
-      className="w-[640px] max-w-[90vw] rounded-md shadow-2xl"
+      className="w-[960px] max-w-[95vw] max-h-[85vh] rounded-md shadow-2xl"
     >
-      <div className="flex-1 overflow-y-auto min-h-0">
-          {loading ? (
-            <div className="flex items-center justify-center py-12 text-neutral-500 text-sm">
-              <RefreshCw className="w-4 h-4 animate-spin mr-2" />
-              Laden...
-            </div>
-          ) : error ? (
-            <div className="flex items-center justify-center py-12 text-red-400 text-sm">
-              {error}
-            </div>
-          ) : detail ? (
-            <div className="p-4 space-y-4">
-              {/* Title */}
-              <h2 className="text-base font-semibold text-neutral-100 leading-snug">
-                {detail.title}
-              </h2>
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-neutral-500 text-sm">
+          <RefreshCw className="w-4 h-4 animate-spin mr-2" />
+          Laden…
+        </div>
+      ) : error ? (
+        <div className="flex flex-col items-center justify-center py-12 gap-3">
+          <AlertCircle className="w-8 h-8 text-neutral-600" />
+          <span className="text-red-400 text-sm">{error}</span>
+          <button
+            onClick={() => void loadDetail()}
+            className="px-3 py-1.5 text-xs text-neutral-300 bg-surface-raised border border-neutral-700 rounded-sm hover:bg-hover-overlay transition-colors"
+          >
+            Erneut versuchen
+          </button>
+        </div>
+      ) : detail ? (
+        <div className="flex flex-1 overflow-hidden min-h-0">
+          {/* Main content column */}
+          <main className="flex-1 overflow-y-auto p-4 min-w-0 space-y-4">
+            <IssueBody body={detail.body} />
+            <IssueLinkedPRs linkedPRs={linkedPRs} />
+            <IssueComments comments={detail.comments} formatDate={formatDate} />
+            <IssueCommentForm
+              folder={folder}
+              issueNumber={issueNumber}
+              onCommentPosted={handleCommentPosted}
+            />
+          </main>
 
-              {/* Meta row */}
-              <div className="flex items-center gap-4 text-xs text-neutral-500 flex-wrap">
-                <span
-                  className={`px-2 py-0.5 rounded-sm text-[11px] font-medium ${
-                    detail.state === "CLOSED"
-                      ? "bg-purple-500/20 text-purple-300"
-                      : "bg-green-500/20 text-green-300"
-                  }`}
-                >
-                  {detail.state === "CLOSED" ? "Geschlossen" : "Offen"}
-                </span>
-                {detail.author && (
-                  <span className="flex items-center gap-1">
-                    <User className="w-3 h-3" />
-                    {detail.author}
-                  </span>
-                )}
-                {detail.created_at && (
-                  <span className="flex items-center gap-1">
-                    <Calendar className="w-3 h-3" />
-                    {formatDate(detail.created_at)}
-                  </span>
-                )}
-                {detail.assignee && (
-                  <span className="text-neutral-400">
-                    Zugewiesen: {detail.assignee}
-                  </span>
-                )}
-              </div>
-
-              {/* Labels */}
-              {detail.labels.length > 0 && (
-                <div className="flex items-center gap-1.5 flex-wrap">
-                  <Tag className="w-3 h-3 text-neutral-500 shrink-0" />
-                  {detail.labels.map((label) => (
-                    <span
-                      key={label.name}
-                      className="text-[10px] px-1.5 py-0.5 rounded-sm border font-medium"
-                      style={labelStyle(label.color)}
-                    >
-                      {label.name}
-                    </span>
-                  ))}
-                </div>
-              )}
-
-              {/* Linked PRs & CI Checks */}
-              {linkedPRs.length > 0 && (
-                <div className="border-t border-neutral-700/50 pt-3 space-y-2">
-                  <div className="flex items-center gap-1.5 text-xs text-neutral-400 font-medium">
-                    <GitPullRequest className="w-3.5 h-3.5" />
-                    Verknuepfte Pull Requests
-                  </div>
-                  {linkedPRs.map((pr) => (
-                    <div
-                      key={pr.number}
-                      className="bg-surface-raised border border-neutral-700/50 rounded-sm p-3"
-                    >
-                      <div className="flex items-center justify-between mb-1">
-                        <button
-                          onClick={() => open(pr.url)}
-                          className="text-xs font-medium text-neutral-200 hover:text-accent transition-colors text-left"
-                        >
-                          #{pr.number} {pr.title}
-                        </button>
-                        <span
-                          className={`text-[10px] px-1.5 py-0.5 rounded-sm font-medium ${
-                            pr.state === "MERGED"
-                              ? "bg-purple-500/20 text-purple-300"
-                              : pr.state === "CLOSED"
-                                ? "bg-red-500/20 text-red-300"
-                                : "bg-green-500/20 text-green-300"
-                          }`}
-                        >
-                          {pr.state === "MERGED" ? "Merged" : pr.state === "CLOSED" ? "Closed" : "Open"}
-                        </span>
-                      </div>
-                      {pr.checks.length > 0 && (
-                        <div className="flex flex-wrap gap-1.5 mt-2">
-                          {pr.checks.map((check, i) => {
-                            const isSuccess =
-                              check.conclusion === "SUCCESS" || check.conclusion === "success";
-                            const isFailed =
-                              check.conclusion === "FAILURE" ||
-                              check.conclusion === "failure" ||
-                              check.conclusion === "ERROR" ||
-                              check.conclusion === "error";
-                            const isPending =
-                              check.status === "IN_PROGRESS" ||
-                              check.status === "QUEUED" ||
-                              check.status === "PENDING" ||
-                              check.status === "pending";
-                            return (
-                              <span
-                                key={i}
-                                className={`inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-sm border font-medium ${
-                                  isSuccess
-                                    ? "bg-green-500/10 text-green-400 border-green-500/20"
-                                    : isFailed
-                                      ? "bg-red-500/10 text-red-400 border-red-500/20"
-                                      : isPending
-                                        ? "bg-yellow-500/10 text-yellow-400 border-yellow-500/20"
-                                        : "bg-neutral-500/10 text-neutral-400 border-neutral-700/50"
-                                }`}
-                              >
-                                {isSuccess ? (
-                                  <CheckCircle2 className="w-2.5 h-2.5" />
-                                ) : isFailed ? (
-                                  <XCircle className="w-2.5 h-2.5" />
-                                ) : isPending ? (
-                                  <Loader2 className="w-2.5 h-2.5 animate-spin" />
-                                ) : (
-                                  <Clock className="w-2.5 h-2.5" />
-                                )}
-                                {check.name}
-                              </span>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {/* Body */}
-              {detail.body && (
-                <div className="border-t border-neutral-700/50 pt-3">
-                  <pre className="text-xs text-neutral-300 whitespace-pre-wrap font-sans leading-relaxed">
-                    {detail.body}
-                  </pre>
-                </div>
-              )}
-
-              {/* Comments */}
-              {detail.comments.length > 0 && (
-                <div className="border-t border-neutral-700/50 pt-3 space-y-3">
-                  <div className="flex items-center gap-1.5 text-xs text-neutral-400 font-medium">
-                    <MessageSquare className="w-3.5 h-3.5" />
-                    {detail.comments.length}{" "}
-                    {detail.comments.length === 1 ? "Kommentar" : "Kommentare"}
-                  </div>
-                  {detail.comments.map((comment, i) => (
-                    <div
-                      key={i}
-                      className="bg-surface-raised border border-neutral-700/50 rounded-sm p-3"
-                    >
-                      <div className="flex items-center justify-between mb-2">
-                        <span className="text-xs font-medium text-neutral-300">
-                          {comment.author}
-                        </span>
-                        <span className="text-[10px] text-neutral-600">
-                          {formatDate(comment.created_at)}
-                        </span>
-                      </div>
-                      <pre className="text-xs text-neutral-400 whitespace-pre-wrap font-sans leading-relaxed">
-                        {comment.body}
-                      </pre>
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {/* Closed at */}
-              {detail.closed_at && (
-                <div className="text-[11px] text-neutral-600 pt-2 border-t border-neutral-700/50">
-                  Geschlossen am {formatDate(detail.closed_at)}
-                </div>
-              )}
-            </div>
-          ) : null}
-      </div>
+          {/* Sidebar */}
+          <aside className="w-[220px] shrink-0 border-l border-neutral-700 overflow-y-auto p-4 bg-surface-base">
+            <IssueSidebar
+              state={detail.state}
+              author={detail.author}
+              createdAt={detail.created_at}
+              updatedAt={detail.updated_at}
+              closedAt={detail.closed_at}
+              assignees={detail.assignees}
+              labels={detail.labels}
+              milestone={detail.milestone}
+              formatDate={formatDate}
+            />
+          </aside>
+        </div>
+      ) : null}
     </Modal>
   );
 }

--- a/src/components/kanban/kanbanUtils.ts
+++ b/src/components/kanban/kanbanUtils.ts
@@ -1,0 +1,10 @@
+/** Shared utilities for Kanban components */
+
+export function labelStyle(color: string): React.CSSProperties {
+  const hex = color.startsWith("#") ? color : `#${color}`;
+  return {
+    backgroundColor: `${hex}20`,
+    color: hex,
+    borderColor: `${hex}40`,
+  };
+}


### PR DESCRIPTION
## Summary

- **Modal-Rework**: `KanbanDetailModal` auf 2-Spalten 960px-Layout mit 6 Sub-Components (IssueBody, IssueComments, IssueCommentForm, IssueLinkedPRs, IssueSidebar, kanbanUtils)
- **Markdown-Rendering**: Body und Kommentare werden jetzt als Markdown gerendert (MarkdownBody, DOMPurify Task-List-Fix)
- **Kommentar posten**: Neuer `post_issue_comment` Tauri-Command + IssueCommentForm (Cmd/Ctrl+Enter, Submit-Disable bei leerem Body)
- **Backend-Migration**: `IssueDetail.assignee: String` → `assignees: Vec<String>`, `milestone: Option<String>`, `updated_at: String`
- **D&D-Bugfixes**: onDragLeave-Flackern, fehlender onDragEnd-Cleanup, cursor-grab, Click-während-Drag

## Test plan

- [ ] `npm run test` — 1007 Tests grün
- [ ] `npx tsc --noEmit` — 0 Errors
- [ ] `npm run lint` — 0 Errors
- [ ] `npm run build` — ✓
- [ ] `cargo check` — ✓
- [ ] Manuell: Kanban öffnen, Issue-Modal, Kommentar posten, D&D testen

🤖 Generated with [Claude Code](https://claude.ai/claude-code)