### PR TITLE
chore(ui): enforce number-format standards

### DIFF
--- a/src/components/pipeline/AgentMetricsPanel.tsx
+++ b/src/components/pipeline/AgentMetricsPanel.tsx
@@ -10,23 +10,8 @@ import {
 } from "lucide-react";
 import { useAgentStore } from "../../store/agentStore";
 import type { DetectedAgent, DetectedWorktree } from "../../store/agentStore";
+import { formatElapsed } from "../../utils/format";
 import { DURATION, EASE } from "../../utils/motion";
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return "< 1s";
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  return `${hours}h ${remainingMinutes}m`;
-}
 
 interface AgentMetrics {
   total: number;
@@ -220,8 +205,8 @@ export function AgentMetricsPanel({ sessionId }: AgentMetricsPanelProps) {
         <MetricCard
           icon={Clock}
           label="Laufzeit"
-          value={formatDuration(sessionDuration)}
-          subValue={metrics.total > 1 ? `${formatDuration(Math.round(metrics.totalDurationMs / metrics.total))} avg` : undefined}
+          value={formatElapsed(sessionDuration)}
+          subValue={metrics.total > 1 ? `${formatElapsed(Math.round(metrics.totalDurationMs / metrics.total))} avg` : undefined}
           color="text-neutral-400"
         />
         {metrics.tokenAgents.length > 0 && (

--- a/src/components/pipeline/PipelineHistoryView.test.tsx
+++ b/src/components/pipeline/PipelineHistoryView.test.tsx
@@ -110,7 +110,7 @@ describe("PipelineHistoryView", () => {
     resetStore({ runs: [run] });
 
     render(<PipelineHistoryView />);
-    expect(screen.getByText(/2m 34s/)).toBeInTheDocument();
+    expect(screen.getByText(/2:34/)).toBeInTheDocument();
   });
 
   it("click selects a run", () => {

--- a/src/components/pipeline/PipelineHistoryView.tsx
+++ b/src/components/pipeline/PipelineHistoryView.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { RefreshCw, Loader2, Inbox } from "lucide-react";
 import { usePipelineHistoryStore } from "../../store/pipelineHistoryStore";
-import { formatElapsed } from "../../utils/formatElapsed";
+import { formatElapsed } from "../../utils/format";
 import { OUTCOME_CONFIG, formatTimestamp } from "./pipelineOutcomeConfig";
 import type { PipelineRun } from "../../types/pipelineHistory";
 

--- a/src/components/pipeline/PipelineRunDetail.test.tsx
+++ b/src/components/pipeline/PipelineRunDetail.test.tsx
@@ -72,7 +72,7 @@ describe("PipelineRunDetail", () => {
 
     expect(screen.getByText("my-workflow")).toBeInTheDocument();
     expect(screen.getAllByText("Erfolg").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText(/2m 34s/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/2:34/).length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders step timeline with step details", () => {

--- a/src/components/pipeline/PipelineRunDetail.tsx
+++ b/src/components/pipeline/PipelineRunDetail.tsx
@@ -7,7 +7,7 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { usePipelineHistoryStore } from "../../store/pipelineHistoryStore";
-import { formatElapsed } from "../../utils/formatElapsed";
+import { formatElapsed } from "../../utils/format";
 import { OUTCOME_CONFIG, formatTimestamp } from "./pipelineOutcomeConfig";
 import type {
   PipelineRun,

--- a/src/components/pipeline/PipelineStatusBar.test.tsx
+++ b/src/components/pipeline/PipelineStatusBar.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { PipelineStatusBar } from "./PipelineStatusBar";
-import { formatElapsed } from "../../utils/formatElapsed";
 import { usePipelineStatusStore } from "../../store/pipelineStatusStore";
 import type { PipelineStatusInfo } from "../../protocols/schema";
 
@@ -72,7 +71,7 @@ describe("PipelineStatusBar", () => {
   it("renders elapsed time formatted correctly", () => {
     setStatus({ status: "running", elapsedMs: 154000 });
     render(<PipelineStatusBar />);
-    expect(screen.getByText("Laufzeit 2m 34s")).toBeInTheDocument();
+    expect(screen.getByText("Laufzeit 2:34")).toBeInTheDocument();
   });
 
   it("renders workflow name when present", () => {
@@ -84,23 +83,5 @@ describe("PipelineStatusBar", () => {
     });
     render(<PipelineStatusBar />);
     expect(screen.getByText("my-pipeline")).toBeInTheDocument();
-  });
-});
-
-describe("formatElapsed", () => {
-  it("formats sub-second as '< 1s'", () => {
-    expect(formatElapsed(500)).toBe("< 1s");
-  });
-
-  it("formats seconds only", () => {
-    expect(formatElapsed(45000)).toBe("45s");
-  });
-
-  it("formats minutes and seconds", () => {
-    expect(formatElapsed(154000)).toBe("2m 34s");
-  });
-
-  it("pads seconds with leading zero", () => {
-    expect(formatElapsed(65000)).toBe("1m 05s");
   });
 });

--- a/src/components/pipeline/PipelineStatusBar.tsx
+++ b/src/components/pipeline/PipelineStatusBar.tsx
@@ -6,7 +6,7 @@ import {
   selectIsIdle,
   selectIsTerminal,
 } from "../../store/pipelineStatusStore";
-import { formatElapsed } from "../../utils/formatElapsed";
+import { formatElapsed } from "../../utils/format";
 import type { PipelineState } from "../../protocols/schema";
 
 // ============================================================================

--- a/src/components/sessions/AgentBottomPanel.tsx
+++ b/src/components/sessions/AgentBottomPanel.tsx
@@ -20,6 +20,7 @@ import {
   type DetectedAgent,
   type DetectedWorktree,
 } from "../../store/agentStore";
+import { formatElapsed } from "../../utils/format";
 
 interface AgentBottomPanelProps {
   sessionId: string;
@@ -225,11 +226,7 @@ function AgentDetailCard({
     const duration = agent.completedAt
       ? agent.completedAt - agent.detectedAt
       : Date.now() - agent.detectedAt;
-    const durationSec = Math.floor(duration / 1000);
-    const durationMin = Math.floor(durationSec / 60);
-    return durationMin > 0
-      ? `${durationMin}m ${durationSec % 60}s`
-      : `${durationSec}s`;
+    return formatElapsed(duration);
   })();
 
   const statusLabel = {

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -9,6 +9,7 @@ import { logError } from "../../utils/errorLogger";
 import { SessionStatusDot } from "./SessionStatusDot";
 import { useNowTick } from "../../hooks/useNowTick";
 import { shortenPath } from "../../utils/pathUtils";
+import { formatElapsed, formatExit } from "../../utils/format";
 
 interface SessionCardProps {
   session: ClaudeSession;
@@ -16,13 +17,6 @@ interface SessionCardProps {
   isInGrid?: boolean;
   onClick: (sessionId: string) => void;
   onClose: (sessionId: string) => void;
-}
-
-function formatDuration(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
 }
 
 function TimeDisplay({ session }: { session: ClaudeSession }) {
@@ -37,20 +31,20 @@ function TimeDisplay({ session }: { session: ClaudeSession }) {
       }
       return (
         <span className="text-neutral-400">
-          Läuft seit {formatDuration(now - session.createdAt)}
+          Läuft seit {formatElapsed(now - session.createdAt)}
         </span>
       );
     case "running":
       if (activityLevel === "idle") {
         return (
           <span className="text-neutral-400">
-            Idle seit {formatDuration(now - session.lastOutputAt)}
+            Idle seit {formatElapsed(now - session.lastOutputAt)}
           </span>
         );
       }
       return (
         <span className="text-neutral-400">
-          Läuft seit {formatDuration(now - session.createdAt)}
+          Läuft seit {formatElapsed(now - session.createdAt)}
         </span>
       );
     case "waiting":
@@ -58,13 +52,13 @@ function TimeDisplay({ session }: { session: ClaudeSession }) {
     case "done":
       return (
         <span className="text-neutral-400">
-          Fertig ({formatDuration((session.finishedAt ?? now) - session.createdAt)})
+          Fertig ({formatElapsed((session.finishedAt ?? now) - session.createdAt)})
         </span>
       );
     case "error":
       return (
         <span className="text-error">
-          Fehler (Exit {session.exitCode ?? "?"})
+          Fehler ({session.exitCode != null ? formatExit(session.exitCode) : "Exit ?"})
         </span>
       );
   }

--- a/src/components/sessions/SessionHistoryViewer.tsx
+++ b/src/components/sessions/SessionHistoryViewer.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { RefreshCw, GitBranch, Bot, MessageSquare, Clock, Play } from "lucide-react";
 import { getErrorMessage } from "../../utils/adpError";
 import { logError } from "../../utils/errorLogger";
+import { formatElapsed } from "../../utils/format";
 import { useSettingsStore } from "../../store/settingsStore";
 
 // ============================================================================
@@ -51,14 +52,7 @@ function formatDuration(startIso: string, endIso: string): string {
   if (!startIso || !endIso) return "–";
   const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
   if (ms < 0) return "–";
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainingSec = seconds % 60;
-  if (minutes < 60) return `${minutes}m ${remainingSec}s`;
-  const hours = Math.floor(minutes / 60);
-  const remainingMin = minutes % 60;
-  return `${hours}h ${remainingMin}m`;
+  return formatElapsed(ms);
 }
 
 function formatModel(model: string): string {

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { formatMs, formatElapsed, formatExit } from "./format";
+
+describe("formatMs", () => {
+  it("renders a plain integer with space + lowercase unit", () => {
+    expect(formatMs(312)).toBe("312 ms");
+  });
+
+  it("renders zero as '0 ms'", () => {
+    expect(formatMs(0)).toBe("0 ms");
+  });
+
+  it("rounds fractional input", () => {
+    expect(formatMs(12.7)).toBe("13 ms");
+  });
+
+  it("clamps negative input to zero", () => {
+    expect(formatMs(-5)).toBe("0 ms");
+  });
+
+  it("falls back for non-finite input", () => {
+    expect(formatMs(Number.NaN)).toBe("– ms");
+    expect(formatMs(Number.POSITIVE_INFINITY)).toBe("– ms");
+  });
+});
+
+describe("formatElapsed", () => {
+  it("renders zero as '0:00'", () => {
+    expect(formatElapsed(0)).toBe("0:00");
+  });
+
+  it("pads the seconds field", () => {
+    expect(formatElapsed(65_000)).toBe("1:05");
+  });
+
+  it("renders minutes and seconds", () => {
+    expect(formatElapsed(134_000)).toBe("2:14");
+  });
+
+  it("handles sub-second durations by flooring", () => {
+    expect(formatElapsed(500)).toBe("0:00");
+  });
+
+  it("falls back to '0:00' for negative or non-finite input", () => {
+    expect(formatElapsed(-1)).toBe("0:00");
+    expect(formatElapsed(Number.NaN)).toBe("0:00");
+  });
+});
+
+describe("formatExit", () => {
+  it("renders 'Exit 0' for a success code", () => {
+    expect(formatExit(0)).toBe("Exit 0");
+  });
+
+  it("renders 'Exit 1' for failure", () => {
+    expect(formatExit(1)).toBe("Exit 1");
+  });
+
+  it("preserves non-standard codes verbatim", () => {
+    expect(formatExit(137)).toBe("Exit 137");
+  });
+
+  it("returns an empty string for null/undefined", () => {
+    expect(formatExit(null)).toBe("");
+    expect(formatExit(undefined)).toBe("");
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,50 @@
+/**
+ * Canonical number-formatters for UI rendering.
+ *
+ * Rules (from CLAUDE.md design-system → "Number-Formatting"):
+ *  - Durations   → `ms`   format, with space, lowercase unit (e.g. `312 ms`)
+ *  - Elapsed     → `mm:ss`                                   (e.g. `2:14`)
+ *  - Exit codes  → verbatim                                  (e.g. `Exit 0`, `Exit 1`)
+ *
+ * Use these helpers at every rendering site — do NOT build ad-hoc inline
+ * formatters. Verbatim durations coming from Claude-CLI output (like
+ * `"2m 38s"` parsed from a tool-line) are out of scope and stay as-is.
+ */
+
+/** Format a millisecond duration for UI. Example: `formatMs(312) → "312 ms"`. */
+export function formatMs(ms: number): string {
+  if (!Number.isFinite(ms)) return "– ms";
+  const rounded = Math.max(0, Math.round(ms));
+  return `${rounded} ms`;
+}
+
+/**
+ * Format an elapsed duration as `mm:ss`.
+ *
+ * Accepts milliseconds (not seconds) for symmetry with `Date.now()` deltas
+ * and our Tauri payloads. Examples:
+ *   formatElapsed(0)       → "0:00"
+ *   formatElapsed(134_000) → "2:14"
+ *   formatElapsed(65_000)  → "1:05"
+ *
+ * For durations ≥ 1h the minute-field simply grows (`73:05`) — we do not
+ * switch to `h:mm:ss`, since all current call-sites cap out well below 1h
+ * and switching formats mid-flight would break alignment in status bars.
+ */
+export function formatElapsed(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "0:00";
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Format a process exit-code. Example: `formatExit(0) → "Exit 0"`.
+ * Returns an empty string for null/undefined so callers can render
+ * conditionally without extra checks.
+ */
+export function formatExit(code: number | null | undefined): string {
+  if (code === null || code === undefined) return "";
+  return `Exit ${code}`;
+}

--- a/src/utils/formatElapsed.ts
+++ b/src/utils/formatElapsed.ts
@@ -1,9 +1,0 @@
-/** Format milliseconds into a human-readable duration string. */
-export function formatElapsed(ms: number): string {
-  if (ms < 1000) return "< 1s";
-  const totalSec = Math.floor(ms / 1000);
-  const minutes = Math.floor(totalSec / 60);
-  const seconds = totalSec % 60;
-  if (minutes === 0) return `${seconds}s`;
-  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
-}


### PR DESCRIPTION
## Summary

- Consolidated duration/elapsed/exit-code formatting into a single utility (`src/utils/format.ts`) so every rendering site matches the design-system rule (CLAUDE.md "Number-Formatting").
- Deleted the legacy `src/utils/formatElapsed.ts` helper which produced `"2m 34s"` / `"< 1s"` / `"1m 05s"` — those formats violated the `mm:ss` rule.
- 14 new unit tests for the helpers; three pipeline tests updated for the new expected output.

## Violations fixed

| File | Before | After |
|---|---|---|
| `src/utils/formatElapsed.ts` | `"< 1s"` / `"45s"` / `"2m 34s"` / `"1m 05s"` | file deleted; `formatElapsed` now lives in `format.ts` and returns `"0:00"` / `"0:45"` / `"2:34"` / `"1:05"` |
| `src/components/pipeline/AgentMetricsPanel.tsx` | local `formatDuration` with `"< 1s"` / `"Xs"` / `"Xm Ys"` / `"Xh Ym"` | uses `formatElapsed` — `mm:ss` |
| `src/components/sessions/SessionHistoryViewer.tsx` | local `formatDuration` with `"Xs"` / `"Xm Ys"` / `"Xh Ym"` | uses `formatElapsed` — `mm:ss` |
| `src/components/sessions/AgentBottomPanel.tsx` | fallback inline `${durationMin}m ${durationSec % 60}s` / `${durationSec}s` | uses `formatElapsed` — `mm:ss` (verbatim `agent.durationStr` from Claude CLI still takes precedence) |
| `src/components/sessions/SessionCard.tsx` | local `formatDuration` (already `mm:ss` but ad-hoc) + raw `Exit ${session.exitCode ?? "?"}` | uses `formatElapsed` + `formatExit` helpers |
| `src/components/pipeline/PipelineHistoryView.tsx` | imported from `utils/formatElapsed` | imported from `utils/format` |
| `src/components/pipeline/PipelineRunDetail.tsx` | imported from `utils/formatElapsed` | imported from `utils/format` |
| `src/components/pipeline/PipelineStatusBar.tsx` | imported from `utils/formatElapsed` | imported from `utils/format` |
| `src/components/pipeline/PipelineStatusBar.test.tsx` | `"Laufzeit 2m 34s"` + 4-case `formatElapsed` describe | `"Laufzeit 2:34"`; describe removed (now covered by `format.test.ts`) |
| `src/components/pipeline/PipelineRunDetail.test.tsx` | `/2m 34s/` | `/2:34/` |
| `src/components/pipeline/PipelineHistoryView.test.tsx` | `/2m 34s/` | `/2:34/` |

Out of scope (intentionally untouched):
- `agent.durationStr` (e.g. `"2m 38s"`) — verbatim passthrough from Claude CLI terminal output.
- CSS timing values (`200ms`, `0.01ms`) — build-time transitions, not user-facing numbers.
- Test-comment mentions of `150ms`, `5000ms`, `300ms` — code comments, not rendered.

## Helpers added

```ts
formatMs(312)          // "312 ms"
formatMs(0)            // "0 ms"
formatElapsed(0)       // "0:00"
formatElapsed(134_000) // "2:14"
formatElapsed(65_000)  // "1:05"
formatExit(0)          // "Exit 0"
formatExit(null)       // ""
```

All three handle edge cases: negative/NaN/Infinity fall back to sentinel values (`"– ms"` / `"0:00"` / `""`).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vite build` succeeds
- [x] `npx vitest run` — 1045 tests pass (14 new `format.test.ts` cases)
- [x] `npx eslint` clean on every touched file (pre-existing `SessionStatusBar` / `ConfigPanelTabList` warnings remain, as called out in #244's scope)

Closes #244
Refs #232, #239