### PR TITLE
refactor(ui): Panel-Header Padding-Unify (main vs compact)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,11 @@ Interaction-Patterns (Desktop, kein Touch!):
 - **Modal-Backdrop**: `bg-black/70` ohne `backdrop-blur-*`.
 - **Active/Selected**: `border-left: 2px solid` in semantischer Farbe + getoenter Background (`bg-accent-a10` / `bg-success-a05`).
 
+Panel-Header-Paddings (2 Varianten):
+- **`main`** = `px-4 py-3` — Top-Level-Views, Modal-Header, Config-Panel-Header (ClaudeMd, Settings, Hooks, GitHub, Worktree, Pin, Library, Kanban, Pipeline, Panel-Komponente).
+- **`compact`** = `px-3 py-2` — Sub-Panels, Toolbars, Filter-Leisten, Fold-Header, Sekundaer-Rows (Kanban-Spalten, Agents/Skills/Library-Viewer-Sub, Session-Fold, Favorites-Fold, Log-Toolbar, Editor-Toolbar, Pipeline-History/Status/Task-Summary).
+- Inline-Klassen direkt in JSX setzen — `<Panel>`-Komponente existiert zwar in `src/components/shared/Panel.tsx`, ist aber aktuell ungenutzt (vgl. Follow-up).
+
 Bei neuen Komponenten: gegen Preview-HTMLs in `docs/design-system/preview/` abgleichen.
 
 ## Kommunikation

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -29,7 +29,7 @@ export function EditorToolbar() {
   const closeFile = useEditorStore(selectCloseFile);
 
   return (
-    <div className="flex items-center gap-2 px-4 py-2 bg-surface-raised border-b border-neutral-700 min-h-[44px]">
+    <div className="flex items-center gap-2 px-3 py-2 bg-surface-raised border-b border-neutral-700 min-h-[44px]">
       <FileEdit className="w-4 h-4 text-accent shrink-0" aria-hidden="true" />
 
       {/* File name */}

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -379,7 +379,7 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 shrink-0">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <div className="flex items-center gap-2">
           <Columns3 className="w-4 h-4 text-neutral-400" />
           {/* Project selector */}

--- a/src/components/kanban/KanbanDashboardView.tsx
+++ b/src/components/kanban/KanbanDashboardView.tsx
@@ -84,7 +84,7 @@ export function KanbanDashboardView() {
   if (boardMode === "global") {
     return (
       <div className="flex flex-col h-full">
-        <div className="flex items-center gap-2 px-4 py-2 border-b border-neutral-700 shrink-0">
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-700 shrink-0">
           <Columns3 className="w-3.5 h-3.5 text-neutral-500" />
           <span className="text-xs text-neutral-500 mr-auto">Globales Board</span>
           {modeToggle}
@@ -101,7 +101,7 @@ export function KanbanDashboardView() {
   if (!folderModeFolder && availableOptions.length === 0) {
     return (
       <div className="flex flex-col h-full">
-        <div className="flex items-center justify-end gap-2 px-4 py-2 border-b border-neutral-700 shrink-0">
+        <div className="flex items-center justify-end gap-2 px-3 py-2 border-b border-neutral-700 shrink-0">
           {modeToggle}
         </div>
         <div className="flex flex-col items-center justify-center flex-1 gap-3 text-neutral-500">
@@ -118,7 +118,7 @@ export function KanbanDashboardView() {
   return (
     <div className="flex flex-col h-full">
       {/* Header: folder picker + mode toggle */}
-      <div className="flex items-center gap-2 px-4 py-2 border-b border-neutral-700 shrink-0">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-neutral-700 shrink-0">
         <span className="text-xs text-neutral-500">Projekt:</span>
         <select
           value={folderModeFolder ?? ""}

--- a/src/components/library/LibraryView.tsx
+++ b/src/components/library/LibraryView.tsx
@@ -436,7 +436,7 @@ export function LibraryView() {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 bg-surface-raised shrink-0">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 bg-surface-raised shrink-0">
         <div className="flex items-center gap-2">
           <BookOpen className="w-4 h-4 text-accent" />
           <h1 className="text-sm font-semibold text-neutral-200">

--- a/src/components/logs/LogViewer.tsx
+++ b/src/components/logs/LogViewer.tsx
@@ -160,7 +160,7 @@ export function LogViewer() {
   return (
     <div className="flex flex-col h-full bg-surface-base">
       {/* Toolbar */}
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-neutral-700 bg-surface-raised flex-wrap">
+      <div className="flex items-center gap-3 px-3 py-2 border-b border-neutral-700 bg-surface-raised flex-wrap">
         {/* Severity filters */}
         <div className="flex gap-1">
           {SEVERITY_OPTIONS.map((opt) => (

--- a/src/components/pipeline/PipelineHistoryView.tsx
+++ b/src/components/pipeline/PipelineHistoryView.tsx
@@ -83,7 +83,7 @@ export function PipelineHistoryView() {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-700">
         <h3 className="text-xs font-display font-bold text-neutral-400 tracking-wider uppercase">
           Pipeline-Verlauf
         </h3>

--- a/src/components/pipeline/PipelineStatusBar.tsx
+++ b/src/components/pipeline/PipelineStatusBar.tsx
@@ -48,7 +48,7 @@ export function PipelineStatusBar() {
   const showError = statusInfo.status === "failed" && statusInfo.errorMessage;
 
   return (
-    <div className="border-b border-neutral-700 px-4 py-2">
+    <div className="border-b border-neutral-700 px-3 py-2">
       <AnimatePresence mode="wait">
         <motion.div
           key={statusInfo.status}

--- a/src/components/pipeline/PipelineView.tsx
+++ b/src/components/pipeline/PipelineView.tsx
@@ -66,7 +66,7 @@ export function PipelineView() {
   return (
     <div className="flex flex-col h-full">
       {/* Header with session selector + tabs */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700">
         <div className="flex items-center gap-3">
           <h2 className="text-sm font-display font-bold text-neutral-300 tracking-wider uppercase">
             Pipeline
@@ -111,7 +111,7 @@ export function PipelineView() {
 
           {/* Folder picker — session or favorites */}
           {(favorites.length > 0 || activeSession) && (
-            <div className="flex items-center gap-2 px-4 py-2 border-b border-neutral-700 shrink-0">
+            <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-700 shrink-0">
               <span className="text-xs text-neutral-500">Projekt:</span>
               <select
                 value={folder ?? ""}

--- a/src/components/pipeline/TaskTreeView.tsx
+++ b/src/components/pipeline/TaskTreeView.tsx
@@ -29,7 +29,7 @@ export function TaskTreeView({ sessionId }: TaskTreeViewProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Summary bar */}
-      <div className="flex items-center gap-4 px-4 py-2 border-b border-neutral-700 text-xs text-neutral-400 shrink-0">
+      <div className="flex items-center gap-4 px-3 py-2 border-b border-neutral-700 text-xs text-neutral-400 shrink-0">
         <span>
           <strong className="text-neutral-200">{summary.total}</strong> Agenten
         </span>

--- a/src/components/sessions/ClaudeMdViewer.tsx
+++ b/src/components/sessions/ClaudeMdViewer.tsx
@@ -119,7 +119,7 @@ export function ClaudeMdViewer({ folder }: ClaudeMdViewerProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 shrink-0">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-xs text-neutral-400 font-medium">CLAUDE.md</span>
           {isDirty && (

--- a/src/components/sessions/FavoritesList.tsx
+++ b/src/components/sessions/FavoritesList.tsx
@@ -42,7 +42,7 @@ export function FavoritesList({ onQuickStart }: FavoritesListProps) {
     <div>
       {/* Section header */}
       <div
-        className="flex items-center justify-between px-3 py-1.5 border-b border-neutral-700 cursor-pointer hover:bg-hover-overlay transition-colors"
+        className="flex items-center justify-between px-3 py-2 border-b border-neutral-700 cursor-pointer hover:bg-hover-overlay transition-colors"
         onClick={() => setExpanded((v) => !v)}
       >
         <div className="flex items-center gap-1.5">

--- a/src/components/sessions/GitHubViewer.tsx
+++ b/src/components/sessions/GitHubViewer.tsx
@@ -182,7 +182,7 @@ export function GitHubViewer({ folder }: GitHubViewerProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 shrink-0">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <span className="text-xs text-neutral-400 font-medium">GitHub</span>
         <button
           onClick={() => load(true)}

--- a/src/components/sessions/HooksViewer.tsx
+++ b/src/components/sessions/HooksViewer.tsx
@@ -200,7 +200,7 @@ export function HooksViewer({ folder }: HooksViewerProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 shrink-0">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <div className="flex items-center gap-3">
           <span className="text-xs text-neutral-400 font-medium">
             {eventGroups.length}{" "}

--- a/src/components/sessions/PinnedDocViewer.tsx
+++ b/src/components/sessions/PinnedDocViewer.tsx
@@ -169,7 +169,7 @@ export function PinnedDocViewer({ folder, pinId }: PinnedDocViewerProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 shrink-0">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <div className="flex items-center gap-2 min-w-0">
           <span className="flex items-center gap-1.5 text-xs text-neutral-400 font-medium truncate" title={relativePath}>
             <Pin className="w-3 h-3 shrink-0" aria-hidden="true" />

--- a/src/components/sessions/SessionList.tsx
+++ b/src/components/sessions/SessionList.tsx
@@ -79,7 +79,7 @@ export function SessionList({ onNewSession, onQuickStart }: SessionListProps) {
 
         {/* Sessions section header */}
         <div
-          className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-neutral-500 tracking-widest border-b border-neutral-700 cursor-pointer hover:bg-hover-overlay transition-colors"
+          className="flex items-center gap-1.5 px-3 py-2 text-xs text-neutral-500 tracking-widest border-b border-neutral-700 cursor-pointer hover:bg-hover-overlay transition-colors"
           onClick={() => setSessionsExpanded((v) => !v)}
         >
           {sessionsExpanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}

--- a/src/components/sessions/SettingsViewer.tsx
+++ b/src/components/sessions/SettingsViewer.tsx
@@ -203,7 +203,7 @@ export function SettingsViewer({ folder }: SettingsViewerProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 shrink-0">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <div className="flex items-center gap-3">
           <span className="text-xs text-neutral-400 font-medium">
             {sections.length}{" "}

--- a/src/components/sessions/WorktreeViewer.tsx
+++ b/src/components/sessions/WorktreeViewer.tsx
@@ -80,7 +80,7 @@ export function WorktreeViewer({ folder }: WorktreeViewerProps) {
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-700 shrink-0">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <div className="flex items-center gap-1.5">
           <GitBranch className="w-3.5 h-3.5 text-neutral-400" />
           <span className="text-xs text-neutral-400 font-medium">

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -98,7 +98,7 @@ export function Modal({
           >
             {/* Header (optional) */}
             {title !== undefined && (
-              <div className="flex items-center justify-between px-6 py-4 border-b border-neutral-700 shrink-0">
+              <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
                 <div id={titleId} className="flex-1 min-w-0">{title}</div>
                 <IconButton
                   icon={<X className="w-5 h-5" />}


### PR DESCRIPTION
## Summary

Follow-up zu #232 und #234. Konsolidiert 5 verschiedene Panel-Header-Paddings auf 2 kanonische Klassen.

## Vorher / Nachher

**Vorher:** 5 Padding-Kombinationen mischten sich:
| Padding | Haeufigkeit |
|---|---|
| `px-4 py-2` | 19 Files |
| `px-3 py-2` | 8 Files |
| `px-4 py-3` | 3 Files |
| `px-3 py-1.5` | 2 Files |
| `px-6 py-4` | 1 File |

**Nachher:** 2 Klassen, dokumentiert in CLAUDE.md:
- **`main`** = `px-4 py-3` — Top-Level-Views, Modal-Header, Config-Panel-Header
- **`compact`** = `px-3 py-2` — Sub-Panels, Toolbars, Filter-Leisten, Fold-Header

## Sichtbarer Impact

**Dichte aendert sich merklich** — das ist der Hebel, den du im letzten Review gesucht hast:
- Top-Level-Views + Modals bekommen 4px mehr vertikalen Raum (bisher py-2, jetzt py-3)
- Modal-Header schrumpft horizontal (px-6 → px-4) und vertikal (py-4 → py-3)
- Fold-Headers in Sessions/Favorites bekommen 2px mehr Hoehe (py-1.5 → py-2)
- Sekundaere Rows (Picker, Status, Toolbar) schrumpfen horizontal (px-4 → px-3)

## Changes

19 Files, 21 `className`-String-Updates:

### MAIN (-> px-4 py-3, 11 Stellen)
- LibraryView, KanbanBoard, KanbanDashboardView (Folder-Picker)
- GitHubViewer, HooksViewer, SettingsViewer, WorktreeViewer, ClaudeMdViewer, PinnedDocViewer
- PipelineView (Haupt-Header)
- Modal (reduziert auch von `px-6 py-4`)

### COMPACT (-> px-3 py-2, 10 Stellen)
- LogViewer (Toolbar), EditorToolbar
- PipelineHistoryView (Sub), TaskTreeView (Summary), PipelineView (Sekundaer), PipelineStatusBar
- KanbanDashboardView (Info + Mode-Toggle-Rows)
- SessionList + FavoritesList (beide Fold-Header, von `py-1.5`)

### CLAUDE.md
Neuer Abschnitt "Panel-Header-Paddings (2 Varianten)" mit Klassifikation.

## Nicht im Scope (bewusst)

- Grosse Migration zu `<Panel>`-Komponente — die existiert, ist aber ungenutzt (eigenes Follow-up).
- List-Row-Paddings (Spec: `px-3 py-2.5`) — separates Issue.
- Anpassung der Panel-Komponente (`src/components/shared/Panel.tsx`) — sie nutzt schon `px-4 py-3` korrekt.

## Test plan

- [x] `npx tsc --noEmit` — green
- [x] `npm run test` — 1035/1035 green
- [x] `npm run build` — green
- [ ] Visueller Smoke: Modals, Config-Panels, Pipeline, Sessions-Fold — Dichte sichtbar unterschiedlich

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)