### PR TITLE
chore(ui): unify pill shapes to rounded-sm (option A)

### DIFF
--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -85,7 +85,7 @@ export function SideNav({ badges = {} }: SideNavProps) {
 
           {/* Badge */}
           {item.badge != null && item.badge > 0 && (
-            <span className="ml-auto min-w-[16px] h-4 flex items-center justify-center rounded-full bg-error text-white text-[9px] font-bold px-1">
+            <span className="ml-auto min-w-[16px] h-4 flex items-center justify-center rounded-sm bg-error text-white text-[9px] font-bold px-1">
               {item.badge > 99 ? "99+" : item.badge}
             </span>
           )}

--- a/src/components/library/LibraryDetailContent.tsx
+++ b/src/components/library/LibraryDetailContent.tsx
@@ -28,7 +28,7 @@ function SkillFrontmatterTable({ skill }: { skill: DiscoveredSkill }) {
             <FrontmatterRow label="description">{skill.description}</FrontmatterRow>
           )}
           <FrontmatterRow label="scope">
-            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-neutral-700 text-neutral-300">
+            <span className="text-[10px] px-1.5 py-0.5 rounded-sm bg-neutral-700 text-neutral-300">
               {skill.scope}
             </span>
           </FrontmatterRow>

--- a/src/components/library/LibraryDetailModal.tsx
+++ b/src/components/library/LibraryDetailModal.tsx
@@ -37,7 +37,7 @@ function DetailHeader({ detail }: { detail: SelectedDetail }): JSX.Element {
       <Icon className={`w-4 h-4 shrink-0 ${iconClass}`} />
       <span className="text-sm font-semibold text-neutral-200 truncate">{title}</span>
       {scope && (
-        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-neutral-700 text-neutral-400 shrink-0">
+        <span className="text-[10px] px-1.5 py-0.5 rounded-sm bg-neutral-700 text-neutral-400 shrink-0">
           {scope}
         </span>
       )}

--- a/src/components/library/LibraryView.tsx
+++ b/src/components/library/LibraryView.tsx
@@ -185,7 +185,7 @@ function AgentCard({ agent }: { agent: DiscoveredAgent }) {
           <span className="text-xs font-semibold text-neutral-200">
             {agent.name}
           </span>
-          <span className="text-[10px] px-1.5 rounded-full bg-purple-500/15 text-purple-400 ml-auto shrink-0">
+          <span className="text-[10px] px-1.5 rounded-sm bg-purple-500/15 text-purple-400 ml-auto shrink-0">
             {agent.model}
           </span>
         </div>

--- a/src/components/pipeline/TaskTreeNode.tsx
+++ b/src/components/pipeline/TaskTreeNode.tsx
@@ -87,7 +87,7 @@ export const TaskTreeNode = memo(function TaskTreeNode({
         <div className="flex items-center gap-2 shrink-0 ml-2">
           {/* Blocked badge */}
           {agent.blockedBy != null && (
-            <span className="flex items-center gap-0.5 text-[10px] text-yellow-500 bg-yellow-500/10 px-1.5 py-0.5 rounded-full">
+            <span className="flex items-center gap-0.5 text-[10px] text-yellow-500 bg-yellow-500/10 px-1.5 py-0.5 rounded-sm">
               <Lock className="w-2.5 h-2.5" />
               #{agent.blockedBy}
             </span>

--- a/src/components/pipeline/WorkflowLauncher.tsx
+++ b/src/components/pipeline/WorkflowLauncher.tsx
@@ -80,7 +80,7 @@ function WorkflowCard({
           </span>
         </div>
         <span
-          className={`px-1.5 py-0.5 text-[10px] rounded-full shrink-0 ${config.bg} ${config.color}`}
+          className={`px-1.5 py-0.5 text-[10px] rounded-sm shrink-0 ${config.bg} ${config.color}`}
         >
           {config.label}
         </span>

--- a/src/components/sessions/AgentBottomPanel.tsx
+++ b/src/components/sessions/AgentBottomPanel.tsx
@@ -256,7 +256,7 @@ function AgentDetailCard({
         <span className="text-sm font-semibold text-neutral-200">
           {agent.name ?? agent.task ?? "Agent"}
         </span>
-        <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${statusColorClass}`}>
+        <span className={`text-[10px] px-1.5 py-0.5 rounded-sm ${statusColorClass}`}>
           {statusLabel}
         </span>
       </div>

--- a/src/components/sessions/AgentsViewer.tsx
+++ b/src/components/sessions/AgentsViewer.tsx
@@ -162,7 +162,7 @@ export function AgentsViewer({ folder }: AgentsViewerProps) {
                   )}
                   {metadata.model && (
                     <div className="mt-1">
-                      <span className="inline-block px-1.5 py-0 text-[10px] rounded-full bg-neutral-800 text-neutral-500">
+                      <span className="inline-block px-1.5 py-0 text-[10px] rounded-sm bg-neutral-800 text-neutral-500">
                         {metadata.model}
                       </span>
                     </div>
@@ -200,7 +200,7 @@ function AgentDetail({ entry }: { entry: AgentEntry }) {
             {metadata.name}
           </h2>
           {metadata.model && (
-            <span className="inline-block px-1.5 py-0 text-[10px] rounded-full bg-neutral-800 text-neutral-400">
+            <span className="inline-block px-1.5 py-0 text-[10px] rounded-sm bg-neutral-800 text-neutral-400">
               {metadata.model}
             </span>
           )}
@@ -242,7 +242,7 @@ function AgentDetail({ entry }: { entry: AgentEntry }) {
             {metadata.allowedTools.map((tool) => (
               <span
                 key={tool}
-                className="inline-block px-2 py-0.5 text-xs rounded-full bg-surface-raised text-neutral-300 font-mono"
+                className="inline-block px-2 py-0.5 text-xs rounded-sm bg-surface-raised text-neutral-300 font-mono"
               >
                 {tool}
               </span>

--- a/src/components/sessions/LibraryViewer.tsx
+++ b/src/components/sessions/LibraryViewer.tsx
@@ -170,7 +170,7 @@ export function LibraryViewer({ folder = "" }: LibraryViewerProps) {
               <button
                 key={f}
                 onClick={() => setFilter(f)}
-                className={`px-2 py-0.5 text-xs rounded-full transition-colors ${
+                className={`px-2 py-0.5 text-xs rounded-sm transition-colors ${
                   filter === f
                     ? "bg-accent-a10 text-accent"
                     : "text-neutral-400 hover:text-neutral-200 hover:bg-hover-overlay"
@@ -230,7 +230,7 @@ export function LibraryViewer({ folder = "" }: LibraryViewerProps) {
                   )}
                   <div className="flex items-center gap-1 mt-1">
                     <span
-                      className={`inline-block px-1.5 py-0 text-[10px] rounded-full ${
+                      className={`inline-block px-1.5 py-0 text-[10px] rounded-sm ${
                         TYPE_COLORS[item.item_type]
                       }`}
                     >
@@ -239,7 +239,7 @@ export function LibraryViewer({ folder = "" }: LibraryViewerProps) {
                     {item.tags.slice(0, 2).map((tag) => (
                       <span
                         key={tag}
-                        className="inline-block px-1.5 py-0 text-[10px] rounded-full bg-neutral-800 text-neutral-500"
+                        className="inline-block px-1.5 py-0 text-[10px] rounded-sm bg-neutral-800 text-neutral-500"
                       >
                         {tag}
                       </span>
@@ -348,7 +348,7 @@ function ItemDetail({
             {item.name}
           </h2>
           <span
-            className={`inline-block px-1.5 py-0 text-[10px] rounded-full ${
+            className={`inline-block px-1.5 py-0 text-[10px] rounded-sm ${
               TYPE_COLORS[item.item_type]
             }`}
           >
@@ -363,7 +363,7 @@ function ItemDetail({
             {item.tags.map((tag) => (
               <span
                 key={tag}
-                className="inline-block px-1.5 py-0.5 text-[10px] rounded-full bg-neutral-800 text-neutral-400"
+                className="inline-block px-1.5 py-0.5 text-[10px] rounded-sm bg-neutral-800 text-neutral-400"
               >
                 {tag}
               </span>
@@ -557,7 +557,7 @@ function NewItemForm({
               <button
                 key={type}
                 onClick={() => setItemType(type)}
-                className={`px-2.5 py-1 text-xs rounded-full transition-colors ${
+                className={`px-2.5 py-1 text-xs rounded-sm transition-colors ${
                   itemType === type
                     ? TYPE_COLORS[type]
                     : "text-neutral-400 hover:text-neutral-200 bg-neutral-800 hover:bg-neutral-700"

--- a/src/components/sessions/SkillsViewer.tsx
+++ b/src/components/sessions/SkillsViewer.tsx
@@ -125,7 +125,7 @@ export function SkillsViewer({ folder }: SkillsViewerProps) {
               <button
                 key={f}
                 onClick={() => setFilter(f)}
-                className={`px-2 py-0.5 text-xs rounded-full transition-colors ${
+                className={`px-2 py-0.5 text-xs rounded-sm transition-colors ${
                   filter === f
                     ? "bg-accent-a10 text-accent"
                     : "text-neutral-400 hover:text-neutral-200 hover:bg-hover-overlay"
@@ -183,7 +183,7 @@ export function SkillsViewer({ folder }: SkillsViewerProps) {
                   )}
                   <div className="mt-1">
                     <span
-                      className={`inline-block px-1.5 py-0 text-[10px] rounded-full ${
+                      className={`inline-block px-1.5 py-0 text-[10px] rounded-sm ${
                         metadata.userInvokable
                           ? "bg-accent-a10 text-accent"
                           : "bg-neutral-800 text-neutral-500"
@@ -225,7 +225,7 @@ function SkillDetail({ entry }: { entry: SkillEntry }) {
             {metadata.name}
           </h2>
           <span
-            className={`inline-block px-1.5 py-0 text-[10px] rounded-full ${
+            className={`inline-block px-1.5 py-0 text-[10px] rounded-sm ${
               metadata.userInvokable
                 ? "bg-accent-a10 text-accent"
                 : "bg-neutral-800 text-neutral-500"
@@ -234,7 +234,7 @@ function SkillDetail({ entry }: { entry: SkillEntry }) {
             {metadata.userInvokable ? "Aufrufbar" : "Auto"}
           </span>
           {entry.hasReferenceDir && (
-            <span className="inline-flex items-center gap-1 px-1.5 py-0 text-[10px] rounded-full bg-neutral-800 text-neutral-500">
+            <span className="inline-flex items-center gap-1 px-1.5 py-0 text-[10px] rounded-sm bg-neutral-800 text-neutral-500">
               <FolderOpen className="w-2.5 h-2.5" />
               Referenzen
             </span>


### PR DESCRIPTION
## Summary
- Replace `rounded-full` with `rounded-sm` (2px) on all pill/badge/chip elements for strict design-system compliance (Option A from #245).
- Status-dots, spinners, progress bars, and radio buttons keep `rounded-full` per CLAUDE.md (they are not pills).
- 10 files, 20 class swaps. No logic, behavior, or layout changes.

## Classification

| Element | File | Decision | Reason |
|---|---|---|---|
| Notification count badge | `layout/SideNav.tsx:88` | CHANGE | Numeric count pill (min-w-16px), conveys value, not a status-dot |
| Scope chip | `library/LibraryDetailContent.tsx:31` | CHANGE | Text label chip with padding |
| Scope chip | `library/LibraryDetailModal.tsx:40` | CHANGE | Text label chip with padding |
| Model badge | `library/LibraryView.tsx:188` | CHANGE | Text label chip with padding |
| Blocked badge | `pipeline/TaskTreeNode.tsx:90` | CHANGE | Icon + text badge with bg color |
| Config label chip | `pipeline/WorkflowLauncher.tsx:83` | CHANGE | Text label with bg color |
| Agent status chip | `sessions/AgentBottomPanel.tsx:259` | CHANGE | Status label (Aktiv/Fertig/...) — not a dot |
| Model badges (3x) | `sessions/AgentsViewer.tsx:165,203,245` | CHANGE | Text labels with padding |
| Filter tab buttons (2x) | `sessions/LibraryViewer.tsx:173,560` | CHANGE | Tab-style buttons with text labels |
| Type/tag chips (4x) | `sessions/LibraryViewer.tsx:233,242,351,366` | CHANGE | Text chips with bg color |
| Filter tab button | `sessions/SkillsViewer.tsx:128` | CHANGE | Tab-style button with text label |
| Aufrufbar/Auto chips (2x) | `sessions/SkillsViewer.tsx:186,228` | CHANGE | Status label chips |
| Referenzen chip | `sessions/SkillsViewer.tsx:237` | CHANGE | Icon + text chip |
| Spinner | `DetachedViewApp.tsx:17`, `layout/AppShell.tsx:27`, `shared/LoadingSpinner.tsx:37` | KEEP | Circular spinner (animate-spin / neon-spin) |
| Progress bar | `pipeline/AgentMetricsPanel.tsx:250,252`, `shared/UpdateNotification.tsx:60` | KEEP | Full rounding on track/fill is conventional, not a pill |
| Status-dot (w-1.5/w-2/w-3) | `sessions/AgentBottomPanel.tsx:207`, `sessions/SessionStatusBar.tsx:42,47,52`, `sessions/SessionStatusDot.tsx` (all), `sessions/HooksViewer.tsx:221,262,296`, `sessions/SettingsViewer.tsx:224,264,298`, `editor/EditorToolbar.tsx:44`, `sessions/ClaudeMdViewer.tsx:126`, `sessions/PinnedDocViewer.tsx:184`, `shared/NotesPanel.tsx:144,157,204`, `shared/StatusBadge.tsx:47`, `pipeline/PipelineStatusBar.tsx:65,68` | KEEP | Small circle (<=12px) as explicitly spec'd by CLAUDE.md |
| Timeline step circle | `pipeline/PipelineRunDetail.tsx:46` | KEEP | 18x18 circular icon container (visual anchor on timeline, not a pill) |
| Radio button ring + dot | `sessions/NewSessionDialog.tsx:136,143` | KEEP | Form control (circular radio is conventional, not a pill) |

## Test plan
- [x] `npx tsc --noEmit` green
- [x] `npx vite build` green
- [x] `npx vitest run` — 93 files, 1035 tests passing
- [x] `eslint` — only pre-existing errors in SessionStatusBar.tsx / ConfigPanelTabList.tsx (unrelated to this PR)
- [ ] Visual check in `npm run tauri dev` (dark + light)

Closes #245