### PR TITLE
fix(ui): Library Skill-Cards — .md Skills korrekt gelesen + einheitliche Preview (#184)

### DIFF
--- a/src-tauri/src/session/file_reader.rs
+++ b/src-tauri/src/session/file_reader.rs
@@ -547,14 +547,28 @@ pub mod commands {
             };
 
             let entry_path = entry.path();
-            if !entry_path.is_dir() {
-                continue;
-            }
-
             let dir_name = match entry.file_name().to_str() {
                 Some(name) => name.to_string(),
                 None => continue,
             };
+
+            if entry_path.is_file() {
+                // Simple .md skill file — read content directly
+                if !dir_name.ends_with(".md") {
+                    continue;
+                }
+                let content = std::fs::read_to_string(&entry_path).unwrap_or_default();
+                skills.push(SkillDirEntry {
+                    dir_name,
+                    content,
+                    has_reference_dir: false,
+                });
+                continue;
+            }
+
+            if !entry_path.is_dir() {
+                continue;
+            }
 
             // Look for SKILL.md in the subdirectory
             let skill_md = entry_path.join("SKILL.md");

--- a/src/components/library/LibraryView.tsx
+++ b/src/components/library/LibraryView.tsx
@@ -128,8 +128,19 @@ function Section({
 
 // ── Skill Card ───────────────────────────────────────────────────────
 
+function skillBodyPreview(body: string): string {
+  return body
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/[*_`]/g, "")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .trim()
+    .slice(0, 80);
+}
+
 function SkillCard({ skill }: { skill: DiscoveredSkill }) {
   const openDetail = useConfigDiscoveryStore(selectOpenDetail);
+
+  const preview = skill.description || skillBodyPreview(skill.body);
 
   return (
     <div className="rounded border border-neutral-700 bg-surface-raised mb-1.5">
@@ -148,11 +159,9 @@ function SkillCard({ skill }: { skill: DiscoveredSkill }) {
             </span>
           )}
         </div>
-        {skill.description && (
-          <p className="text-[11px] text-neutral-400 mt-0.5 ml-5 line-clamp-2">
-            {skill.description}
-          </p>
-        )}
+        <p className={`text-[11px] mt-0.5 ml-5 line-clamp-2 ${preview ? "text-neutral-400" : "text-neutral-600"}`}>
+          {preview || "Keine Beschreibung"}
+        </p>
         {skill.args.length > 0 && (
           <div className="flex gap-1 mt-1 ml-5 flex-wrap">
             {skill.args.map((a) => (

--- a/src/store/configDiscoveryStore.ts
+++ b/src/store/configDiscoveryStore.ts
@@ -118,11 +118,12 @@ function parseSkillEntries(
   scope: ConfigScope,
 ): DiscoveredSkill[] {
   return dirs.map((dir) => {
+    const fallbackName = dir.dir_name.replace(/\.md$/, "");
     const parsed: ParsedSkill = dir.content
       ? parseSkillFrontmatter(dir.content)
-      : { metadata: { name: dir.dir_name, description: "", userInvokable: false, args: [] }, body: "" };
+      : { metadata: { name: fallbackName, description: "", userInvokable: false, args: [] }, body: "" };
     return {
-      name: parsed.metadata.name,
+      name: parsed.metadata.name && parsed.metadata.name !== "Unknown" ? parsed.metadata.name : fallbackName,
       dirName: dir.dir_name,
       description: parsed.metadata.description,
       args: parsed.metadata.args,
@@ -258,9 +259,10 @@ export const useConfigDiscoveryStore = create<ConfigDiscoveryState>((set, get) =
         for (const dirName of commandsDirResult.value) {
           let content = "";
           try {
-            content = await invoke<string>("read_user_claude_file", {
-              relativePath: `commands/${dirName}/SKILL.md`,
-            });
+            const relativePath = dirName.endsWith(".md")
+              ? `commands/${dirName}`
+              : `commands/${dirName}/SKILL.md`;
+            content = await invoke<string>("read_user_claude_file", { relativePath });
           } catch {
             // Skill may not have SKILL.md
           }
@@ -275,9 +277,10 @@ export const useConfigDiscoveryStore = create<ConfigDiscoveryState>((set, get) =
           if (existingNames.has(dirName)) continue; // avoid duplicates
           let content = "";
           try {
-            content = await invoke<string>("read_user_claude_file", {
-              relativePath: `skills/${dirName}/SKILL.md`,
-            });
+            const relativePath = dirName.endsWith(".md")
+              ? `skills/${dirName}`
+              : `skills/${dirName}/SKILL.md`;
+            content = await invoke<string>("read_user_claude_file", { relativePath });
           } catch {
             // Skill may not have SKILL.md
           }


### PR DESCRIPTION
## Summary
- `list_skill_dirs` (Rust): `.md`-Dateien in `.claude/skills/` wurden bisher übersprungen (`is_dir()` check) — jetzt werden sie direkt eingelesen
- `discoverGlobal` (Store): unterscheidet `.md`-Dateien von Verzeichnissen → liest `skills/name.md` direkt statt `skills/name.md/SKILL.md`
- `parseSkillEntries`: Name-Fallback entfernt `.md`-Suffix und ignoriert den Parser-Default "Unknown"
- `SkillCard`: zeigt immer eine Preview-Zeile: `description` → Body-Preview (Markdown-Syntax gestrippen) → "Keine Beschreibung"

## Test plan
- [ ] Global `~/.claude/skills/`: `sprint-plan.md`, `commit.md` etc. zeigen Body-Preview statt leer
- [ ] Skills als Verzeichnis (`agent-browser/`, `graphify-windows/`) verhalten sich unverändert
- [ ] Alle Skill-Cards haben gleiche Mindesthöhe
- [ ] 45 Tests grün, `tsc --noEmit` ✓, `cargo check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)