### PR TITLE
chore(ui): audit & enforce 3-dimension hover pattern

### DIFF
--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -364,7 +364,7 @@ export function KanbanBoard({ folder }: KanbanBoardProps) {
             setError("");
             void loadBoard(controller.signal, true);
           }}
-          className="mt-2 px-3 py-1.5 text-xs text-neutral-300 bg-surface-raised border border-neutral-700 rounded-sm hover:bg-hover-overlay transition-colors"
+          className="mt-2 px-3 py-1.5 text-xs text-neutral-300 bg-surface-raised border border-neutral-700 rounded-sm hover:text-neutral-100 hover:border-neutral-500 hover:bg-hover-overlay transition-colors"
         >
           Erneut versuchen
         </button>

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -74,7 +74,7 @@ export function KanbanCard({ issue, onClick, onDragStart, onDragEnd }: KanbanCar
 
   return (
     <div
-      className={`group bg-surface-base border border-neutral-700 rounded-sm p-3 hover:border-neutral-500 transition-colors select-none ${
+      className={`group bg-surface-base border border-neutral-700 rounded-sm p-3 hover:border-neutral-500 hover:bg-hover-overlay transition-colors select-none ${
         isDragging ? "opacity-50 cursor-grabbing pointer-events-none" : "cursor-grab"
       }`}
       onPointerDown={handlePointerDown}

--- a/src/components/kanban/KanbanDetailModal.tsx
+++ b/src/components/kanban/KanbanDetailModal.tsx
@@ -171,7 +171,7 @@ export function KanbanDetailModal({
           <span className="text-red-400 text-sm">{error}</span>
           <button
             onClick={() => void loadDetail()}
-            className="px-3 py-1.5 text-xs text-neutral-300 bg-surface-raised border border-neutral-700 rounded-sm hover:bg-hover-overlay transition-colors"
+            className="px-3 py-1.5 text-xs text-neutral-300 bg-surface-raised border border-neutral-700 rounded-sm hover:text-neutral-100 hover:border-neutral-500 hover:bg-hover-overlay transition-colors"
           >
             Erneut versuchen
           </button>

--- a/src/components/logs/LogEntry.tsx
+++ b/src/components/logs/LogEntry.tsx
@@ -44,7 +44,7 @@ export const LogEntryRow = memo(function LogEntryRow({
   const hasStack = !!entry.stack;
 
   return (
-    <div className="group border-b border-neutral-800 hover:bg-neutral-800/30 font-mono text-xs">
+    <div className="group border-b border-neutral-800 hover:bg-hover-overlay font-mono text-xs">
       <div
         className={`flex items-center gap-2 px-3 ${hasStack ? "cursor-pointer" : ""}`}
         style={{ height: LOG_ROW_HEIGHT }}

--- a/src/components/pipeline/PipelineHistoryView.tsx
+++ b/src/components/pipeline/PipelineHistoryView.tsx
@@ -29,7 +29,7 @@ function RunRow({
       exit={{ opacity: 0, y: -8 }}
       transition={{ duration: 0.15 }}
       onClick={() => onSelect(run.id)}
-      className="w-full text-left px-4 py-3 hover:bg-surface-raised/60 transition-colors border-b border-neutral-700/50 flex items-center gap-3 group"
+      className="w-full text-left px-4 py-3 hover:bg-hover-overlay transition-colors border-b border-neutral-700/50 flex items-center gap-3 group"
       data-testid={`run-row-${run.id}`}
     >
       {/* Status icon */}
@@ -90,7 +90,7 @@ export function PipelineHistoryView() {
         <button
           onClick={() => loadRuns()}
           disabled={isLoading}
-          className="p-1 rounded hover:bg-surface-raised text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="p-1 rounded hover:bg-hover-overlay text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           title="Aktualisieren"
           data-testid="refresh-button"
         >

--- a/src/components/pipeline/PipelineRunDetail.tsx
+++ b/src/components/pipeline/PipelineRunDetail.tsx
@@ -137,7 +137,7 @@ export function PipelineRunDetail({ run }: { run: PipelineRun }) {
         <div className="flex items-center gap-2">
           <button
             onClick={clearSelection}
-            className="p-1 rounded hover:bg-surface-raised text-neutral-500 hover:text-neutral-300 transition-colors"
+            className="p-1 rounded hover:bg-hover-overlay text-neutral-500 hover:text-neutral-300 transition-colors"
             title="Zurueck"
             data-testid="back-button"
           >

--- a/src/components/pipeline/TaskTreeNode.tsx
+++ b/src/components/pipeline/TaskTreeNode.tsx
@@ -63,7 +63,7 @@ export const TaskTreeNode = memo(function TaskTreeNode({
               e.stopPropagation();
               setIsExpanded(!isExpanded);
             }}
-            className="p-0.5 hover:bg-neutral-700 rounded shrink-0"
+            className="p-0.5 hover:bg-hover-overlay rounded shrink-0"
           >
             {isExpanded ? (
               <ChevronDown className="w-3 h-3 text-neutral-500" />

--- a/src/components/sessions/GitHubViewer.tsx
+++ b/src/components/sessions/GitHubViewer.tsx
@@ -251,7 +251,7 @@ export function GitHubViewer({ folder }: GitHubViewerProps) {
                 {prs.map((pr) => (
                   <div
                     key={pr.number}
-                    className="flex items-center gap-2 bg-surface-base border border-neutral-700 rounded-sm px-3 py-2 group hover:border-neutral-600 transition-colors"
+                    className="flex items-center gap-2 bg-surface-base border border-neutral-700 rounded-sm px-3 py-2 group hover:border-neutral-500 hover:bg-hover-overlay transition-colors"
                   >
                     <span className="text-xs font-mono text-neutral-500">#{pr.number}</span>
                     <span className="text-xs text-neutral-200 truncate flex-1">{pr.title}</span>
@@ -291,7 +291,7 @@ export function GitHubViewer({ folder }: GitHubViewerProps) {
                 {issues.map((issue) => (
                   <div
                     key={issue.number}
-                    className="flex items-center gap-2 bg-surface-base border border-neutral-700 rounded-sm px-3 py-2 group hover:border-neutral-600 transition-colors"
+                    className="flex items-center gap-2 bg-surface-base border border-neutral-700 rounded-sm px-3 py-2 group hover:border-neutral-500 hover:bg-hover-overlay transition-colors"
                   >
                     <span className="text-xs font-mono text-neutral-500">#{issue.number}</span>
                     <span className="text-xs text-neutral-200 truncate flex-1">{issue.title}</span>

--- a/src/components/sessions/LibraryViewer.tsx
+++ b/src/components/sessions/LibraryViewer.tsx
@@ -115,7 +115,7 @@ export function LibraryViewer({ folder = "" }: LibraryViewerProps) {
           </button>
           <button
             onClick={handleRefresh}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-neutral-400 border border-neutral-700 rounded hover:bg-hover-overlay transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-neutral-400 border border-neutral-700 rounded hover:text-neutral-200 hover:border-neutral-500 hover:bg-hover-overlay transition-colors"
           >
             <RefreshCw className="w-3.5 h-3.5" />
             Index neu aufbauen
@@ -376,7 +376,7 @@ function ItemDetail({
       <div className="flex items-center gap-2">
         <button
           onClick={handleCopyPath}
-          className="flex items-center gap-1.5 px-2.5 py-1 text-xs text-neutral-300 border border-neutral-700 rounded hover:bg-hover-overlay transition-colors"
+          className="flex items-center gap-1.5 px-2.5 py-1 text-xs text-neutral-300 border border-neutral-700 rounded hover:text-neutral-100 hover:border-neutral-500 hover:bg-hover-overlay transition-colors"
           title="Pfad in Zwischenablage kopieren"
         >
           <Copy className="w-3.5 h-3.5" />

--- a/src/components/sessions/SessionHistoryViewer.tsx
+++ b/src/components/sessions/SessionHistoryViewer.tsx
@@ -145,7 +145,7 @@ const SessionHistoryViewer: React.FC<SessionHistoryViewerProps> = ({ folder, onR
         </span>
         <button
           onClick={loadSessions}
-          className="text-xs text-neutral-500 hover:text-neutral-200 transition-colors px-2 py-0.5 rounded hover:bg-neutral-800"
+          className="text-xs text-neutral-500 hover:text-neutral-200 transition-colors px-2 py-0.5 rounded hover:bg-hover-overlay"
           title="Neu laden"
         >
           <RefreshCw className="w-3 h-3" />

--- a/src/components/sessions/WorktreeViewer.tsx
+++ b/src/components/sessions/WorktreeViewer.tsx
@@ -104,7 +104,7 @@ export function WorktreeViewer({ folder }: WorktreeViewerProps) {
             {worktrees.map((wt) => (
               <div
                 key={wt.path}
-                className="flex items-center gap-2 bg-surface-base border border-neutral-700 rounded-sm px-3 py-2 hover:border-neutral-600 transition-colors"
+                className="flex items-center gap-2 bg-surface-base border border-neutral-700 rounded-sm px-3 py-2 hover:border-neutral-500 hover:bg-hover-overlay transition-colors"
               >
                 <GitBranch className="w-4 h-4 text-accent shrink-0" />
                 <div className="flex flex-col flex-1 min-w-0">

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -26,7 +26,7 @@ const variantClasses: Record<ButtonVariant, string> = {
   primary:
     "bg-neon-green text-neutral-900 font-bold tracking-wider hover:bg-neon-green/90 border border-transparent",
   secondary:
-    "border border-neutral-700 text-neutral-400 hover:text-neutral-200 hover:border-neutral-500",
+    "border border-neutral-700 text-neutral-400 hover:text-neutral-200 hover:border-neutral-500 hover:bg-hover-overlay",
   ghost:
     "text-neutral-400 hover:text-neutral-200 hover:bg-hover-overlay",
   danger:


### PR DESCRIPTION
## Summary
- Audits all interactive elements in `src/components/**/*.tsx` against the CLAUDE.md hover spec (text brighten + `hover:bg-hover-overlay` + border lighten).
- Adds missing hover dimensions to bordered rows/cards (Bucket A) and bordered buttons (Bucket B); leaves text-only icon buttons unchanged (Bucket C per spec).
- Normalises non-canonical hover backgrounds (`bg-surface-raised`, `bg-neutral-800/30`, `bg-neutral-700`) to the canonical `hover:bg-hover-overlay` token so every overlay uses the same CSS variable.

## Matrix of fixes

| File | Element | Before | After |
|---|---|---|---|
| `ui/Button.tsx` | `secondary` variant | text + border lighten | **+ `hover:bg-hover-overlay`** |
| `kanban/KanbanCard.tsx` | draggable card | `hover:border-neutral-500` | **+ `hover:bg-hover-overlay`** |
| `kanban/KanbanBoard.tsx` | retry button | bg + `hover:bg-hover-overlay` | **+ `hover:text-neutral-100` + `hover:border-neutral-500`** |
| `kanban/KanbanDetailModal.tsx` | retry button | bg + `hover:bg-hover-overlay` | **+ `hover:text-neutral-100` + `hover:border-neutral-500`** |
| `sessions/GitHubViewer.tsx` | PR row | `hover:border-neutral-600` | **`hover:border-neutral-500` + `hover:bg-hover-overlay`** |
| `sessions/GitHubViewer.tsx` | Issue row | `hover:border-neutral-600` | **`hover:border-neutral-500` + `hover:bg-hover-overlay`** |
| `sessions/WorktreeViewer.tsx` | worktree row | `hover:border-neutral-600` | **`hover:border-neutral-500` + `hover:bg-hover-overlay`** |
| `sessions/LibraryViewer.tsx` | "Index neu aufbauen" button | border + `hover:bg-hover-overlay` | **+ `hover:text-neutral-200` + `hover:border-neutral-500`** |
| `sessions/LibraryViewer.tsx` | "Copy Path" button | border + `hover:bg-hover-overlay` | **+ `hover:text-neutral-100` + `hover:border-neutral-500`** |
| `sessions/SessionHistoryViewer.tsx` | reload button | `hover:bg-neutral-800` | `hover:bg-hover-overlay` |
| `pipeline/PipelineHistoryView.tsx` | run row button | `hover:bg-surface-raised/60` | `hover:bg-hover-overlay` |
| `pipeline/PipelineHistoryView.tsx` | refresh button | `hover:bg-surface-raised` | `hover:bg-hover-overlay` |
| `pipeline/PipelineRunDetail.tsx` | back button | `hover:bg-surface-raised` | `hover:bg-hover-overlay` |
| `pipeline/TaskTreeNode.tsx` | chevron toggle | `hover:bg-neutral-700` | `hover:bg-hover-overlay` |
| `logs/LogEntry.tsx` | log row | `hover:bg-neutral-800/30` | `hover:bg-hover-overlay` |

Total: 15 fixes across 12 files.

## Non-obvious calls
- **Bucket C (text-only icon buttons)** left untouched per the issue — ~25 instances of `p-0.5/p-1 text-neutral-500 hover:text-neutral-300` on action chrome, `IconButton.tsx` base style, close/open icons. Spec: text-only is OK.
- **`FavoriteCard`** keeps `hover:border-l-accent` (2px accent indicator bar); not a neutral-border element, so the neutral-500 lighten rule doesn't apply.
- **`SessionCard`** / **`LibraryViewer` active item** / **`AgentsViewer` active item**: `border-l-transparent hover:bg-hover-overlay` — `border-l` is an active-state indicator, not a resting frame border. Treated as 2-of-3 satisfied.
- **Accent-themed hovers** (`hover:bg-accent-a10`, `hover:bg-accent-a15`, `hover:bg-accent/90`, `hover:border-accent`) intentionally left in place — these are explicit accent-feedback patterns, not general neutral hovers.
- **`LibraryViewer` type-filter toggle** (`bg-neutral-800 hover:bg-neutral-700`) left as-is — deliberate opaque darker-to-lighter cycle on a Bucket B button with its own solid bg (no overlay needed per spec).
- **Section-header fold rows** (`FavoritesList`, `SessionList`) use `border-b` as divider, not a frame border — 2-of-3 already satisfied, no border lighten applicable.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vite build` success
- [x] `npx vitest run` — 1045/1045 passing
- [x] `npx eslint .` — only the 2 pre-existing errors in SessionStatusBar/ConfigPanelTabList and the pre-existing ConfigPanelTabList warning; no new lint output

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)