### PR TITLE
chore(ui): enforce UPPERCASE + tracking-widest on panel & toast titles

### DIFF
--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -469,7 +469,7 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
               >
                 {/* Column header */}
                 <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-700 shrink-0">
-                  <span className="text-xs font-medium text-neutral-300">
+                  <span className="text-xs font-medium text-neutral-300 uppercase tracking-widest">
                     {lane.name}
                   </span>
                   <span className="text-[10px] text-neutral-400 bg-neutral-800 px-1.5 py-0.5 rounded-sm">
@@ -529,7 +529,7 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
                 className="flex flex-col w-[260px] min-w-[260px] bg-surface-raised border border-dashed border-neutral-700 rounded-sm"
               >
                 <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-700 shrink-0">
-                  <span className="text-xs font-medium text-neutral-500">
+                  <span className="text-xs font-medium text-neutral-500 uppercase tracking-widest">
                     Kein Status
                   </span>
                   <span className="text-[10px] text-neutral-400 bg-neutral-800 px-1.5 py-0.5 rounded-sm">

--- a/src/components/kanban/KanbanDashboardView.tsx
+++ b/src/components/kanban/KanbanDashboardView.tsx
@@ -86,7 +86,7 @@ export function KanbanDashboardView() {
       <div className="flex flex-col h-full">
         <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-700 shrink-0">
           <Columns3 className="w-3.5 h-3.5 text-neutral-500" />
-          <span className="text-xs text-neutral-500 mr-auto">Globales Board</span>
+          <span className="text-xs text-neutral-500 mr-auto uppercase tracking-widest">Globales Board</span>
           {modeToggle}
         </div>
         <div className="flex-1 min-h-0">

--- a/src/components/library/LibraryView.tsx
+++ b/src/components/library/LibraryView.tsx
@@ -439,7 +439,7 @@ export function LibraryView() {
       <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 bg-surface-raised shrink-0">
         <div className="flex items-center gap-2">
           <BookOpen className="w-4 h-4 text-accent" />
-          <h1 className="text-sm font-semibold text-neutral-200">
+          <h1 className="text-sm font-semibold text-neutral-200 uppercase tracking-widest">
             Library
           </h1>
         </div>

--- a/src/components/pipeline/AgentMetricsPanel.tsx
+++ b/src/components/pipeline/AgentMetricsPanel.tsx
@@ -185,7 +185,7 @@ export function AgentMetricsPanel({ sessionId }: AgentMetricsPanelProps) {
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-2 border-b border-neutral-800">
         <Activity className="w-4 h-4 text-neutral-400" />
-        <span className="text-xs font-medium text-neutral-300 tracking-wider uppercase">
+        <span className="text-xs font-medium text-neutral-300 tracking-widest uppercase">
           Agent-Metriken
         </span>
       </div>

--- a/src/components/pipeline/PipelineHistoryView.tsx
+++ b/src/components/pipeline/PipelineHistoryView.tsx
@@ -84,7 +84,7 @@ export function PipelineHistoryView() {
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-700">
-        <h3 className="text-xs font-display font-bold text-neutral-400 tracking-wider uppercase">
+        <h3 className="text-xs font-display font-bold text-neutral-400 tracking-widest uppercase">
           Pipeline-Verlauf
         </h3>
         <button

--- a/src/components/pipeline/PipelineView.tsx
+++ b/src/components/pipeline/PipelineView.tsx
@@ -68,7 +68,7 @@ export function PipelineView() {
       {/* Header with session selector + tabs */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700">
         <div className="flex items-center gap-3">
-          <h2 className="text-sm font-display font-bold text-neutral-300 tracking-wider uppercase">
+          <h2 className="text-sm font-display font-bold text-neutral-300 tracking-widest uppercase">
             Pipeline
           </h2>
           <div className="flex items-center gap-1">

--- a/src/components/pipeline/WorkflowLauncher.tsx
+++ b/src/components/pipeline/WorkflowLauncher.tsx
@@ -221,7 +221,7 @@ export function WorkflowLauncher({ folder: folderProp }: WorkflowLauncherProps) 
       <div className="flex items-center justify-between px-4 py-2 border-b border-neutral-800">
         <div className="flex items-center gap-2">
           <Layers className="w-4 h-4 text-neutral-400" />
-          <span className="text-xs font-medium text-neutral-300 tracking-wider uppercase">
+          <span className="text-xs font-medium text-neutral-300 tracking-widest uppercase">
             Erkannte Workflows
           </span>
           {workflows.length > 0 && (

--- a/src/components/sessions/AgentsViewer.tsx
+++ b/src/components/sessions/AgentsViewer.tsx
@@ -103,7 +103,7 @@ export function AgentsViewer({ folder }: AgentsViewerProps) {
       <div className="w-64 min-w-[256px] border-r border-neutral-700 flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-700 shrink-0">
-          <span className="text-xs text-neutral-400 font-medium">
+          <span className="text-xs text-neutral-400 font-medium uppercase tracking-widest">
             Agents ({agents.length})
           </span>
           <button

--- a/src/components/sessions/ClaudeMdViewer.tsx
+++ b/src/components/sessions/ClaudeMdViewer.tsx
@@ -121,7 +121,7 @@ export function ClaudeMdViewer({ folder }: ClaudeMdViewerProps) {
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <div className="flex items-center gap-2">
-          <span className="text-xs text-neutral-400 font-medium">CLAUDE.md</span>
+          <span className="text-xs text-neutral-400 font-medium uppercase tracking-widest">CLAUDE.md</span>
           {isDirty && (
             <span className="w-2 h-2 rounded-full bg-orange-400" title="Ungespeicherte Änderungen" />
           )}

--- a/src/components/sessions/FavoritesList.tsx
+++ b/src/components/sessions/FavoritesList.tsx
@@ -47,7 +47,7 @@ export function FavoritesList({ onQuickStart }: FavoritesListProps) {
       >
         <div className="flex items-center gap-1.5">
           {expanded ? <ChevronDown className="w-3 h-3 text-neutral-500" /> : <ChevronRight className="w-3 h-3 text-neutral-500" />}
-          <span className="text-xs text-neutral-500 tracking-widest">FAVORITEN</span>
+          <span className="text-xs text-neutral-500 uppercase tracking-widest">FAVORITEN</span>
         </div>
         <button
           onClick={(e) => { e.stopPropagation(); handleAddFavorite(); }}

--- a/src/components/sessions/GitHubViewer.tsx
+++ b/src/components/sessions/GitHubViewer.tsx
@@ -183,7 +183,7 @@ export function GitHubViewer({ folder }: GitHubViewerProps) {
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
-        <span className="text-xs text-neutral-400 font-medium">GitHub</span>
+        <span className="text-xs text-neutral-400 font-medium uppercase tracking-widest">GitHub</span>
         <button
           onClick={() => load(true)}
           className="p-1 text-neutral-500 hover:text-neutral-300 transition-colors"

--- a/src/components/sessions/LibraryViewer.tsx
+++ b/src/components/sessions/LibraryViewer.tsx
@@ -131,7 +131,7 @@ export function LibraryViewer({ folder = "" }: LibraryViewerProps) {
       <div className="w-64 min-w-[256px] border-r border-neutral-700 flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-700 shrink-0">
-          <span className="text-xs text-neutral-400 font-medium">
+          <span className="text-xs text-neutral-400 font-medium uppercase tracking-widest">
             Library ({items.length})
           </span>
           <div className="flex items-center gap-1">

--- a/src/components/sessions/NewSessionDialog.tsx
+++ b/src/components/sessions/NewSessionDialog.tsx
@@ -85,7 +85,7 @@ export function NewSessionDialog({ open: isOpen, onClose }: NewSessionDialogProp
   }
 
   const headerTitle = (
-    <h2 className="text-neon-green font-bold text-sm tracking-widest">
+    <h2 className="text-neon-green font-bold text-sm uppercase tracking-widest">
       NEUE CLAUDE SESSION
     </h2>
   );

--- a/src/components/sessions/SessionList.tsx
+++ b/src/components/sessions/SessionList.tsx
@@ -79,7 +79,7 @@ export function SessionList({ onNewSession, onQuickStart }: SessionListProps) {
 
         {/* Sessions section header */}
         <div
-          className="flex items-center gap-1.5 px-3 py-2 text-xs text-neutral-500 tracking-widest border-b border-neutral-700 cursor-pointer hover:bg-hover-overlay transition-colors"
+          className="flex items-center gap-1.5 px-3 py-2 text-xs text-neutral-500 uppercase tracking-widest border-b border-neutral-700 cursor-pointer hover:bg-hover-overlay transition-colors"
           onClick={() => setSessionsExpanded((v) => !v)}
         >
           {sessionsExpanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}

--- a/src/components/sessions/SkillsViewer.tsx
+++ b/src/components/sessions/SkillsViewer.tsx
@@ -106,7 +106,7 @@ export function SkillsViewer({ folder }: SkillsViewerProps) {
       <div className="w-64 min-w-[256px] border-r border-neutral-700 flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-700 shrink-0">
-          <span className="text-xs text-neutral-400 font-medium">
+          <span className="text-xs text-neutral-400 font-medium uppercase tracking-widest">
             Skills ({skills.length})
           </span>
           <button

--- a/src/components/sessions/WorktreeViewer.tsx
+++ b/src/components/sessions/WorktreeViewer.tsx
@@ -83,7 +83,7 @@ export function WorktreeViewer({ folder }: WorktreeViewerProps) {
       <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <div className="flex items-center gap-1.5">
           <GitBranch className="w-3.5 h-3.5 text-neutral-400" />
-          <span className="text-xs text-neutral-400 font-medium">
+          <span className="text-xs text-neutral-400 font-medium uppercase tracking-widest">
             Worktrees ({worktrees.length})
           </span>
         </div>

--- a/src/components/shared/ChangelogDialog.tsx
+++ b/src/components/shared/ChangelogDialog.tsx
@@ -80,7 +80,7 @@ export function ChangelogDialog({ open, onClose }: ChangelogDialogProps) {
 
   const headerTitle = (
     <div>
-      <h2 className="text-accent font-bold text-sm tracking-widest font-display">
+      <h2 className="text-accent font-bold text-sm uppercase tracking-widest font-display">
         CHANGELOG
       </h2>
       <div className="flex items-center gap-3 mt-1.5">

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -51,7 +51,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         >
           <div className="flex items-center gap-3 mb-4">
             <AlertTriangle className="w-6 h-6 text-error" />
-            <span className="text-error font-bold text-sm tracking-widest">
+            <span className="text-error font-bold text-sm uppercase tracking-widest">
               RUNTIME ERROR
             </span>
           </div>

--- a/src/components/shared/Toast.tsx
+++ b/src/components/shared/Toast.tsx
@@ -74,7 +74,7 @@ export function Toast({ toast, onDismiss }: ToastProps) {
       <div className="flex items-start gap-3 px-4 py-3">
         <Icon className={`w-5 h-5 ${config.text} shrink-0 mt-0.5`} aria-hidden="true" />
         <div className="flex-1 min-w-0">
-          <p className={`text-sm font-bold tracking-wide ${config.text}`}>
+          <p className={`text-sm font-bold uppercase tracking-widest ${config.text}`}>
             {toast.title}
           </p>
           {toast.message && (


### PR DESCRIPTION
## Summary

- Unified panel-headers and toast-titles to the CLAUDE.md design-system rule: UPPERCASE + tracking-widest (>= 0.12em).
- 20 violations fixed across 19 files (0 test changes — DOM text unaffected by CSS text-transform).
- Explicit Mixed-Case exceptions documented (dynamic filenames, issue/workflow titles, item/skill/agent names).

## Violations fixed

| File:Line | Before | After | Type |
|---|---|---|---|
| src/components/sessions/ClaudeMdViewer.tsx:124 | `text-xs text-neutral-400 font-medium` | `... uppercase tracking-widest` | Panel (main) |
| src/components/sessions/WorktreeViewer.tsx:86 | `text-xs text-neutral-400 font-medium` | `... uppercase tracking-widest` | Panel (main) |
| src/components/sessions/GitHubViewer.tsx:186 | `text-xs text-neutral-400 font-medium` | `... uppercase tracking-widest` | Panel (main) |
| src/components/library/LibraryView.tsx:442 | `text-sm font-semibold text-neutral-200` | `... uppercase tracking-widest` | Panel (main) |
| src/components/sessions/AgentsViewer.tsx:106 | `text-xs text-neutral-400 font-medium` | `... uppercase tracking-widest` | Panel (compact) |
| src/components/sessions/SkillsViewer.tsx:109 | `text-xs text-neutral-400 font-medium` | `... uppercase tracking-widest` | Panel (compact) |
| src/components/sessions/LibraryViewer.tsx:134 | `text-xs text-neutral-400 font-medium` | `... uppercase tracking-widest` | Panel (compact) |
| src/components/kanban/KanbanBoard.tsx:472 | `text-xs font-medium text-neutral-300` | `... uppercase tracking-widest` | Panel (compact, lane) |
| src/components/kanban/KanbanBoard.tsx:532 | `text-xs font-medium text-neutral-500` | `... uppercase tracking-widest` | Panel (compact, lane) |
| src/components/kanban/KanbanDashboardView.tsx:89 | `text-xs text-neutral-500 mr-auto` | `... uppercase tracking-widest` | Panel (compact) |
| src/components/pipeline/PipelineView.tsx:71 | `tracking-wider uppercase` | `tracking-widest uppercase` | Panel (main) |
| src/components/pipeline/PipelineHistoryView.tsx:87 | `tracking-wider uppercase` | `tracking-widest uppercase` | Panel (compact) |
| src/components/pipeline/AgentMetricsPanel.tsx:188 | `tracking-wider uppercase` | `tracking-widest uppercase` | Panel (compact) |
| src/components/pipeline/WorkflowLauncher.tsx:224 | `tracking-wider uppercase` | `tracking-widest uppercase` | Panel (compact) |
| src/components/sessions/SessionList.tsx:82 | `tracking-widest` (SESSIONS fold) | `uppercase tracking-widest` | Panel (compact, fold) |
| src/components/sessions/FavoritesList.tsx:50 | `tracking-widest` (FAVORITEN fold) | `uppercase tracking-widest` | Panel (compact, fold) |
| src/components/shared/ErrorBoundary.tsx:54 | `font-bold text-sm tracking-widest` | `... uppercase tracking-widest` | Panel (error) |
| src/components/shared/ChangelogDialog.tsx:83 | `font-bold text-sm tracking-widest font-display` | `... uppercase tracking-widest ...` | Modal |
| src/components/sessions/NewSessionDialog.tsx:88 | `font-bold text-sm tracking-widest` | `... uppercase tracking-widest` | Modal |
| src/components/shared/Toast.tsx:77 | `font-bold tracking-wide` | `font-bold uppercase tracking-widest` | Toast |

## Reviewed-and-kept (not panel-headers or explicit exception)

Dynamic Mixed-Case content (exception per issue spec — "wenn der Titel Mixed-Case-Information traegt"):
- `PinnedDocViewer.tsx:174` — dynamic `{label}` (user-given filename)
- `KanbanBoard.tsx:391` — dynamic project title
- `KanbanDetailModal.tsx:122` — dynamic issue title
- `LibraryDetailModal.tsx:38` — dynamic skill/agent/hook name
- `AgentsViewer.tsx:199`, `SkillsViewer.tsx:224`, `LibraryViewer.tsx:347` — detail `<h2>` with `metadata.name`
- `PipelineRunDetail.tsx:146` — dynamic `run.workflowName`

Not panel-headers per spec (row-headers, sub-labels, form-labels, tab buttons):
- `IssueSidebar.tsx:33/43/66/84/103` — field labels in issue sidebar (Autor/Datum/Zugewiesen/Labels/Milestone)
- `AgentsViewer.tsx:217/226/238/257`, `SkillsViewer.tsx:251/280`, `LibraryViewer.tsx:423/448` — `<h3>` sub-labels inside scrollable content areas (Erlaubte Tools/Inhalt/Parameter/etc.)
- `PipelineRunDetail.tsx:174/190` — `<h4>` content sub-labels (Eingaben/Schritte)
- `PipelineControls.tsx:173/281` — form labels for workflow select
- `AgentBottomPanel.tsx:90/108` — list-section separators
- `NewSessionDialog.tsx:127` — "Shell:" form label
- `NotesPanel.tsx:136/149` — tab buttons (Projekt-Notizen / Globale Notizen)
- `SettingsViewer/HooksViewer` headers — dynamic count-only rows ("N Kategorien" / "N Events" + source legend), no static title
- `PipelineStatusBar`, `TaskTreeView`, `EditorToolbar`, `LogViewer` toolbar — status/filter/action bars without a static panel-title

## Non-obvious classification calls

- **`ClaudeMdViewer` "CLAUDE.md"** is a filename but the issue spec explicitly shows it as the `Vorher/Nachher` example — kept as panel-title per spec (renders as `CLAUDE.MD` via CSS uppercase).
- **Kanban lane column headers** (`Todo`, `Ready`, `In Progress`, `Done`) — treated as compact panel-headers per CLAUDE.md ("compact ... Kanban-Spalten").
- **`KanbanDashboardView` "Globales Board"** — sits in a compact toolbar next to mode-toggle; treated as the section title for the global-board view.
- **`tracking-wider` -> `tracking-widest`** applied even though CLAUDE.md calls out `tracking-widest` as the canonical class and the task brief asked me to upgrade narrower trackings.
- **Modals with already-UPPERCASE verbatim text** (CHANGELOG, RUNTIME ERROR, NEUE CLAUDE SESSION) got the `uppercase` class added defensively so future text changes stay conformant.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — 93 files, built in 5.07s
- [x] `npx vitest run` — 1035/1035 tests passing
- [x] `npx eslint src --max-warnings=0` — only pre-existing SessionStatusBar/ConfigPanelTabList errors (per task note to ignore)

Closes #243

Co-Authored-By: Claude <noreply@anthropic.com>