### PR TITLE
feat(design): Style-Contract haerten (Content + Interaction Rules)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,19 @@ Non-negotiable:
 - Fokus-Ring: `outline: 2px solid var(--color-accent); outline-offset: 2px` auf `:focus-visible` — niemals `outline: none` ohne Ersatz.
 - Motion-Tokens aus `src/utils/motion.ts` verwenden (`DURATION`, `EASE`) — kein Spring im Prod-Code.
 
+Content-Regeln (UI-Strings):
+- **Pronouns**: Kein `du`/`Sie`/`Ihre`/`Ihnen`. Nur Imperativ/Infinitiv. Beispiel: `Session schliessen` statt `Schliessen Sie die Session`, `Projektordner waehlen` statt `Waehlen Sie Ihren Ordner`.
+- **Number-Formatting**: `ms` fuer Durations (`312 ms`), `mm:ss` fuer Elapsed (`2:14`), Exit-Codes verbatim (`Exit 0`, `Exit 1`).
+- **Panel-Titel**: UPPERCASE + wide-tracking. Toast-Titel ebenso.
+
+Interaction-Patterns (Desktop, kein Touch!):
+- **Hover**: Text brightens one step (`text-neutral-400 → text-neutral-200`), Background bekommt `hover:bg-hover-overlay`, Border lightens (`border-neutral-700 → border-neutral-500`).
+- **Press**: KEIN `scale-*` transform. Dies ist ein Desktop-Tool.
+- **Disabled**: IMMER `disabled:opacity-40` + `disabled:cursor-not-allowed` zusammen setzen.
+- **Card-Action-Chrome**: `opacity-0 group-hover:opacity-100` (Aktionen nur bei Card-Hover sichtbar).
+- **Modal-Backdrop**: `bg-black/70` ohne `backdrop-blur-*`.
+- **Active/Selected**: `border-left: 2px solid` in semantischer Farbe + getoenter Background (`bg-accent-a10` / `bg-success-a05`).
+
 Bei neuen Komponenten: gegen Preview-HTMLs in `docs/design-system/preview/` abgleichen.
 
 ## Kommunikation

