### PR TITLE
fix(kanban): PointerEvent DnD — WebView2-kompatibles Drag & Drop (#185)

### DIFF
--- a/src/components/kanban/KanbanBoard.test.tsx
+++ b/src/components/kanban/KanbanBoard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, waitFor, fireEvent, createEvent, act } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { KanbanBoard } from "./KanbanBoard";
 import { invoke } from "@tauri-apps/api/core";
 import type { KanbanIssue } from "./KanbanCard";
@@ -202,61 +202,35 @@ describe("KanbanBoard", () => {
     expect(emptyMessages.length).toBe(4);
   });
 
-  /** Helper: fire dragOver with a mock dataTransfer to avoid jsdom TypeError */
-  function fireDragOver(element: Element) {
-    const ev = createEvent.dragOver(element);
-    Object.defineProperty(ev, "dataTransfer", {
-      value: { dropEffect: "" },
-      configurable: true,
-    });
-    act(() => {
-      element.dispatchEvent(ev);
-    });
-  }
-
-  it("onDragOver sets column highlight", async () => {
+  it("each column has data-lane-id attribute for PointerEvent DnD", async () => {
     mockInvoke.mockResolvedValueOnce(makeIssues());
 
-    const { container } = render(<KanbanBoard folder="/test/dragover" />);
+    const { container } = render(<KanbanBoard folder="/test/lane-ids" />);
 
     await waitFor(() => {
       expect(screen.getByText("Kanban (6 Issues)")).toBeTruthy();
     });
 
-    const columns = container.querySelectorAll(".flex.flex-col.w-\\[260px\\]");
-    const backlogColumn = columns[0] as HTMLElement;
+    const laneIds = Array.from(
+      container.querySelectorAll("[data-lane-id]"),
+    ).map((el) => el.getAttribute("data-lane-id"));
 
-    // dragOver should set highlight (dragOverColumn = "backlog")
-    fireDragOver(backlogColumn);
-
-    await waitFor(() => {
-      expect(backlogColumn.className).toContain("border-accent");
-    });
+    expect(laneIds).toEqual(["backlog", "todo", "in-progress", "done"]);
   });
 
-  it("onDragLeave clears highlight when leaving to an element outside the column", async () => {
+  it("column has no HTML5 DnD handlers (onDragOver/onDrop removed)", async () => {
     mockInvoke.mockResolvedValueOnce(makeIssues());
 
-    const { container } = render(<KanbanBoard folder="/test/dragleave-out" />);
+    const { container } = render(<KanbanBoard folder="/test/no-dnd" />);
 
     await waitFor(() => {
       expect(screen.getByText("Kanban (6 Issues)")).toBeTruthy();
     });
 
-    const columns = container.querySelectorAll(".flex.flex-col.w-\\[260px\\]");
-    const backlogColumn = columns[0] as HTMLElement;
-    const todoColumn = columns[1] as HTMLElement;
-
-    // Drag over backlog to set highlight
-    fireDragOver(backlogColumn);
-
-    await waitFor(() => {
-      expect(backlogColumn.className).toContain("border-accent");
+    const columns = container.querySelectorAll("[data-lane-id]");
+    // No dragover attribute means HTML5 DnD is not set
+    columns.forEach((col) => {
+      expect(col.getAttribute("draggable")).toBeNull();
     });
-
-    // DragLeave to a sibling column (outside) → contains() returns false → highlight clears
-    fireEvent.dragLeave(backlogColumn, { relatedTarget: todoColumn });
-
-    expect(backlogColumn.className).not.toContain("border-accent");
   });
 });

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -108,16 +108,13 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
     };
   }, [load]);
 
-  const handleDrop = useCallback(
-    async (targetLane: string, e: React.DragEvent) => {
-      e.preventDefault();
-      setDragOverColumn(null);
-
+  const handleDropLane = useCallback(
+    async (targetLane: string) => {
       const issueNumber = draggedIssueNumberRef.current;
       draggedIssueNumberRef.current = null;
+      setDragOverColumn(null);
       if (issueNumber == null) return;
 
-      // Check if already in this lane
       const issue = issues.find((i) => i.number === issueNumber);
       if (!issue) return;
       const currentLane = classifyIssue(issue);
@@ -131,7 +128,6 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
           number: issueNumber,
           targetLane,
         });
-        // Refresh after move
         cache.delete(folder);
         await load(true);
       } catch (err) {
@@ -143,6 +139,32 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
     },
     [folder, issues, load]
   );
+
+  const startGlobalDragListeners = useCallback(() => {
+    const onMove = (e: PointerEvent) => {
+      if (draggedIssueNumberRef.current == null) return;
+      const els = document.elementsFromPoint(e.clientX, e.clientY);
+      const laneEl = els.find((el) => el.hasAttribute("data-lane-id"));
+      setDragOverColumn(laneEl?.getAttribute("data-lane-id") ?? null);
+    };
+
+    const onUp = (e: PointerEvent) => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      if (draggedIssueNumberRef.current == null) return;
+      const els = document.elementsFromPoint(e.clientX, e.clientY);
+      const laneEl = els.find((el) => el.hasAttribute("data-lane-id"));
+      const laneId = laneEl?.getAttribute("data-lane-id") ?? null;
+      if (laneId) void handleDropLane(laneId);
+      else {
+        draggedIssueNumberRef.current = null;
+        setDragOverColumn(null);
+      }
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }, [handleDropLane]);
 
   if (loading) {
     return (
@@ -207,22 +229,12 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
           {columns.map((col) => (
             <div
               key={col.id}
+              data-lane-id={col.id}
               className={`flex flex-col w-[260px] min-w-[260px] bg-surface-raised border rounded-sm transition-colors ${
                 dragOverColumn === col.id
                   ? "border-accent bg-accent-a10/5"
                   : "border-neutral-700"
               }`}
-              onDragOver={(e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-                setDragOverColumn(col.id);
-              }}
-              onDragLeave={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
-                  setDragOverColumn(null);
-                }
-              }}
-              onDrop={(e) => handleDrop(col.id, e)}
             >
               {/* Column header */}
               <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-700 shrink-0">
@@ -253,6 +265,7 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
                         onClick={() => setSelectedIssue(issue.number)}
                         onDragStart={() => {
                           draggedIssueNumberRef.current = issue.number;
+                          startGlobalDragListeners();
                         }}
                         onDragEnd={() => {
                           draggedIssueNumberRef.current = null;

--- a/src/components/kanban/KanbanCard.test.tsx
+++ b/src/components/kanban/KanbanCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { KanbanCard, type KanbanIssue } from "./KanbanCard";
 
 // ── Mocks ─────────────────────────────────────────────────────────────
@@ -25,6 +25,42 @@ function makeIssue(overrides: Partial<KanbanIssue> = {}): KanbanIssue {
     url: "https://github.com/org/repo/issues/42",
     ...overrides,
   };
+}
+
+/**
+ * jsdom does not propagate clientX/clientY from fireEvent.pointerMove init
+ * into React's SyntheticEvent. Use native PointerEvent constructors instead.
+ * Wrap in act() so React state updates (setIsDragging) are flushed synchronously.
+ */
+function nativePointerDown(element: Element, clientX = 0, clientY = 0) {
+  act(() => {
+    element.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, cancelable: true, clientX, clientY, button: 0 }),
+    );
+  });
+}
+
+function nativePointerMove(element: Element, clientX: number, clientY = 0) {
+  act(() => {
+    element.dispatchEvent(
+      new PointerEvent("pointermove", { bubbles: true, cancelable: true, clientX, clientY }),
+    );
+  });
+}
+
+function nativePointerUp(element: Element) {
+  act(() => {
+    element.dispatchEvent(
+      new PointerEvent("pointerup", { bubbles: true, cancelable: true }),
+    );
+  });
+}
+
+/** Simulate a full drag gesture beyond the 5px threshold */
+function simulateDrag(element: Element, dx = 20) {
+  nativePointerDown(element);
+  nativePointerMove(element, dx);
+  nativePointerUp(element);
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────
@@ -65,11 +101,10 @@ describe("KanbanCard", () => {
 
   it("hides assignee when empty", () => {
     render(<KanbanCard issue={makeIssue({ assignee: "" })} />);
-
     expect(screen.queryByText("alice")).toBeNull();
   });
 
-  it("calls onClick when card is clicked", () => {
+  it("calls onClick when card is clicked (no drag)", () => {
     const onClick = vi.fn();
     render(<KanbanCard issue={makeIssue()} onClick={onClick} />);
 
@@ -77,18 +112,75 @@ describe("KanbanCard", () => {
     expect(onClick).toHaveBeenCalledOnce();
   });
 
-  it("calls onDragStart and sets dataTransfer on drag", () => {
+  it("card has cursor-grab class for drag affordance", () => {
+    const { container } = render(<KanbanCard issue={makeIssue()} />);
+    const card = container.firstElementChild!;
+    expect(card.className).toContain("cursor-grab");
+  });
+
+  it("calls onDragStart when pointer moves beyond threshold", () => {
     const onDragStart = vi.fn();
     const { container } = render(
       <KanbanCard issue={makeIssue()} onDragStart={onDragStart} />,
     );
 
     const card = container.firstElementChild!;
-    const dataTransfer = { setData: vi.fn(), effectAllowed: "" };
-    fireEvent.dragStart(card, { dataTransfer });
+    nativePointerDown(card, 0, 0);
+    nativePointerMove(card, 10); // 10px > 5px threshold
 
-    expect(dataTransfer.setData).toHaveBeenCalledWith("text/plain", "42");
     expect(onDragStart).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT call onDragStart for sub-threshold pointer move", () => {
+    const onDragStart = vi.fn();
+    const { container } = render(
+      <KanbanCard issue={makeIssue()} onDragStart={onDragStart} />,
+    );
+
+    const card = container.firstElementChild!;
+    nativePointerDown(card, 0, 0);
+    nativePointerMove(card, 3); // 3px < 5px threshold
+
+    expect(onDragStart).not.toHaveBeenCalled();
+  });
+
+  it("calls onDragEnd on pointerUp after a drag", () => {
+    const onDragEnd = vi.fn();
+    const { container } = render(
+      <KanbanCard issue={makeIssue()} onDragEnd={onDragEnd} />,
+    );
+
+    const card = container.firstElementChild!;
+    simulateDrag(card);
+
+    expect(onDragEnd).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT call onDragEnd when pointerUp follows no drag (pure click)", () => {
+    const onDragEnd = vi.fn();
+    const { container } = render(
+      <KanbanCard issue={makeIssue()} onDragEnd={onDragEnd} />,
+    );
+
+    const card = container.firstElementChild!;
+    nativePointerDown(card);
+    nativePointerUp(card);
+
+    expect(onDragEnd).not.toHaveBeenCalled();
+  });
+
+  it("suppresses onClick during active drag", () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <KanbanCard issue={makeIssue()} onClick={onClick} />,
+    );
+
+    const card = container.firstElementChild!;
+    nativePointerDown(card, 0, 0);
+    nativePointerMove(card, 10); // drag threshold exceeded → isDraggingRef = true
+    fireEvent.click(card);       // click while dragging → suppressed
+
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   it("opens URL in browser when external link button is clicked", async () => {
@@ -104,7 +196,6 @@ describe("KanbanCard", () => {
 
   it("does not render external link button when url is empty", () => {
     render(<KanbanCard issue={makeIssue({ url: "" })} />);
-
     expect(screen.queryByTitle("Im Browser öffnen")).toBeNull();
   });
 
@@ -115,62 +206,6 @@ describe("KanbanCard", () => {
     const linkButton = screen.getByTitle("Im Browser öffnen");
     fireEvent.click(linkButton);
 
-    // stopPropagation prevents onClick on card
     expect(onClick).not.toHaveBeenCalled();
-  });
-
-  it("card has cursor-grab class for drag affordance", () => {
-    const { container } = render(<KanbanCard issue={makeIssue()} />);
-    const card = container.firstElementChild!;
-    expect(card.className).toContain("cursor-grab");
-  });
-
-  it("suppresses onClick when dragging (isDraggingRef guard)", () => {
-    const onClick = vi.fn();
-    const { container } = render(
-      <KanbanCard issue={makeIssue()} onClick={onClick} />,
-    );
-
-    const card = container.firstElementChild!;
-    const dataTransfer = { setData: vi.fn(), effectAllowed: "" };
-
-    // Start drag then immediately click — click should be suppressed
-    fireEvent.dragStart(card, { dataTransfer });
-    fireEvent.click(card);
-
-    expect(onClick).not.toHaveBeenCalled();
-  });
-
-  it("calls onDragEnd when drag finishes", () => {
-    const onDragEnd = vi.fn();
-    const { container } = render(
-      <KanbanCard issue={makeIssue()} onDragEnd={onDragEnd} />,
-    );
-
-    const card = container.firstElementChild!;
-    const dataTransfer = { setData: vi.fn(), effectAllowed: "" };
-
-    fireEvent.dragStart(card, { dataTransfer });
-    fireEvent.dragEnd(card);
-
-    expect(onDragEnd).toHaveBeenCalledOnce();
-  });
-
-  it("allows onClick again after drag ends", () => {
-    const onClick = vi.fn();
-    const { container } = render(
-      <KanbanCard issue={makeIssue()} onClick={onClick} />,
-    );
-
-    const card = container.firstElementChild!;
-    const dataTransfer = { setData: vi.fn(), effectAllowed: "" };
-
-    // Drag cycle: start → end
-    fireEvent.dragStart(card, { dataTransfer });
-    fireEvent.dragEnd(card);
-
-    // After drag ends, click should work again
-    fireEvent.click(card);
-    expect(onClick).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useCallback } from "react";
 import { ExternalLink } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
 import { logWarn } from "../../utils/errorLogger";
@@ -25,6 +25,8 @@ interface KanbanCardProps {
   onDragEnd?: () => void;
 }
 
+const DRAG_THRESHOLD_PX = 5;
+
 async function openUrl(url: string) {
   try {
     await open(url);
@@ -35,30 +37,48 @@ async function openUrl(url: string) {
 
 export function KanbanCard({ issue, onClick, onDragStart, onDragEnd }: KanbanCardProps) {
   const [isDragging, setIsDragging] = useState(false);
-  // Guard: suppress onClick if the pointer moved (drag rather than click)
   const isDraggingRef = useRef(false);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
 
-  return (
-    <div
-      className={`group bg-surface-base border border-neutral-700 rounded-sm p-3 hover:border-neutral-500 transition-colors cursor-grab active:cursor-grabbing select-none ${
-        isDragging ? "opacity-60" : ""
-      }`}
-      draggable
-      onClick={() => {
-        if (isDraggingRef.current) return;
-        onClick?.();
-      }}
-      onDragStart={(e) => {
-        e.dataTransfer.setData("text/plain", String(issue.number));
-        e.dataTransfer.effectAllowed = "move";
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    startPosRef.current = { x: e.clientX, y: e.clientY };
+    isDraggingRef.current = false;
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!startPosRef.current || isDraggingRef.current) return;
+      const dx = Math.abs(e.clientX - startPosRef.current.x);
+      const dy = Math.abs(e.clientY - startPosRef.current.y);
+      if (dx > DRAG_THRESHOLD_PX || dy > DRAG_THRESHOLD_PX) {
         isDraggingRef.current = true;
         setIsDragging(true);
         onDragStart?.();
-      }}
-      onDragEnd={() => {
-        isDraggingRef.current = false;
-        setIsDragging(false);
-        onDragEnd?.();
+      }
+    },
+    [onDragStart],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    const wasDragging = isDraggingRef.current;
+    isDraggingRef.current = false;
+    startPosRef.current = null;
+    setIsDragging(false);
+    if (wasDragging) onDragEnd?.();
+  }, [onDragEnd]);
+
+  return (
+    <div
+      className={`group bg-surface-base border border-neutral-700 rounded-sm p-3 hover:border-neutral-500 transition-colors select-none ${
+        isDragging ? "opacity-50 cursor-grabbing pointer-events-none" : "cursor-grab"
+      }`}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onClick={() => {
+        if (isDraggingRef.current) return;
+        onClick?.();
       }}
     >
       {/* Header: number + external link */}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -16,6 +16,22 @@ if (!globalThis.crypto?.randomUUID) {
   });
 }
 
+// jsdom does not provide PointerEvent — polyfill via MouseEvent so clientX/clientY work
+if (!globalThis.PointerEvent) {
+  class PointerEvent extends MouseEvent {
+    public readonly pointerId: number;
+    public readonly pointerType: string;
+    public readonly isPrimary: boolean;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? "mouse";
+      this.isPrimary = params.isPrimary ?? true;
+    }
+  }
+  globalThis.PointerEvent = PointerEvent as typeof globalThis.PointerEvent;
+}
+
 // Mock @tauri-apps/api/event — Tauri IPC is not available in test environment
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),


### PR DESCRIPTION
## Problem

HTML5 Drag & Drop (`draggable`, `onDragStart`, `onDrop`) is silently broken in Tauri's WebView2 host — cards could not be moved between Kanban columns.

## Lösung

Replaced the entire DnD implementation with a **PointerEvent-based system** that works reliably in WebView2:

### KanbanCard.tsx
- Removed `draggable` + HTML5 `onDragStart/onDragEnd` handlers
- Added `onPointerDown/Move/Up` handlers with a **5px movement threshold** before drag is committed
- `isDraggingRef` (ref, not state) tracks drag state synchronously to suppress click events after drag
- During drag: `pointer-events: none` + `cursor-grabbing` applied via CSS class

### KanbanBoard.tsx
- Removed `onDragOver/onDragLeave/onDrop` column handlers
- Added `data-lane-id` attribute to each column div
- `startGlobalDragListeners()` registers `window.pointermove` + `window.pointerup` once drag threshold is crossed
- Drop target detection via `document.elementsFromPoint(e.clientX, e.clientY)` → finds element with `data-lane-id`

### src/test/setup.ts
- Added `PointerEvent` polyfill for jsdom (extends `MouseEvent` so `clientX`/`clientY` work correctly in test assertions)

## Tests

- 13/13 KanbanCard tests pass (5 new pointer drag tests)
- 8/8 KanbanBoard tests pass (new `data-lane-id` and no-HTML5-DnD assertions)
- All 62 Kanban tests green
- `npx tsc --noEmit` clean

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)