### PR TITLE
chore(rust): pin toolchain to 1.95

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
             librsvg2-dev \
             patchelf
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.95.0"
           components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
@@ -75,7 +76,9 @@ jobs:
             librsvg2-dev \
             patchelf
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
 
       - run: npm ci
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -36,7 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,12 @@ npm run lint             # ESLint
 - **Signature Changes**: Grep nach allen Usages, ALLE Caller updaten
 - **Nicht behaupten, verifizieren**: Build-Log/Screenshot als Beweis
 
+## Rust Toolchain
+
+- **Autoritativ**: `src-tauri/rust-toolchain.toml` pinnt die Rust-Version (aktuell `1.95.0`) + `rustfmt` + `clippy`. `rustup` installiert beim ersten `cargo`-Aufruf automatisch die richtige Version.
+- **CI matcht lokal**: Alle Workflows (`ci.yml`, `release.yml`, `security-audit.yml`) pinnen dieselbe Version via `dtolnay/rust-toolchain@master` mit `toolchain: "1.95.0"`. Bump passiert an beiden Stellen gemeinsam.
+- **Bei Clippy-Drift**: `rustup update` + `cargo clean` + `cargo clippy -- -D warnings` lokal laufen lassen, dann push.
+
 ## Quality Gates (vor "Done")
 
 - [ ] 1 Happy-Path-Test + 1 Edge-Case-Test pro Feature

--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
## Summary
- Add `src-tauri/rust-toolchain.toml` pinned to `1.95.0` with `rustfmt` + `clippy` (profile `minimal`), so `rustup` auto-switches locally to match CI.
- Pin all three CI workflows (`ci.yml`, `release.yml`, `security-audit.yml`) to `dtolnay/rust-toolchain@master` with `toolchain: "1.95.0"` for redundancy (issue recommends both).
- Document the new rule in `CLAUDE.md` under a new "Rust Toolchain" section (authoritative file, CI-pin location, clippy-drift recovery).

## Motivation
Sprint #232 / PR #233 burned three extra commits because local `rustc 1.94.1` diverged from CI `stable` (1.95) and picked up new Clippy lints only after push. This pin makes the drift impossible.

## Test plan
- [x] `cargo check` (green — 1m20s)
- [x] `cargo fmt --check` (green)
- [x] `cargo clippy -- -D warnings` (green — 5s)
- [x] `rustup show` confirms auto-switch: "active because: overridden by rust-toolchain.toml" → 1.95.0 installed on first cargo call

Closes #241
Refs #232, #233

Co-Authored-By: Claude <noreply@anthropic.com>