--- a/src/components/kanban/IssueCommentForm.tsx
+++ b/src/components/kanban/IssueCommentForm.tsx
@@ -68,7 +68,7 @@ export function IssueCommentForm({
         disabled={submitting}
         placeholder="Kommentar verfassen (Markdown, ⌘/Ctrl+Enter zum Senden)"
         rows={4}
-        className="w-full bg-surface-base border border-neutral-700 rounded-sm p-2 text-sm text-neutral-200 placeholder:text-neutral-500 resize-y disabled:opacity-50 focus:outline-none focus:border-neutral-500 transition-colors"
+        className="w-full bg-surface-base border border-neutral-700 rounded-sm p-2 text-sm text-neutral-200 placeholder:text-neutral-500 resize-y disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:border-neutral-500 transition-colors"
       />
       {error && (
         <p className="text-xs text-red-400">{error}</p>
@@ -77,7 +77,7 @@ export function IssueCommentForm({
         <button
           type="submit"
           disabled={!body.trim() || submitting}
-          className="px-3 py-1.5 text-xs font-medium bg-accent text-white rounded-sm disabled:opacity-40 hover:bg-accent/90 transition-colors"
+          className="px-3 py-1.5 text-xs font-medium bg-accent text-white rounded-sm disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
         >
           {submitting ? "Wird gesendet…" : "Kommentar posten"}
         </button>

--- a/src/components/pipeline/PipelineControls.tsx
+++ b/src/components/pipeline/PipelineControls.tsx
@@ -178,7 +178,7 @@ export function PipelineControls({ projectPath }: PipelineControlsProps) {
                 value={selectedPath}
                 onChange={(e) => setSelectedPath(e.target.value)}
                 disabled={isRunning || loadingList}
-                className="w-full appearance-none bg-surface-raised border border-neutral-700 text-sm text-neutral-300 rounded px-3 py-1.5 pr-8 focus:outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
+                className="w-full appearance-none bg-surface-raised border border-neutral-700 text-sm text-neutral-300 rounded px-3 py-1.5 pr-8 focus:outline-none focus:ring-1 focus:ring-accent disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {workflows.length === 0 && (
                   <option value="">

--- a/src/components/pipeline/PipelineHistoryView.tsx
+++ b/src/components/pipeline/PipelineHistoryView.tsx
@@ -90,7 +90,7 @@ export function PipelineHistoryView() {
         <button
           onClick={() => loadRuns()}
           disabled={isLoading}
-          className="p-1 rounded hover:bg-surface-raised text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50"
+          className="p-1 rounded hover:bg-surface-raised text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           title="Aktualisieren"
           data-testid="refresh-button"
         >

--- a/src/components/pipeline/WorkflowLauncher.tsx
+++ b/src/components/pipeline/WorkflowLauncher.tsx
@@ -233,7 +233,7 @@ export function WorkflowLauncher({ folder: folderProp }: WorkflowLauncherProps) 
         <button
           onClick={handleRefresh}
           disabled={loading}
-          className="p-1 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50"
+          className="p-1 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           title="Workflows neu erkennen"
         >
           {loading ? (

--- a/src/components/sessions/ClaudeMdViewer.tsx
+++ b/src/components/sessions/ClaudeMdViewer.tsx
@@ -132,7 +132,7 @@ export function ClaudeMdViewer({ folder }: ClaudeMdViewerProps) {
               <button
                 onClick={saveFile}
                 disabled={!isDirty || isSaving}
-                className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded transition-colors disabled:opacity-40 text-accent hover:bg-accent-a10"
+                className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-accent hover:bg-accent-a10"
                 title="Speichern (Ctrl+S)"
                 aria-label="Datei speichern"
               >

--- a/src/components/sessions/PinnedDocViewer.tsx
+++ b/src/components/sessions/PinnedDocViewer.tsx
@@ -190,7 +190,7 @@ export function PinnedDocViewer({ folder, pinId }: PinnedDocViewerProps) {
               <button
                 onClick={saveFile}
                 disabled={!isDirty || isSaving}
-                className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded transition-colors disabled:opacity-40 text-accent hover:bg-accent-a10"
+                className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-accent hover:bg-accent-a10"
                 title="Speichern (Ctrl+S)"
                 aria-label="Datei speichern"
               >


### PR DESCRIPTION
## Summary

Follow-up zu #232 (Design-System-Intake). Kodifiziert zwei Rule-Blocks aus `docs/design-system/README.md` in `CLAUDE.md` und fixt alle 7 gefundenen Disabled-State-Violations.

## Research-Basis

| Check | Ergebnis |
|---|---|
| Pronouns (`du`/`Sie`/`Ihre`) | **0 Violations** — Code nutzt bereits Infinitiv/Imperativ |
| Press `scale-*` transforms | **0 Violations** |
| Modal `backdrop-blur-*` | **0 Violations** |
| Disabled ohne `cursor-not-allowed` | **7 Violations in 6 Files** |
| Card-Chrome Pattern | 8 Files bereits korrekt |

## Changes

### CLAUDE.md — Content-Regeln
- Pronouns: kein `du`/`Sie`/`Ihre`/`Ihnen`, nur Imperativ/Infinitiv
- Number-Formatting: `ms`, `mm:ss`, Exit-Codes verbatim
- Panel/Toast-Titel: UPPERCASE + wide tracking

### CLAUDE.md — Interaction-Patterns
- Hover (text brighten + hover-overlay + border lighten)
- Press: KEIN `scale-*` transform
- Disabled: `opacity-40` + `cursor-not-allowed` zusammen
- Card-Action-Chrome: `opacity-0 group-hover:opacity-100`
- Modal-Backdrop: `bg-black/70`, kein Blur
- Active/Selected: `border-left-2` + getoenter Background

### Code-Fixes (7 Controls in 6 Files)
- `src/components/kanban/IssueCommentForm.tsx` (textarea + submit)
- `src/components/sessions/ClaudeMdViewer.tsx` (save)
- `src/components/sessions/PinnedDocViewer.tsx` (save)
- `src/components/pipeline/PipelineControls.tsx` (workflow select)
- `src/components/pipeline/PipelineHistoryView.tsx` (refresh)
- `src/components/pipeline/WorkflowLauncher.tsx` (refresh)

## Sichtbarer Impact

Beim Deaktivieren eines Controls aendert sich der Cursor jetzt konsistent zu `not-allowed` (Verbotsschild). Vorher: die Opacity sank aber der Cursor blieb `text` oder `pointer` — ein UX-Bug.

## Test plan

- [x] `npx tsc --noEmit` — green
- [x] `npm run build` — green
- [ ] Visueller Smoke: IssueCommentForm mit leerem Body, ClaudeMdViewer ohne Dirty-State, PipelineControls ohne Workflow — Cursor muss `not-allowed` sein

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)