### PR TITLE
feat(ui): add semantic type classes (.ae-*) + initial adoption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,18 @@ Content-Regeln (UI-Strings):
 - **Number-Formatting**: `ms` fuer Durations (`312 ms`), `mm:ss` fuer Elapsed (`2:14`), Exit-Codes verbatim (`Exit 0`, `Exit 1`).
 - **Panel-Titel**: UPPERCASE + wide-tracking. Toast-Titel ebenso.
 
+Semantic Type Classes (`.ae-*` in `src/index.css`):
+- Optional, nicht verpflichtend. Nutzen, wenn ein Tailwind-String >= 4 Tokens wiederholt auftritt und die Klasse 1:1 den Stil trifft.
+- `.ae-h1` — Display-Font, `text-xl`, bold, tight leading, `neutral-100`. Page-/Modal-Heading.
+- `.ae-h2` — Display-Font, `1.25rem`, bold, uppercase, `accent`-farbig. Hero/Section-Heading mit Akzent.
+- `.ae-h3` — Display-Font, `text-sm`, bold, uppercase, tracking `0.12em`, `neutral-300`. Panel-Heading (strict variant).
+- `.ae-body` — Body-Font, `text-sm`, normales Leading, `neutral-200`. Default-Fliesstext.
+- `.ae-body-sm` — Body-Font, `text-xs`, `neutral-400`. Sekundaer-Text, Meta, Timestamps.
+- `.ae-label` — Body-Font, `text-xs`, Letter-Spacing `0.04em`, `neutral-400`. Form-Labels, Separator-Titel.
+- `.ae-mono` — Mono-Font, `text-xs`, `neutral-300`. Inline Pfade/IDs.
+- `.ae-code` — Mono-Font, `0.875em`, Success-Farbe auf `neutral-800`. Inline-Code.
+- Quelle/Preview: `docs/design-system/colors_and_type.css`.
+
 Interaction-Patterns (Desktop, kein Touch!):
 - **Hover**: Text brightens one step (`text-neutral-400 → text-neutral-200`), Background bekommt `hover:bg-hover-overlay`, Border lightens (`border-neutral-700 → border-neutral-500`).
 - **Press**: KEIN `scale-*` transform. Dies ist ein Desktop-Tool.

--- a/src/components/kanban/IssueComments.tsx
+++ b/src/components/kanban/IssueComments.tsx
@@ -34,7 +34,7 @@ export function IssueComments({ comments, formatDate }: IssueCommentsProps) {
               {formatDate(comment.created_at)}
             </span>
           </div>
-          <MarkdownBody content={comment.body} className="text-xs text-neutral-400" />
+          <MarkdownBody content={comment.body} className="ae-body-sm" />
         </div>
       ))}
     </div>

