### PR TITLE
feat(ui): add icon-registry with size tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Non-negotiable:
 - Ein Akzent (cyan-teal, hue 190) — keine weiteren einfuehren.
 - Deutsche UI-Copy, englische Code-Identifier. Kein Emoji. Kein Unicode-as-Icon.
 - Lucide-Icons only, 2px stroke, `currentColor`.
+- Icon-Zuordnungen und Groessen aus `src/utils/icons.ts` verwenden (`ICONS.*` + `ICON_SIZE.{inline|card|nav|close}`). Direkte `lucide-react`-Imports in Komponenten vermeiden.
 - Exponential Easing `cubic-bezier(0.16, 1, 0.3, 1)`, Durations 100/200/300/500ms, keine Springs/Bounce.
 - Flache Surfaces — keine Gradients, Blur, Glassmorphism, Illustrations.
 - Panel-Header: UPPERCASE, `tracking-widest` (>= 0.12em).

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -1,8 +1,5 @@
 import { useState } from "react";
-import {
-  Monitor, Columns3, ScrollText, BookOpen, FileEdit,
-  Sun, Moon, ArrowDownCircle, AlertCircle, ExternalLink,
-} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useUIStore, type ActiveTab } from "../../store/uiStore";
 import { useSettingsStore } from "../../store/settingsStore";
@@ -12,15 +9,20 @@ import { UpdateNotification } from "../shared/UpdateNotification";
 import { useAutoUpdate } from "../../hooks/useAutoUpdate";
 import { version } from "../../../package.json";
 import { logError } from "../../utils/errorLogger";