--- a/src/components/sessions/HooksViewer.tsx
+++ b/src/components/sessions/HooksViewer.tsx
@@ -202,7 +202,7 @@ export function HooksViewer({ folder }: HooksViewerProps) {
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-700 shrink-0">
         <div className="flex items-center gap-3">
-          <span className="text-xs text-neutral-400 font-medium">
+          <span className="ae-body-sm font-medium">
             {eventGroups.length}{" "}
             {eventGroups.length === 1 ? "Event" : "Events"}
           </span>

--- a/src/components/sessions/SessionHistoryViewer.tsx
+++ b/src/components/sessions/SessionHistoryViewer.tsx
@@ -140,7 +140,7 @@ const SessionHistoryViewer: React.FC<SessionHistoryViewerProps> = ({ folder, onR
     <div className="flex flex-col gap-2 p-2 h-full overflow-y-auto">
       {/* Header */}
       <div className="flex items-center justify-between mb-1">
-        <span className="text-xs text-neutral-400">
+        <span className="ae-body-sm">
           {sessions.length} {sessions.length === 1 ? "Session" : "Sessions"}
         </span>
         <button

--- a/src/components/sessions/SkillsViewer.tsx
+++ b/src/components/sessions/SkillsViewer.tsx
@@ -265,7 +265,7 @@ function SkillDetail({ entry }: { entry: SkillEntry }) {
                     *erforderlich
                   </span>
                 )}
-                <span className="text-xs text-neutral-400">
+                <span className="ae-body-sm">
                   {arg.description}
                 </span>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -314,6 +314,68 @@ code, pre, kbd,
               transform var(--duration-fast) var(--ease-in);
 }
 
+/* ============================================
+   Semantic Type Classes (.ae-*)
+   Kanonische Quelle: docs/design-system/colors_and_type.css
+   Zweck: Wiederkehrende Typografie-Rezepte in einem semantischen Namen
+   buendeln. Klassen sind optional — bestehende Tailwind-Strings bleiben
+   gueltig und werden nur bei exakter visueller Aequivalenz migriert.
+   ============================================ */
+.ae-h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: 700;
+  line-height: var(--leading-tight);
+  letter-spacing: 0.02em;
+  color: var(--neutral-100);
+}
+.ae-h2 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: var(--leading-tight);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+.ae-h3 {
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--neutral-300);
+}
+.ae-body {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--neutral-200);
+}
+.ae-body-sm {
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  color: var(--neutral-400);
+}
+.ae-label {
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  color: var(--neutral-400);
+}
+.ae-mono {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--neutral-300);
+}
+.ae-code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  padding: 0.15em 0.4em;
+  background: var(--neutral-800);
+  color: var(--color-success);
+}
+
 /* ── Markdown Preview ── */
 .md-preview {
   user-select: text;

--- a/src/styles/semanticTypeClasses.test.ts
+++ b/src/styles/semanticTypeClasses.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Nicht ueber `src/` via Vite importieren — statisch lesen damit wir
+// wirklich die geparste Quelldatei pruefen.
+const CSS_PATH = resolve(__dirname, "..", "index.css");
+const css = readFileSync(CSS_PATH, "utf8");
+
+// Jede Klasse muss im index.css existieren und mit den kanonischen CSS-Variablen
+// aus docs/design-system/colors_and_type.css uebereinstimmen.
+const EXPECTED_CLASSES: Array<{
+  name: string;
+  mustContain: string[];
+}> = [
+  {
+    name: ".ae-h1",
+    mustContain: [
+      "font-family: var(--font-display)",
+      "font-size: var(--text-xl)",
+      "font-weight: 700",
+      "color: var(--neutral-100)",
+    ],
+  },
+  {
+    name: ".ae-h2",
+    mustContain: [
+      "font-family: var(--font-display)",
+      "font-weight: 700",
+      "text-transform: uppercase",
+      "color: var(--color-accent)",
+    ],
+  },
+  {
+    name: ".ae-h3",
+    mustContain: [
+      "font-family: var(--font-display)",
+      "font-size: var(--text-sm)",
+      "letter-spacing: 0.12em",
+      "text-transform: uppercase",
+      "color: var(--neutral-300)",
+    ],
+  },
+  {
+    name: ".ae-body",
+    mustContain: [
+      "font-family: var(--font-body)",
+      "font-size: var(--text-sm)",
+      "color: var(--neutral-200)",
+    ],
+  },
+  {
+    name: ".ae-body-sm",
+    mustContain: [
+      "font-family: var(--font-body)",
+      "font-size: var(--text-xs)",
+      "color: var(--neutral-400)",
+    ],
+  },
+  {
+    name: ".ae-label",
+    mustContain: [
+      "font-family: var(--font-body)",
+      "font-size: var(--text-xs)",
+      "letter-spacing: 0.04em",
+      "color: var(--neutral-400)",
+    ],
+  },
+  {
+    name: ".ae-mono",
+    mustContain: [
+      "font-family: var(--font-mono)",
+      "font-size: var(--text-xs)",
+      "color: var(--neutral-300)",
+    ],
+  },
+  {
+    name: ".ae-code",
+    mustContain: [
+      "font-family: var(--font-mono)",
+      "background: var(--neutral-800)",
+      "color: var(--color-success)",
+    ],
+  },
+];
+
+function extractRuleBody(source: string, selector: string): string {
+  const escaped = selector.replace(/[.]/g, "\\.");
+  const pattern = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`);
+  const match = source.match(pattern);
+  if (!match) {
+    throw new Error(`Class ${selector} not found in index.css`);
+  }
+  return match[1];
+}
+
+describe("semantic type classes (.ae-*)", () => {
+  it.each(EXPECTED_CLASSES)(
+    "$name is defined with canonical declarations",
+    ({ name, mustContain }) => {
+      const body = extractRuleBody(css, name);
+      for (const decl of mustContain) {
+        expect(body).toContain(decl);
+      }
+    },
+  );
+
+  it("exposes exactly the 8 canonical ae-* classes", () => {
+    const names = EXPECTED_CLASSES.map((c) => c.name);
+    for (const name of names) {
+      expect(css).toContain(name);
+    }
+    // No accidental duplicate definition (each class block appears exactly once).
+    for (const name of names) {
+      const escaped = name.replace(/[.]/g, "\\.");
+      const pattern = new RegExp(`${escaped}\\s*\\{`, "g");
+      const matches = css.match(pattern) ?? [];
+      expect(matches.length).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 8 semantic typography classes (`.ae-*`) to `src/index.css`, aligned 1:1 with `docs/design-system/colors_and_type.css` (the design-system source of truth).
- All classes are CSS-variable-driven (`var(--neutral-*)`, `var(--font-*)`, etc.) and therefore theme-aware via the existing `.dark` overrides.
- Initial S:S adoption in 4 files — only exact visual matches, no regressions.
- Adoption rule: classes are **optional**. Existing Tailwind-strings stay unless migration is visually equivalent.

## Classes introduced

| Class | Expansion | Purpose |
|---|---|---|
| `.ae-h1` | display font, `text-xl`, `font-weight: 700`, tight leading, `neutral-100`, `letter-spacing: 0.02em` | Page / modal heading |
| `.ae-h2` | display font, `1.25rem`, bold, uppercase, `color: var(--color-accent)`, `letter-spacing: 0.04em` | Hero / section heading with accent |
| `.ae-h3` | display font, `text-sm`, bold, uppercase, `letter-spacing: 0.12em`, `neutral-300` | Panel heading (strict design-system variant) |
| `.ae-body` | body font, `text-sm`, `leading-normal`, `neutral-200` | Default body text |
| `.ae-body-sm` | body font, `text-xs`, `neutral-400` | Secondary text, meta, timestamps |
| `.ae-label` | body font, `text-xs`, `letter-spacing: 0.04em`, `neutral-400` | Form labels, separator titles |
| `.ae-mono` | mono font, `text-xs`, `neutral-300` | Inline paths / IDs |
| `.ae-code` | mono font, `0.875em`, inline padding, success color on `neutral-800` | Inline code |

## Migrated files (initial S:S batch)

Only 1:1 visual matches migrated. Line-height + font-family inheritance verified equivalent.

- `src/components/sessions/SessionHistoryViewer.tsx` — session counter span: `text-xs text-neutral-400` -> `ae-body-sm`
- `src/components/sessions/SkillsViewer.tsx` — skill-argument description span: `text-xs text-neutral-400` -> `ae-body-sm`
- `src/components/sessions/HooksViewer.tsx` — event-group counter span: `text-xs text-neutral-400 font-medium` -> `ae-body-sm font-medium`
- `src/components/kanban/IssueComments.tsx` — `MarkdownBody` wrapper className: `text-xs text-neutral-400` -> `ae-body-sm`

## Tests
- New: `src/styles/semanticTypeClasses.test.ts` parses `src/index.css` and asserts each `.ae-*` class contains its canonical `var()` tokens and is defined exactly once.
- Total test count: **1045 -> 1054** (+9 new parametric cases).

## Docs
- `CLAUDE.md` Design-System section now lists all 8 classes + short usage hints and points at `docs/design-system/colors_and_type.css` as the canonical source.

## Follow-up (out of scope)
- Opportunistic migration in future PRs as files are touched.
- The existing `text-xs text-neutral-400 font-medium uppercase tracking-widest` panel-header pattern does **not** match `.ae-h3` (different weight/color/font/tracking) — leave as-is unless a deliberate visual redesign lands.
- Consider custom markdown-it render rules so `MarkdownPreview` h1/h2/h3 emit `.ae-h1/.ae-h2/.ae-h3` instead of the current `.md-preview h1/h2/h3` selectors — would consolidate the markdown heading styles into the `.ae-*` set.

## Scan surprises
- Most existing panel-headers use `text-xs text-neutral-400 font-medium uppercase tracking-widest`, but the design-system `.ae-h3` spec is `text-sm` + `font-bold` + `neutral-300` + tracking `0.12em`. Not a drop-in replacement — flagged as a follow-up, not migrated.
- Issue #236 listed `Panel.tsx` as migration candidate, but that component was removed in #247 — migration list updated accordingly.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `npm run test` (1054 passed / 1054)
- [x] `npm run lint` (2 pre-existing errors in `SessionStatusBar.tsx`, 1 pre-existing warning in `ConfigPanelTabList.tsx` — unrelated to this PR)

Closes #236

Co-Authored-By: Claude <noreply@anthropic.com>