+import { ICONS, ICON_SIZE } from "../../utils/icons";
 
 function StatusIcon({ status }: { status: string }) {
   switch (status) {
     case "available":
     case "downloading":
-    case "ready":
-      return <ArrowDownCircle className="w-3 h-3 text-accent status-pulse-animation" />;
-    case "error":
-      return <AlertCircle className="w-3 h-3 text-red-400" />;
+    case "ready": {
+      const Available = ICONS.update.available;
+      return <Available className={`${ICON_SIZE.inline} text-accent status-pulse-animation`} />;
+    }
+    case "error": {
+      const Err = ICONS.update.error;
+      return <Err className={`${ICON_SIZE.inline} text-red-400`} />;
+    }
     default:
       return null;
   }
@@ -29,7 +31,7 @@ function StatusIcon({ status }: { status: string }) {
 interface NavItem {
   id: ActiveTab;
   label: string;
-  icon: typeof Monitor;
+  icon: LucideIcon;
   badge?: number;
 }
 
@@ -49,17 +51,20 @@ export function SideNav({ badges = {} }: SideNavProps) {
     : `Version ${version}`;
 
   const topItems: NavItem[] = [
-    { id: "sessions", label: "Sitzungen", icon: Monitor, badge: badges.sessions },
-    { id: "kanban", label: "Kanban", icon: Columns3, badge: badges.kanban },
-    { id: "library", label: "Bibliothek", icon: BookOpen, badge: badges.library },
-    { id: "editor", label: "Editor", icon: FileEdit, badge: badges.editor },
+    { id: "sessions", label: "Sitzungen", icon: ICONS.nav.sessions, badge: badges.sessions },
+    { id: "kanban", label: "Kanban", icon: ICONS.nav.kanban, badge: badges.kanban },
+    { id: "library", label: "Bibliothek", icon: ICONS.nav.library, badge: badges.library },
+    { id: "editor", label: "Editor", icon: ICONS.nav.editor, badge: badges.editor },
   ];
 
   const bottomItems: NavItem[] = [
-    { id: "logs", label: "Protokolle", icon: ScrollText, badge: badges.logs },
+    { id: "logs", label: "Protokolle", icon: ICONS.nav.logs, badge: badges.logs },
   ];
 
   const detachableViews = new Set<ActiveTab>(["kanban", "library", "editor"]);
+  const ExternalLinkIcon = ICONS.action.externalLink;
+  const LightIcon = ICONS.theme.light;
+  const DarkIcon = ICONS.theme.dark;
 
   function renderItem(item: NavItem) {
     const isActive = activeTab === item.id;
@@ -80,7 +85,7 @@ export function SideNav({ badges = {} }: SideNavProps) {
           `}
           aria-label={item.label}
         >
-          <Icon className="w-4 h-4 shrink-0" />
+          <Icon className={`${ICON_SIZE.nav} shrink-0`} />
           <span className="text-xs truncate">{item.label}</span>
 
           {/* Badge */}
@@ -104,7 +109,7 @@ export function SideNav({ badges = {} }: SideNavProps) {
             title={`${item.label} in eigenem Fenster öffnen`}
             aria-label={`${item.label} in eigenem Fenster öffnen`}
           >
-            <ExternalLink className="w-3 h-3" />
+            <ExternalLinkIcon className={ICON_SIZE.inline} />
           </button>
         )}
       </div>
@@ -141,7 +146,9 @@ export function SideNav({ badges = {} }: SideNavProps) {
             aria-label={mode === "dark" ? "Light Mode aktivieren" : "Dark Mode aktivieren"}
             title={mode === "dark" ? "Light Mode" : "Dark Mode"}
           >
-            {mode === "dark" ? <Sun className="w-4 h-4 shrink-0" /> : <Moon className="w-4 h-4 shrink-0" />}
+            {mode === "dark"
+              ? <LightIcon className={`${ICON_SIZE.nav} shrink-0`} />
+              : <DarkIcon className={`${ICON_SIZE.nav} shrink-0`} />}
             <span className="text-xs truncate">{mode === "dark" ? "Light" : "Dark"}</span>
           </button>
 

--- a/src/components/logs/LogViewer.tsx
+++ b/src/components/logs/LogViewer.tsx
@@ -2,13 +2,6 @@ import { useEffect, useRef, useMemo, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
-  RefreshCw,
-  Trash2,
-  ArrowDownToLine,
-  Search,
-  ExternalLink,
-} from "lucide-react";
-import {
   useLogViewerStore,
   parseBackendLogLine,
   groupConsecutiveEntries,
@@ -16,7 +9,14 @@ import {
   type LogSource,
 } from "../../store/logViewerStore";
 import { getRecentLogs, subscribeToLogs, logError } from "../../utils/errorLogger";
+import { ICONS, ICON_SIZE } from "../../utils/icons";
 import { LogEntryRow, LOG_ROW_HEIGHT } from "./LogEntry";
+
+const SearchIcon = ICONS.action.search;
+const ArrowDownToLineIcon = ICONS.action.scrollToBottom;
+const RefreshIcon = ICONS.action.refresh;
+const TrashIcon = ICONS.action.trash;
+const ExternalLinkIcon = ICONS.action.externalLink;
 
 const SEVERITY_OPTIONS: { key: LogSeverity; label: string; color: string }[] = [
   { key: "error", label: "Error", color: "bg-red-400/20 text-red-400 border-red-400/40" },
@@ -201,7 +201,7 @@ export function LogViewer() {
 
         {/* Search */}
         <div className="relative flex-1 min-w-[140px] max-w-[300px]">
-          <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-neutral-500" />
+          <SearchIcon className={`absolute left-2 top-1/2 -translate-y-1/2 ${ICON_SIZE.card} text-neutral-500`} />
           <input
             type="text"
             value={searchText}
@@ -224,7 +224,7 @@ export function LogViewer() {
             }`}
             title="Live-Tail"
           >
-            <ArrowDownToLine className="w-3.5 h-3.5" />
+            <ArrowDownToLineIcon className={ICON_SIZE.card} />
             Live
           </button>
 
@@ -233,7 +233,7 @@ export function LogViewer() {
             className="flex items-center gap-1 px-2 py-1 text-[11px] text-neutral-400 hover:text-neutral-200 rounded transition-all"
             title="Backend-Logs aktualisieren"
           >
-            <RefreshCw className="w-3.5 h-3.5" />
+            <RefreshIcon className={ICON_SIZE.card} />
           </button>
 
           <button
@@ -241,7 +241,7 @@ export function LogViewer() {
             className="flex items-center gap-1 px-2 py-1 text-[11px] text-neutral-400 hover:text-red-400 rounded transition-all"
             title="Logs leeren"
           >
-            <Trash2 className="w-3.5 h-3.5" />
+            <TrashIcon className={ICON_SIZE.card} />
           </button>
 
           <button
@@ -249,7 +249,7 @@ export function LogViewer() {
             className="flex items-center gap-1 px-2 py-1 text-[11px] text-neutral-400 hover:text-neutral-200 rounded transition-all"
             title="In eigenem Fenster öffnen"
           >
-            <ExternalLink className="w-3.5 h-3.5" />
+            <ExternalLinkIcon className={ICON_SIZE.card} />
           </button>
         </div>
       </div>

--- a/src/components/shared/Toast.tsx
+++ b/src/components/shared/Toast.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 import { motion } from "framer-motion";
-import { X, CheckCircle2, AlertTriangle, Trophy, Info } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { DURATION, EASE } from "../../utils/motion";
+import { ICONS, ICON_SIZE } from "../../utils/icons";
 
 export interface ToastData {
   id: string;
@@ -17,25 +17,25 @@ const TOAST_CONFIG: Record<
   { icon: LucideIcon; border: string; text: string; glow: string }
 > = {
   success: {
-    icon: CheckCircle2,
+    icon: ICONS.toast.success,
     border: "border-success",
     text: "text-success",
     glow: "0 0 8px oklch(72% 0.16 155), 0 0 12px oklch(72% 0.16 155 / 0.2)",
   },
   error: {
-    icon: AlertTriangle,
+    icon: ICONS.toast.error,
     border: "border-error",
     text: "text-error",
     glow: "0 0 8px oklch(62% 0.22 25), 0 0 12px oklch(62% 0.22 25 / 0.2)",
   },
   achievement: {
-    icon: Trophy,
+    icon: ICONS.toast.achievement,
     border: "border-info",
     text: "text-info",
     glow: "0 0 8px oklch(60% 0.20 300), 0 0 12px oklch(60% 0.20 300 / 0.2)",
   },
   info: {
-    icon: Info,
+    icon: ICONS.toast.info,
     border: "border-accent",
     text: "text-accent",
     glow: "0 0 8px oklch(72% 0.14 190), 0 0 12px oklch(72% 0.14 190 / 0.2)",
@@ -52,6 +52,7 @@ interface ToastProps {
 export function Toast({ toast, onDismiss }: ToastProps) {
   const config = TOAST_CONFIG[toast.type];
   const Icon = config.icon;
+  const CloseIcon = ICONS.action.close;
   const duration = toast.duration ?? DEFAULT_DURATION;
 
   useEffect(() => {
@@ -72,7 +73,7 @@ export function Toast({ toast, onDismiss }: ToastProps) {
       role="alert"
     >
       <div className="flex items-start gap-3 px-4 py-3">
-        <Icon className={`w-5 h-5 ${config.text} shrink-0 mt-0.5`} aria-hidden="true" />
+        <Icon className={`${ICON_SIZE.close} ${config.text} shrink-0 mt-0.5`} aria-hidden="true" />
         <div className="flex-1 min-w-0">
           <p className={`text-sm font-bold tracking-wide ${config.text}`}>
             {toast.title}
@@ -88,7 +89,7 @@ export function Toast({ toast, onDismiss }: ToastProps) {
           className="text-neutral-500 hover:text-neutral-300 transition-colors shrink-0"
           aria-label="Benachrichtigung schließen"
         >
-          <X className="w-4 h-4" aria-hidden="true" />
+          <CloseIcon className={ICON_SIZE.nav} aria-hidden="true" />
         </button>
       </div>
     </motion.div>

--- a/src/components/shared/UpdateNotification.tsx
+++ b/src/components/shared/UpdateNotification.tsx
@@ -1,5 +1,5 @@
-import { Download, RefreshCw, RotateCcw, X, AlertCircle, CheckCircle } from "lucide-react";
 import { type UpdateState } from "../../hooks/useAutoUpdate";
+import { ICONS, ICON_SIZE } from "../../utils/icons";
 
 interface Props extends UpdateState {
   onUpdate: () => void;
@@ -27,6 +27,13 @@ export function UpdateNotification({
       ? "border-red-400/40 bg-red-400/10"
       : "border-accent/40 bg-accent/10";
 
+  const DownloadIcon = ICONS.action.download;
+  const RefreshIcon = ICONS.action.refresh;
+  const ReadyIcon = ICONS.toast.ready;
+  const ErrorIcon = ICONS.update.error;
+  const RetryIcon = ICONS.action.retry;
+  const CloseIcon = ICONS.action.close;
+
   return (
     <div
       role="status"
@@ -35,7 +42,7 @@ export function UpdateNotification({
     >
       {status === "available" && (
         <>
-          <Download className="w-3.5 h-3.5 text-accent shrink-0" />
+          <DownloadIcon className={`${ICON_SIZE.card} text-accent shrink-0`} />
           <span className="text-neutral-200">v{newVersion} verfügbar</span>
           <button
             onClick={onUpdate}
@@ -48,14 +55,14 @@ export function UpdateNotification({
             className="text-neutral-500 hover:text-neutral-300 ml-1 transition-colors"
             title="Später"
           >
-            <X className="w-3.5 h-3.5" />
+            <CloseIcon className={ICON_SIZE.card} />
           </button>
         </>
       )}
 
       {status === "downloading" && (
         <>
-          <RefreshCw className="w-3.5 h-3.5 text-accent shrink-0 animate-spin" />
+          <RefreshIcon className={`${ICON_SIZE.card} text-accent shrink-0 animate-spin`} />
           <span className="text-neutral-200">Lade Update... {progress}%</span>
           <div className="w-20 h-1.5 bg-neutral-700 rounded-full overflow-hidden">
             <div
@@ -68,7 +75,7 @@ export function UpdateNotification({
 
       {status === "ready" && (
         <>
-          <CheckCircle className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
+          <ReadyIcon className={`${ICON_SIZE.card} text-emerald-400 shrink-0`} />
           <span className="text-neutral-200">Update bereit</span>
           <button
             onClick={onRelaunch}
@@ -81,7 +88,7 @@ export function UpdateNotification({
 
       {status === "error" && (
         <>
-          <AlertCircle className="w-3.5 h-3.5 text-red-400 shrink-0" />
+          <ErrorIcon className={`${ICON_SIZE.card} text-red-400 shrink-0`} />
           <span className="text-red-400 truncate max-w-[200px]" title={error ?? ""}>
             Update-Fehler: {error}
           </span>
@@ -89,14 +96,14 @@ export function UpdateNotification({
             onClick={onRetry}
             className="text-accent hover:text-accent/80 ml-1 transition-colors"
           >
-            <RotateCcw className="w-3.5 h-3.5 inline mr-0.5" />
+            <RetryIcon className={`${ICON_SIZE.card} inline mr-0.5`} />
             Erneut prüfen
           </button>
           <button
             onClick={onDismiss}
             className="text-neutral-500 hover:text-neutral-300 ml-1 transition-colors"
           >
-            <X className="w-3.5 h-3.5" />
+            <CloseIcon className={ICON_SIZE.card} />
           </button>
         </>
       )}

--- a/src/utils/icons.test.ts
+++ b/src/utils/icons.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { ICONS, ICON_SIZE } from "./icons";
+
+describe("ICONS registry", () => {
+  it("exports stable nav keys", () => {
+    expect(Object.keys(ICONS.nav).sort()).toEqual(
+      ["editor", "kanban", "library", "logs", "sessions"],
+    );
+  });
+
+  it("exports stable theme keys", () => {
+    expect(Object.keys(ICONS.theme).sort()).toEqual(["dark", "light"]);
+  });
+
+  it("exports stable toast keys", () => {
+    expect(Object.keys(ICONS.toast).sort()).toEqual(
+      ["achievement", "error", "info", "ready", "success"],
+    );
+  });
+
+  it("exports stable update keys", () => {
+    expect(Object.keys(ICONS.update).sort()).toEqual(["available", "error"]);
+  });
+
+  it("exports stable action keys", () => {
+    expect(Object.keys(ICONS.action).sort()).toEqual([
+      "close",
+      "collapse",
+      "detach",
+      "download",
+      "externalLink",
+      "folderOpen",
+      "loading",
+      "refresh",
+      "retry",
+      "scrollToBottom",
+      "search",
+      "terminal",
+      "trash",
+    ]);
+  });
+
+  it("exposes every nav icon as a callable component", () => {
+    for (const Icon of Object.values(ICONS.nav)) {
+      expect(typeof Icon).toBe("object"); // Lucide icons are forwardRef objects
+      expect(Icon).toBeTruthy();
+    }
+  });
+
+  it("includes the Pin icon at the top level", () => {
+    expect(ICONS.pin).toBeTruthy();
+  });
+});
+
+describe("ICON_SIZE tokens", () => {
+  it("maps the four canonical sizes to Tailwind classes", () => {
+    expect(ICON_SIZE.inline).toBe("w-3 h-3");
+    expect(ICON_SIZE.card).toBe("w-3.5 h-3.5");
+    expect(ICON_SIZE.nav).toBe("w-4 h-4");
+    expect(ICON_SIZE.close).toBe("w-5 h-5");
+  });
+
+  it("exposes exactly four size keys (prevents silent expansion)", () => {
+    expect(Object.keys(ICON_SIZE).sort()).toEqual(
+      ["card", "close", "inline", "nav"],
+    );
+  });
+});

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -1,0 +1,100 @@
+/**
+ * Icon Registry — zentrale Quelle fuer Icon-Zuordnung und Groessen.
+ *
+ * Warum zentral?
+ * - Design-System-Regel (CLAUDE.md): "Lucide-Icons only, 2px stroke, currentColor."
+ * - 24+ kanonische Icon-Zuordnungen aus `docs/design-system/README.md` werden
+ *   hier als Code-Konstanten abgelegt, damit Rename/Swap ein Ein-Datei-Edit ist.
+ * - Groessen-Standard wird ueber `ICON_SIZE` erzwungen — nicht-standard
+ *   Icon-Groessen (z. B. `w-6 h-6`) sollen kein Pattern werden.
+ *
+ * Verwendung:
+ * ```tsx
+ * import { ICONS, ICON_SIZE } from "@/utils/icons";
+ * const Close = ICONS.action.close;
+ * <Close className={ICON_SIZE.nav} aria-hidden="true" />
+ * ```
+ *
+ * Lucide setzt `strokeWidth={2}` bereits als Default — explizit nur setzen,
+ * wenn abweichend.
+ */
+
+import {
+  // nav
+  Monitor, Columns3, BookOpen, FileEdit, ScrollText,
+  // theme
+  Sun, Moon,
+  // actions
+  X, FolderOpen, Terminal, ExternalLink, LayoutGrid, ChevronDown, Loader2,
+  RefreshCw, RotateCcw, Download, Trash2, ArrowDownToLine, Search,
+  // toast
+  CheckCircle2, AlertTriangle, Trophy, Info, CheckCircle,
+  // update
+  ArrowDownCircle, AlertCircle,
+  // misc
+  Pin,
+} from "lucide-react";
+
+/**
+ * Kanonische Icon-Zuordnung — gruppiert nach semantischer Rolle.
+ *
+ * Neue Icons: hier hinzufuegen statt direkt aus `lucide-react` importieren.
+ */
+export const ICONS = {
+  nav: {
+    sessions: Monitor,
+    kanban: Columns3,
+    library: BookOpen,
+    editor: FileEdit,
+    logs: ScrollText,
+  },
+  theme: {
+    light: Sun,
+    dark: Moon,
+  },
+  action: {
+    close: X,
+    folderOpen: FolderOpen,
+    terminal: Terminal,
+    externalLink: ExternalLink,
+    detach: LayoutGrid,
+    collapse: ChevronDown,
+    loading: Loader2,
+    refresh: RefreshCw,
+    retry: RotateCcw,
+    download: Download,
+    trash: Trash2,
+    scrollToBottom: ArrowDownToLine,
+    search: Search,
+  },
+  toast: {
+    success: CheckCircle2,
+    error: AlertTriangle,
+    achievement: Trophy,
+    info: Info,
+    ready: CheckCircle,
+  },
+  update: {
+    available: ArrowDownCircle,
+    error: AlertCircle,
+  },
+  pin: Pin,
+} as const;
+
+/**
+ * Icon-Size-Standard (Tailwind-Klassen).
+ *
+ * Verwendung statt freier `w-X h-X`-Klassen:
+ * - `inline` (12px) — inline nav badges, chevrons, status dots
+ * - `card`   (14px) — session card buttons, toolbar buttons
+ * - `nav`    (16px) — side nav, panel headers (Standard)
+ * - `close`  (20px) — toast icon, modal close button
+ */
+export const ICON_SIZE = {
+  inline: "w-3 h-3",
+  card: "w-3.5 h-3.5",
+  nav: "w-4 h-4",
+  close: "w-5 h-5",
+} as const;
+
+export type IconSize = keyof typeof ICON_SIZE;


### PR DESCRIPTION
## Summary
- Neue zentrale Icon-Registry in `src/utils/icons.ts` (`ICONS` + `ICON_SIZE`) setzt Design-System-Regel "Lucide-Icons only, 2px stroke, currentColor" durch.
- Kanonische Icon-Zuordnungen aus `docs/design-system/README.md` (nav, theme, action, toast, update, pin) sind jetzt typisierte Konstanten.
- Vier Size-Tokens (`inline`/`card`/`nav`/`close`) ersetzen freie `w-X h-X`-Klassen.
- Migration von 4 High-Traffic-Dateien als S:S-Startbatch; Rest folgt in Nachfolge-PRs.

## Registry API
```ts
import { ICONS, ICON_SIZE, type IconSize } from "@/utils/icons";

const Close = ICONS.action.close;
<Close className={ICON_SIZE.nav} aria-hidden="true" />

ICON_SIZE = {
  inline: "w-3 h-3",    // 12px — status dots, inline badges
  card:   "w-3.5 h-3.5", // 14px — toolbar/card buttons
  nav:    "w-4 h-4",     // 16px — side nav, panel headers (Standard)
  close:  "w-5 h-5",     // 20px — toast icon, modal close
}
```

## Migrated files (initial S:S batch)
- `src/components/layout/SideNav.tsx` — nav, theme, update, external-link icons
- `src/components/shared/Toast.tsx` — toast type icons + close
- `src/components/shared/UpdateNotification.tsx` — all 6 update-state icons
- `src/components/logs/LogViewer.tsx` — 5 toolbar action icons

## Follow-up
- Restliche direkte `lucide-react`-Imports in Session-, Kanban-, Library-, Editor-, Pipeline-Komponenten migrieren (getrennte PRs, je Scope einer).
- Optional: ESLint-Rule, die `lucide-react`-Imports ausserhalb `src/utils/icons.ts` verbietet.

## Test plan
- [x] `npx tsc --noEmit` gruen
- [x] `npm run build` gruen
- [x] `npx vitest run` — 1044 Tests gruen (inkl. 9 neue in `icons.test.ts`)
- [x] `npx eslint src` — nur pre-existing SessionStatusBar/ConfigPanelTabList-Findings

Closes #235